### PR TITLE
Improve observer UI text positioning/scaling

### DIFF
--- a/d1/main/CMakeLists.txt
+++ b/d1/main/CMakeLists.txt
@@ -112,6 +112,11 @@ if(WIN32)
         # MSVC will automatically generate a manifest using this method - which will cause a
         # collision - so we need to tell it not to.
         target_link_options(d1x-redux PRIVATE "/MANIFEST:NO")
+        if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+            # Enable Hot Reload for debug builds
+            target_link_options(${PROJECT_NAME} PRIVATE $<$<CONFIG:Debug>:/INCREMENTAL>)
+            target_compile_options(${PROJECT_NAME} PRIVATE $<$<CONFIG:Debug>:/ZI>)
+        endif()
     endif()
 
     install(FILES

--- a/d1/main/gauges.c
+++ b/d1/main/gauges.c
@@ -733,7 +733,7 @@ void hud_show_score()
 		sprintf(score_str, "%s: %5d", TXT_KILLS, Players[pnum].net_kills_total);
 	} else {
 		sprintf(score_str, "%s: %5d", TXT_SCORE, Players[pnum].score);
-  	}
+	}
 
 	gr_get_string_size(score_str, &w, &h, &aw );
 
@@ -1000,9 +1000,9 @@ void hud_show_energy(void)
 		gr_set_curfont( GAME_FONT );
 		gr_set_fontcolor(BM_XRGB(0,31,0),-1 );
 		if (Game_mode & GM_MULTI)
-		     gr_printf(FSPACX(1), (grd_curcanv->cv_bitmap.bm_h-(LINE_SPACING*5)),"%s: %i", TXT_ENERGY, f2ir(Players[pnum].energy));
+			 gr_printf(FSPACX(1), (grd_curcanv->cv_bitmap.bm_h-(LINE_SPACING*5)),"%s: %i", TXT_ENERGY, f2ir(Players[pnum].energy));
 		else
-		     gr_printf(FSPACX(1), (grd_curcanv->cv_bitmap.bm_h-LINE_SPACING),"%s: %i", TXT_ENERGY, f2ir(Players[pnum].energy));
+			 gr_printf(FSPACX(1), (grd_curcanv->cv_bitmap.bm_h-LINE_SPACING),"%s: %i", TXT_ENERGY, f2ir(Players[pnum].energy));
 	}
 
 	if (Newdemo_state==ND_STATE_RECORDING )
@@ -1100,7 +1100,7 @@ void hud_show_weapons_mode(int type,int vertical,int x,int y){
 			if (vertical){
 				y-=h+FSPACX(2);
 			}else
-			     x-=w+FSPACY(3);
+				 x-=w+FSPACY(3);
 			gr_string(x, y, weapon_str);
 		}
 	} else {
@@ -1118,7 +1118,7 @@ void hud_show_weapons_mode(int type,int vertical,int x,int y){
 			if (vertical){
 				y-=h+FSPACX(2);
 			}else
-			     x-=w+FSPACY(3);
+				 x-=w+FSPACY(3);
 			gr_string(x, y, weapon_str);
 		}
 	}
@@ -1704,7 +1704,7 @@ void draw_keys()
 
 	if (Players[pnum].flags & PLAYER_FLAGS_BLUE_KEY )	{
 		PIGGY_PAGE_IN(Gauges[GAUGE_BLUE_KEY]);
-                hud_bitblt( HUD_SCALE_X(GAUGE_BLUE_KEY_X), HUD_SCALE_Y(GAUGE_BLUE_KEY_Y), &GameBitmaps[Gauges[GAUGE_BLUE_KEY].index]);
+				hud_bitblt( HUD_SCALE_X(GAUGE_BLUE_KEY_X), HUD_SCALE_Y(GAUGE_BLUE_KEY_Y), &GameBitmaps[Gauges[GAUGE_BLUE_KEY].index]);
 	} else {
 		PIGGY_PAGE_IN(Gauges[GAUGE_BLUE_KEY_OFF]);
 		hud_bitblt( HUD_SCALE_X(GAUGE_BLUE_KEY_X), HUD_SCALE_Y(GAUGE_BLUE_KEY_Y), &GameBitmaps[Gauges[GAUGE_BLUE_KEY_OFF].index]);
@@ -2047,7 +2047,7 @@ const rgb player_rgb[] = {	//{0,0,0}, // black
 							//{23, 23, 23}, // white
 							{24,17,6},     // 0xC08830 ---> light orange (PROBLEM)
 							{14,21,12},    // 0x70A860 ---> light green (PROBLEM)
-			                {29,29,0}, };  // 0xE8E800 ---> YELLOW
+							{29,29,0}, };  // 0xE8E800 ---> YELLOW
 
 const rgb player_rgb_alt[] = {
 
@@ -2276,7 +2276,7 @@ void hud_show_kill_list()
 	else
 		n_left = (players + (Netgame.host_is_obs ? 0 : 1)) / 2;
 
-    if(Netgame.BlackAndWhitePyros)
+	if(Netgame.BlackAndWhitePyros)
 		selected_player_rgb = player_rgb_alt;
 	else
 		selected_player_rgb = player_rgb;
@@ -2509,9 +2509,11 @@ void observer_show_time() {
 	int y = 5;
 
 	if (GameTime64 < 3600 * F1_0)
-		sprintf(time_str, "%02i:%02i", (int)(f2i(GameTime64) / 60 % 60), (int)(f2i(GameTime64) % 60));
+		snprintf(time_str, sizeof(time_str) / sizeof(time_str[0]), "%02i:%02i",
+			(int)(f2i(GameTime64) / 60 % 60), (int)(f2i(GameTime64) % 60));
 	else
-		sprintf(time_str, "%i:%02i:%02i", (int)(f2i(GameTime64) / 3600), (int)(f2i(GameTime64) / 60 % 60), (int)(f2i(GameTime64) % 60));
+		snprintf(time_str, sizeof(time_str) / sizeof(time_str[0]), "%i:%02i:%02i",
+			(int)(f2i(GameTime64) / 3600), (int)(f2i(GameTime64) / 60 % 60), (int)(f2i(GameTime64) % 60));
 
 	gr_set_curfont( MEDIUM3_FONT );
 	gr_get_string_size( time_str, &sw, &sh, &saw );
@@ -2523,7 +2525,8 @@ void observer_show_time() {
 		int w = sw;
 		int h = sh;
 
-		sprintf(decimal_str, ".%02i", (int)(f2i(GameTime64 * 100) % 100));
+		snprintf(decimal_str, sizeof(decimal_str) / sizeof(decimal_str[0]), ".%02i",
+			(int)(f2i(GameTime64 * 100) % 100));
 		while ((t = strchr(decimal_str, '1')) != NULL)
 			*t = '\x84';	//convert to wide '1'
 
@@ -2596,7 +2599,7 @@ int observer_draw_player_card(int pnum, int color, int x, int y) {
 
 		y += sh + 3;
 	} else {
-		sprintf(score, "%d", Players[pnum].net_kills_total);
+		snprintf(score, sizeof(score) / sizeof(score[0]), "%d", Players[pnum].net_kills_total);
 
 		gr_set_curfont( MEDIUM1_FONT );
 
@@ -2614,7 +2617,8 @@ int observer_draw_player_card(int pnum, int color, int x, int y) {
 			// Shields
 			char shields[7];
 
-			sprintf(shields, "%0.1f%s", f2db(Players[pnum].shields), Players[pnum].shields_certain ? "" : "?" );
+			snprintf(shields, sizeof(shields) / sizeof(shields[0]), "%0.1f%s",
+				f2db(Players[pnum].shields), Players[pnum].shields_certain ? "" : "?" );
 
 			gr_set_fontcolor(color, -1);
 
@@ -2709,19 +2713,20 @@ int observer_draw_player_card(int pnum, int color, int x, int y) {
 			char primary[8];
 			switch (Players[pnum].primary_weapon) {
 				case 0:
-					sprintf(primary, "%s %i", (Players[pnum].flags & PLAYER_FLAGS_QUAD_LASERS) ? "QUAD" : "LASER", Players[pnum].laser_level + 1);
+					snprintf(primary, sizeof(primary) / sizeof(primary[0]), "%s %i",
+						(Players[pnum].flags & PLAYER_FLAGS_QUAD_LASERS) ? "QUAD" : "LASER", Players[pnum].laser_level + 1);
 					break;
 				case 1:
-					sprintf(primary, "VUL");
+					snprintf(primary, sizeof(primary) / sizeof(primary[0]), "VUL");
 					break;
 				case 2:
-					sprintf(primary, "SPREAD");
+					snprintf(primary, sizeof(primary) / sizeof(primary[0]), "SPREAD");
 					break;
 				case 3:
-					sprintf(primary, "PLASMA");
+					snprintf(primary, sizeof(primary) / sizeof(primary[0]), "PLASMA");
 					break;
 				case 4:
-					sprintf(primary, "FUSION");
+					snprintf(primary, sizeof(primary) / sizeof(primary[0]), "FUSION");
 					break;
 			}
 
@@ -2740,7 +2745,7 @@ int observer_draw_player_card(int pnum, int color, int x, int y) {
 			} else {
 				// Energy for everything else
 				gr_set_fontcolor(BM_XRGB(25, 18, 6), -1);
-				sprintf(primary_ammo, "%i", (int)energy);
+				snprintf(primary_ammo, sizeof(primary_ammo) / sizeof(primary_ammo[0]), "%i", (int)energy);
 			}
 
 			gr_get_string_size(primary_ammo, &sw, &sh, &saw);
@@ -2754,19 +2759,19 @@ int observer_draw_player_card(int pnum, int color, int x, int y) {
 			char secondary[7];
 			switch (Players[pnum].secondary_weapon) {
 				case 0:
-					sprintf(secondary, "CONC");
+					snprintf(secondary, sizeof(secondary) / sizeof(secondary[0]), "CONC");
 					break;
 				case 1:
-					sprintf(secondary, "HOMING");
+					snprintf(secondary, sizeof(secondary) / sizeof(secondary[0]), "HOMING");
 					break;
 				case 2:
-					sprintf(secondary, "PROX");
+					snprintf(secondary, sizeof(secondary) / sizeof(secondary[0]), "PROX");
 					break;
 				case 3:
-					sprintf(secondary, "SMART");
+					snprintf(secondary, sizeof(secondary) / sizeof(secondary[0]), "SMART");
 					break;
 				case 4:
-					sprintf(secondary, "MEGA");
+					snprintf(secondary, sizeof(secondary) / sizeof(secondary[0]), "MEGA");
 					break;
 			}
 
@@ -2777,7 +2782,8 @@ int observer_draw_player_card(int pnum, int color, int x, int y) {
 
 			// Secondary ammo
 			char secondary_ammo[3];
-			sprintf(secondary_ammo, "%i", Players[pnum].secondary_ammo[Players[pnum].secondary_weapon]);
+			snprintf(secondary_ammo, sizeof(secondary_ammo) / sizeof(secondary_ammo[0]), "%i",
+				Players[pnum].secondary_ammo[Players[pnum].secondary_weapon]);
 			
 			gr_get_string_size(secondary_ammo, &sw, &sh, &saw);
 			gr_printf(x + OBS_PLAYER_CARD_WIDTH - 1 - sw, y, secondary_ammo);
@@ -2812,8 +2818,7 @@ int observer_draw_player_card_in_slot(int pnum, int slot_num, int team_mode, int
 	int color;
 	if (Players[pnum].connected != CONNECT_PLAYING) {
 		color = BM_XRGB(12, 12, 12);
-	}
-	else {
+	} else {
 		int color_for_player = get_color_for_player(pnum, 0);
 		color = BM_XRGB(selected_player_rgb[color_for_player].r, selected_player_rgb[color_for_player].g, selected_player_rgb[color_for_player].b);
 	}
@@ -2823,17 +2828,13 @@ int observer_draw_player_card_in_slot(int pnum, int slot_num, int team_mode, int
 	if (grd_curcanv->cv_bitmap.bm_w < 2 * OBS_PLAYER_CARD_WIDTH_PADDED + OBS_TIME_WIDTH) {
 		num_columns = 2;
 		draw_below_time_text = 1;
-	}
-	else if (grd_curcanv->cv_bitmap.bm_w < 4 * OBS_PLAYER_CARD_WIDTH_PADDED + OBS_TIME_WIDTH) {
+	} else if (grd_curcanv->cv_bitmap.bm_w < 4 * OBS_PLAYER_CARD_WIDTH_PADDED + OBS_TIME_WIDTH) {
 		num_columns = 2;
-	}
-	else if (grd_curcanv->cv_bitmap.bm_w < 6 * OBS_PLAYER_CARD_WIDTH_PADDED + OBS_TIME_WIDTH) {
+	} else if (grd_curcanv->cv_bitmap.bm_w < 6 * OBS_PLAYER_CARD_WIDTH_PADDED + OBS_TIME_WIDTH) {
 		num_columns = 4;
-	}
-	else if (grd_curcanv->cv_bitmap.bm_w < 8 * OBS_PLAYER_CARD_WIDTH_PADDED + OBS_TIME_WIDTH) {
+	} else if (grd_curcanv->cv_bitmap.bm_w < 8 * OBS_PLAYER_CARD_WIDTH_PADDED + OBS_TIME_WIDTH) {
 		num_columns = 6;
-	}
-	else {
+	} else {
 		num_columns = 8;
 	}
 	int ideal_num_columns = team_mode ? (num_drawn_players * 2) : (num_drawn_players + 1) & ~1;
@@ -2841,15 +2842,12 @@ int observer_draw_player_card_in_slot(int pnum, int slot_num, int team_mode, int
 		num_columns = ideal_num_columns;
 
 	int column_num, row_num;
-	if (team_mode)
-	{
+	if (team_mode) {
 		column_num = (abs(slot_num) - 1) % (num_columns / 2);
 		if (slot_num > 0)
 			column_num += num_columns / 2;
 		row_num = (abs(slot_num) - 1) / (num_columns / 2);
-	}
-	else
-	{
+	} else {
 		column_num = slot_num % num_columns;
 		row_num = slot_num / num_columns;
 	}
@@ -2857,10 +2855,13 @@ int observer_draw_player_card_in_slot(int pnum, int slot_num, int team_mode, int
 	int x = (grd_curcanv->cv_bitmap.bm_w - num_columns * OBS_PLAYER_CARD_WIDTH_PADDED) / 2
 		+ OBS_PLAYER_CARD_WIDTH_PADDED * column_num + OBS_PLAYER_CARD_PADDING;
 	int y = obs_player_card_height * row_num;
-	if (draw_below_time_text)
-		y += 53;
-	else
+	if (draw_below_time_text) {
+		// Temporarily switch to time font for measurement
+		gr_set_curfont(MEDIUM3_FONT);
+		y += LINE_SPACING;
+	} else {
 		x += OBS_TIME_WIDTH * (2 * column_num / num_columns) - (OBS_TIME_WIDTH / 2);
+	}
 
 	obs_player_card_height = observer_draw_player_card(pnum, color, x, y);
 
@@ -2882,8 +2883,7 @@ int observer_show_player_cards() {
 		int team_position_blue = 0;
 		int team_position_red = 0;
 
-		for (int i = 0; i < n_players; i++)
-		{
+		for (int i = 0; i < n_players; i++) {
 			int pnum = player_list[i];
 
 			if (Netgame.host_is_obs && pnum == 0)
@@ -2897,8 +2897,7 @@ int observer_show_player_cards() {
 			if (card_max_y > player_cards_max_y)
 				player_cards_max_y = card_max_y;
 		}
-	}
-	else {
+	} else {
 		int pnum;
 		int drawn_players = n_players - (Netgame.host_is_obs ? 1 : 0);
 		bool found_host_as_obs = 0;
@@ -2929,21 +2928,21 @@ void observer_maybe_show_team_score() {
 
 void observer_maybe_show_kill_graph() {
 	if (PlayerCfg.ObsShowKillGraph && GameTime64 < Show_graph_until) {
-        int pnum;
-        kill_event *ev;
-        int minscore = 0;
-        int maxscore = 0;
-        int x, y;
-        int scorescale = 0;
-        int timescale = 0;
-        int gridminy, gridmaxy;
-        char score[10];
-        int sw, sh, aw;
-        int gridminx, gridminx2, gridmaxx;
-        char time[10];
-        int color;
-        kill_event *last_ev;
-        int old_x, old_y;
+		int pnum;
+		kill_event *ev;
+		int minscore = 0;
+		int maxscore = 0;
+		int x, y;
+		int scorescale = 0;
+		int timescale = 0;
+		int gridminy, gridmaxy;
+		char score[10];
+		int sw, sh, aw;
+		int gridminx, gridminx2, gridmaxx;
+		char time[10];
+		int color;
+		kill_event *last_ev;
+		int old_x, old_y;
 
 #ifdef OGL
 		glLineWidth(1);
@@ -3113,11 +3112,11 @@ void observer_maybe_show_kill_graph() {
 			gridminy = grd_curcanv->cv_bitmap.bm_h - 10 - FSPACY(6);
 			gridmaxy = grd_curcanv->cv_bitmap.bm_h - 200;
 
-			sprintf(score, "%i", minscore);
+			snprintf(score, sizeof(score) / sizeof(score[0]), "%i", minscore);
 			gr_get_string_size(score, &sw, &sh, &aw);
 			gridminx = (grd_curcanv->cv_bitmap.bm_w - 1000) / 2 + 5 + sw;
 
-			sprintf(score, "%i", maxscore);
+			snprintf(score, sizeof(score) / sizeof(score[0]), "%i", maxscore);
 			gr_get_string_size(score, &sw, &sh, &aw);
 			gridminx2 = (grd_curcanv->cv_bitmap.bm_w - 1000) / 2 + 5 + sw;
 
@@ -3129,7 +3128,7 @@ void observer_maybe_show_kill_graph() {
 
 			for (int i = trunc((float)minscore / (float)scorescale); i <= maxscore; i += scorescale) {
 				y = gridminy - (int)((float)(gridminy - gridmaxy) * (((float)(i - minscore)) / (float)(maxscore - minscore)));
-				sprintf(score, "%i", i);
+				snprintf(score, sizeof(score) / sizeof(score[0]), "%i", i);
 				gr_get_string_size(score, &sw, &sh, &aw);
 				gr_set_fontcolor(BM_XRGB(31, 31, 31), -1);
 				gr_printf(gridminx - sw, y - sh / 2, "%s", score);
@@ -3140,7 +3139,7 @@ void observer_maybe_show_kill_graph() {
 			for (int i = 0; i2f(i) < GameTime64; i += timescale * 60) {
 				x = gridminx + (int)((float)(gridmaxx - gridminx) * (((float)i2f(i)) / (float)(GameTime64)));
 				if (i > 0) {
-					sprintf(time, "%i", i / 60);
+					snprintf(time, sizeof(time) / sizeof(time[0]), "%i", i / 60);
 					gr_get_string_size(time, &sw, &sh, &aw);
 					gr_set_fontcolor(BM_XRGB(31, 31, 31), -1);
 					gr_printf(x - sw / 2, gridminy + 1, "%s", time);
@@ -3189,146 +3188,148 @@ void observer_maybe_show_kill_graph() {
 		glLineWidth(linedotscale);
 #endif
 	} else if (PlayerCfg.ObsShowBreakdown && GameTime64 < Show_graph_until + (PlayerCfg.ObsShowKillGraph ? i2f(15) : 0)) {
-        int drawn_players = n_players - (Netgame.host_is_obs ? 1 : 0);
+		int drawn_players = n_players - (Netgame.host_is_obs ? 1 : 0);
 		int y = GHEIGHT - (LINE_SPACING * 2); // Make space for the demo indicator
-        int x;
+		int x;
 		int sw, sh, aw;
-        int color;
-        int pnum;
-    	char reason[20];
+		int color;
+		int pnum;
+		char reason[20];
 		char damage_info_text[40];
 
-        if (drawn_players <= 2) {
-            // Show top 3 damage done sources per pilot.
+		if (drawn_players <= 2) {
+			// Show top 3 damage done sources per pilot.
 			y -= (LINE_SPACING * 5);
 
-            gr_set_fontcolor(BM_XRGB(0, 31, 0), -1);
+			gr_set_fontcolor(BM_XRGB(0, 31, 0), -1);
 			gr_string(0x8000, y, "Top Damaging Weapons");
 
 			y += LINE_SPACING;
 
 			x = (GWIDTH / 2) - FSPACX(60);
 
-            for (int i = 0; i < n_players; i++) {
-                int this_y = y;
+			for (int i = 0; i < n_players; i++) {
+				int this_y = y;
 
-                pnum = player_list[i];
+				pnum = player_list[i];
 
-                if (Netgame.host_is_obs && pnum == 0) {
-                    continue;
-                }
+				if (Netgame.host_is_obs && pnum == 0) {
+					continue;
+				}
 
-                if (Players[pnum].connected != CONNECT_PLAYING) {
-                    color = BM_XRGB(12, 12, 12);
-                } else {
-                    int color_for_player = get_color_for_player(pnum, 0);
-                    color = BM_XRGB(selected_player_rgb[color_for_player].r, selected_player_rgb[color_for_player].g, selected_player_rgb[color_for_player].b);
-                }
+				if (Players[pnum].connected != CONNECT_PLAYING) {
+					color = BM_XRGB(12, 12, 12);
+				} else {
+					int color_for_player = get_color_for_player(pnum, 0);
+					color = BM_XRGB(selected_player_rgb[color_for_player].r, selected_player_rgb[color_for_player].g, selected_player_rgb[color_for_player].b);
+				}
 
-                gr_set_fontcolor(color, -1);
+				gr_set_fontcolor(color, -1);
 				gr_get_string_size(Players[pnum].callsign, &sw, &sh, &aw);
 				gr_string(x - (sw / 2), this_y, Players[pnum].callsign);
 
 				this_y += LINE_SPACING;
 
-                if (First_damage_done_totals[pnum] != NULL) {
-                    int j = 0;
-                    damage_done_totals* ddt = First_damage_done_totals[pnum];
+				if (First_damage_done_totals[pnum] != NULL) {
+					int j = 0;
+					damage_done_totals* ddt = First_damage_done_totals[pnum];
 
-                    while (j < 3 && ddt != NULL) {
-                        switch (ddt->source_id) {
-                            case SHIP_EXPLOSION_DAMAGE:
-                                sprintf(reason, "Explosion");
-                                break;
-                            case SHIP_COLLISION_DAMAGE:
-                                sprintf(reason, "Ramming");
-                                break;
-                            default:
-                                sprintf(reason, "%s", weapon_id_to_name(ddt->source_id));
-                                break;
-                        }
+					while (j < 3 && ddt != NULL) {
+						switch (ddt->source_id) {
+							case SHIP_EXPLOSION_DAMAGE:
+								snprintf(reason, sizeof(reason) / sizeof(reason[0]), "Explosion");
+								break;
+							case SHIP_COLLISION_DAMAGE:
+								snprintf(reason, sizeof(reason) / sizeof(reason[0]), "Ramming");
+								break;
+							default:
+								snprintf(reason, sizeof(reason) / sizeof(reason[0]), "%s",
+									weapon_id_to_name(ddt->source_id));
+								break;
+						}
 
 						// Center each column
-						sprintf(damage_info_text, "%s: %0.1f", reason, f2fl(ddt->total_damage));
+						snprintf(damage_info_text, sizeof(damage_info_text) / sizeof(damage_info_text[0]), "%s: %0.1f",
+							reason, f2fl(ddt->total_damage));
 						gr_get_string_size(damage_info_text, &sw, &sh, &aw);
 						gr_string(x - (sw / 2), this_y, damage_info_text);
 
 						this_y += LINE_SPACING;
 
-                        j++;
-                        ddt = ddt->next;
-                    }
-                } else {
-					sprintf(damage_info_text, "No Damage");
+						j++;
+						ddt = ddt->next;
+					}
+				} else {
+					snprintf(damage_info_text, sizeof(damage_info_text) / sizeof(damage_info_text[0]), "No Damage");
 					gr_get_string_size(damage_info_text, &sw, &sh, &aw);
 					gr_string(x - (sw / 2), this_y, damage_info_text);
-                }
+				}
 
 				x += FSPACX(120);
-            }
-        } else {
-            // Show top 1 damage done source per pilot.
+			}
+		} else {
+			// Show top 1 damage done source per pilot.
 			y -= (LINE_SPACING * 5);
 
-            gr_set_fontcolor(BM_XRGB(0, 31, 0), -1);
+			gr_set_fontcolor(BM_XRGB(0, 31, 0), -1);
 			gr_string(0x8000, y, "Top Damaging Weapon");
 
-            y += 27;
+			y += 27;
 
-            int this_y = y;
-            int n_drawn = 0;
+			int this_y = y;
+			int n_drawn = 0;
 			int column_num = 0;
 
-            for (int i = 0; i < n_players; i++) {
-                pnum = player_list[i];
+			for (int i = 0; i < n_players; i++) {
+				pnum = player_list[i];
 
-                if (Netgame.host_is_obs && pnum == 0) {
-                    continue;
-                }
+				if (Netgame.host_is_obs && pnum == 0) {
+					continue;
+				}
 
-                if (Players[pnum].connected != CONNECT_PLAYING) {
-                    color = BM_XRGB(12, 12, 12);
-                } else {
-                    int color_for_player = get_color_for_player(pnum, 0);
-                    color = BM_XRGB(selected_player_rgb[color_for_player].r, selected_player_rgb[color_for_player].g, selected_player_rgb[color_for_player].b);
-                }
+				if (Players[pnum].connected != CONNECT_PLAYING) {
+					color = BM_XRGB(12, 12, 12);
+				} else {
+					int color_for_player = get_color_for_player(pnum, 0);
+					color = BM_XRGB(selected_player_rgb[color_for_player].r, selected_player_rgb[color_for_player].g, selected_player_rgb[color_for_player].b);
+				}
 
-                if (First_damage_done_totals[pnum] != NULL) {
-                    int j = 0;
-                    damage_done_totals* ddt = First_damage_done_totals[pnum];
+				if (First_damage_done_totals[pnum] != NULL) {
+					int j = 0;
+					damage_done_totals* ddt = First_damage_done_totals[pnum];
 
-                    switch (ddt->source_id) {
-                        case SHIP_EXPLOSION_DAMAGE:
-                            sprintf(reason, "Explosion");
-                            break;
-                        case SHIP_COLLISION_DAMAGE:
-                            sprintf(reason, "Ramming");
-                            break;
-                        default:
-                            sprintf(reason, "%s", weapon_id_to_name(ddt->source_id));
-                            break;
-                    }
+					switch (ddt->source_id) {
+						case SHIP_EXPLOSION_DAMAGE:
+							snprintf(reason, sizeof(reason) / sizeof(reason[0]), "Explosion");
+							break;
+						case SHIP_COLLISION_DAMAGE:
+							snprintf(reason, sizeof(reason) / sizeof(reason[0]), "Ramming");
+							break;
+						default:
+							snprintf(reason, sizeof(reason) / sizeof(reason[0]), "%s",
+								weapon_id_to_name(ddt->source_id));
+							break;
+					}
 
-					sprintf(damage_info_text, "%s's %s: %0.1f", Players[pnum].callsign, reason, f2fl(ddt->total_damage));
-                } else {
-					sprintf(damage_info_text, "%s: No Damage", Players[pnum].callsign);
-                }
+					snprintf(damage_info_text, sizeof(damage_info_text) / sizeof(damage_info_text[0]), "%s's %s: %0.1f",
+						Players[pnum].callsign, reason, f2fl(ddt->total_damage));
+				} else {
+					snprintf(damage_info_text, sizeof(damage_info_text) / sizeof(damage_info_text[0]), "%s: No Damage",
+						Players[pnum].callsign);
+				}
 
-				if (column_num == 0)
-				{
+				if (column_num == 0) {
 					// First column is right-aligned
 					gr_get_string_size(damage_info_text, &sw, &sh, &aw);
 					x = (GWIDTH / 2) - FSPACX(5) - sw;
-				}
-				else
-				{
+				} else {
 					// Second column is left-aligned
 					x = (GWIDTH / 2) + FSPACX(5);
 				}
 
 				gr_string(x, this_y, damage_info_text);
 
-                n_drawn++;
+				n_drawn++;
 
 				if (n_drawn > drawn_players / 2 && column_num == 0) {
 					column_num = 1;
@@ -3336,9 +3337,9 @@ void observer_maybe_show_kill_graph() {
 				} else {
 					this_y += LINE_SPACING;
 				}
-            }
-        }
-    }
+			}
+		}
+	}
 }
 
 int maybe_show_observers(int startY) {
@@ -3431,9 +3432,11 @@ int observer_maybe_show_streaks(int startY) {
 		if (((is_anarchy || is_team_anarchy) && Kill_streak[pnum] >= 3) || (is_bounty && pnum == Bounty_target)) {
 			status.type = GST_KILL_STREAK;
 			if (is_bounty) {
-				sprintf(status.text, "Bounty Kill Streak: %i", Kill_streak[pnum]);
+				snprintf(status.text, sizeof(status.text) / sizeof(status.text[0]), "Bounty Kill Streak: %i",
+					Kill_streak[pnum]);
 			} else {
-				sprintf(status.text, "Kill Streak: %i", Kill_streak[pnum]);
+				snprintf(status.text, sizeof(status.text) / sizeof(status.text[0]), "Kill Streak: %i",
+					Kill_streak[pnum]);
 			}
 			add_player_status(pnum, status);
 			remove_player_status(pnum, GST_LAST_KILL);
@@ -3441,9 +3444,11 @@ int observer_maybe_show_streaks(int startY) {
 		} else if ((is_anarchy || is_team_anarchy) && Last_kill[pnum] != NULL && ((diff = GameTime64 - Last_kill[pnum]->timestamp) >= i2f(60))) {
 			status.type = GST_LAST_KILL;
 			if (diff >= i2f(3600)) {
-				sprintf(status.text, "Last Kill: %i:%02i:%02i", (int)(diff / i2f(3600)), (int)(diff / i2f(60)) % 60, (int)(diff / i2f(1)) % 60);
+				snprintf(status.text, sizeof(status.text) / sizeof(status.text[0]), "Last Kill: %i:%02i:%02i",
+					(int)(diff / i2f(3600)), (int)(diff / i2f(60)) % 60, (int)(diff / i2f(1)) % 60);
 			} else {
-				sprintf(status.text, "Last Kill: %02i:%02i", (int)(diff / i2f(60)) % 60, (int)(diff / i2f(1)) % 60);
+				snprintf(status.text, sizeof(status.text) / sizeof(status.text[0]), "Last Kill: %02i:%02i",
+					(int)(diff / i2f(60)) % 60, (int)(diff / i2f(1)) % 60);
 			}
 			add_player_status(pnum, status);
 			remove_player_status(pnum, GST_KILL_STREAK);
@@ -3451,9 +3456,11 @@ int observer_maybe_show_streaks(int startY) {
 		} else if (n_players > 2 + (Netgame.host_is_obs ? 1 : 0) && Last_death[pnum] != NULL && ((diff = GameTime64 - Last_death[pnum]->timestamp) >= i2f(60))) {
 			status.type = GST_LAST_DEATH;
 			if (diff >= i2f(3600)) {
-				sprintf(status.text, "Last Death: %i:%02i:%02i", (int)(diff / i2f(3600)), (int)(diff / i2f(60)) % 60, (int)(diff / i2f(1)) % 60);
+				snprintf(status.text, sizeof(status.text) / sizeof(status.text[0]), "Last Death: %i:%02i:%02i",
+					(int)(diff / i2f(3600)), (int)(diff / i2f(60)) % 60, (int)(diff / i2f(1)) % 60);
 			} else {
-				sprintf(status.text, "Last Death: %02i:%02i", (int)(diff / i2f(60)) % 60, (int)(diff / i2f(1)) % 60);
+				snprintf(status.text, sizeof(status.text) / sizeof(status.text[0]), "Last Death: %02i:%02i",
+					(int)(diff / i2f(60)) % 60, (int)(diff / i2f(1)) % 60);
 			}
 			add_player_status(pnum, status);
 			remove_player_status(pnum, GST_KILL_STREAK);
@@ -3521,9 +3528,13 @@ int observer_maybe_show_streaks(int startY) {
 
 					status.type = GST_RUN;
 					if (diff >= i2f(3600)) {
-						sprintf(status.text, "Run: %i-%i in %i:%02i:%02i", initial_score - last_ev->score, initial_opp_score - last_opp_ev->score, (int)(diff / i2f(3600)), (int)(diff / i2f(60)) % 60, (int)(diff / i2f(1)) % 60);
+						snprintf(status.text, sizeof(status.text) / sizeof(status.text[0]), "Run: %i-%i in %i:%02i:%02i",
+							initial_score - last_ev->score, initial_opp_score - last_opp_ev->score,
+							(int)(diff / i2f(3600)), (int)(diff / i2f(60)) % 60, (int)(diff / i2f(1)) % 60);
 					} else {
-						sprintf(status.text, "Run: %i-%i in %02i:%02i", initial_score - last_ev->score, initial_opp_score - last_opp_ev->score, (int)(diff / i2f(60)) % 60, (int)(diff / i2f(1)) % 60);
+						snprintf(status.text, sizeof(status.text) / sizeof(status.text[0]), "Run: %i-%i in %02i:%02i",
+							initial_score - last_ev->score, initial_opp_score - last_opp_ev->score,
+							(int)(diff / i2f(60)) % 60, (int)(diff / i2f(1)) % 60);
 					}
 					add_player_status(pnum, status);
 				} else {
@@ -3631,7 +3642,7 @@ void observer_maybe_show_death_log(int y) {
 	gr_set_curfont( GAME_FONT );
 
 	while (kle != NULL && GameTime64 - kle->timestamp < i2f(5)) {
-		sprintf(killed, "%s", Players[kle->killed_id].callsign);
+		snprintf(killed, sizeof(killed) / sizeof(killed[0]), "%s", Players[kle->killed_id].callsign);
 
 		color = get_color_for_player(kle->killed_id, 0);
 		killed_color = BM_XRGB(selected_player_rgb[color].r,selected_player_rgb[color].g,selected_player_rgb[color].b);
@@ -3639,12 +3650,12 @@ void observer_maybe_show_death_log(int y) {
 		switch (kle->killer_type) {
 			case OBJ_WALL:
 				// You can't die to a wall, but you can die to lava which is considered a wall.
-				sprintf(killer, "Lava");
+				snprintf(killer, sizeof(killer) / sizeof(killer[0]), "Lava");
 				killer_color = BM_XRGB(12, 12, 12);
 				reason[0] = '\0';
 				break;
 			case OBJ_ROBOT:
-				sprintf(killer, "Robot");
+				snprintf(killer, sizeof(killer) / sizeof(killer[0]), "Robot");
 				killer_color = BM_XRGB(12, 12, 12);
 				reason[0] = '\0';
 				break;
@@ -3652,7 +3663,8 @@ void observer_maybe_show_death_log(int y) {
 				if (kle->killer_id == kle->killed_id) {
 					killer[0] = '\0';
 				} else {
-					sprintf(killer, "%s", Players[kle->killer_id].callsign);
+					snprintf(killer, sizeof(killer) / sizeof(killer[0]), "%s",
+						Players[kle->killer_id].callsign);
 					color = get_color_for_player(kle->killer_id, 0);
 					killer_color = BM_XRGB(selected_player_rgb[color].r,selected_player_rgb[color].g,selected_player_rgb[color].b);
 				}
@@ -3661,24 +3673,25 @@ void observer_maybe_show_death_log(int y) {
 					case DAMAGE_WEAPON:
 					case DAMAGE_BLAST:
 						if (kle->source_id == SHIP_EXPLOSION_DAMAGE) {
-							sprintf(reason, "Explosion");
+							snprintf(reason, sizeof(reason) / sizeof(reason[0]), "Explosion");
 						} else {
-							sprintf(reason, "%s", weapon_id_to_name(kle->source_id));
+							snprintf(reason, sizeof(reason) / sizeof(reason[0]), "%s",
+								weapon_id_to_name(kle->source_id));
 						}
 						break;
 					case DAMAGE_COLLISION:
-						sprintf(reason, "Ramming");
+						snprintf(reason, sizeof(reason) / sizeof(reason[0]), "Ramming");
 						break;
 					case DAMAGE_LAVA:
-						sprintf(reason, "Lava");
+						snprintf(reason, sizeof(reason) / sizeof(reason[0]), "Lava");
 						break;
 					case DAMAGE_OVERCHARGE:
-						sprintf(reason, "Overcharge");
+						snprintf(reason, sizeof(reason) / sizeof(reason[0]), "Overcharge");
 						break;
 				}
 				break;
 			case OBJ_CNTRLCEN:
-				sprintf(killer, "Reactor");
+				snprintf(killer, sizeof(killer) / sizeof(killer[0]), "Reactor");
 				killer_color = BM_XRGB(12, 12, 12);
 				reason[0] = '\0';
 				break;
@@ -3721,100 +3734,106 @@ void observer_maybe_show_death_log(int y) {
 		kle = kle->next;
 		y += LINE_SPACING;
 	}
-    
-    if (PlayerCfg.ObsShowDeathSummary) {
-        kle = Kill_log;
+	
+	if (PlayerCfg.ObsShowDeathSummary) {
+		kle = Kill_log;
 
-        damage_taken_totals* dtt;
-        char damage_for[32];
-        bool player_shown[8] = {0, 0, 0, 0, 0, 0, 0, 0};
-        while (kle != NULL && GameTime64 - kle->timestamp < i2f(15)) {
-            if (player_shown[kle->killed_id] == 1) {
-                kle = kle->next;
-                continue;
-            }
-            player_shown[kle->killed_id] = 1;
+		damage_taken_totals* dtt;
+		char damage_for[32];
+		bool player_shown[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+		while (kle != NULL && GameTime64 - kle->timestamp < i2f(15)) {
+			if (player_shown[kle->killed_id] == 1) {
+				kle = kle->next;
+				continue;
+			}
+			player_shown[kle->killed_id] = 1;
 
-            y += 10;
-        
-            color = get_color_for_player(kle->killed_id, 0);
-            gr_set_fontcolor(BM_XRGB(selected_player_rgb[color].r,selected_player_rgb[color].g,selected_player_rgb[color].b), -1);
+			y += 10;
+		
+			color = get_color_for_player(kle->killed_id, 0);
+			gr_set_fontcolor(BM_XRGB(selected_player_rgb[color].r,selected_player_rgb[color].g,selected_player_rgb[color].b), -1);
 
-            sprintf(damage_for, "Top damage for %s:", Players[kle->killed_id].callsign);
+			snprintf(damage_for, sizeof(damage_for) / sizeof(damage_for[0]), "Top damage for %s:",
+				Players[kle->killed_id].callsign);
 
-            x = grd_curcanv->cv_bitmap.bm_w - 5;
-            gr_get_string_size(damage_for, &sw, &sh, &aw);
-            x -= sw;
-            gr_printf(x, y, damage_for);
-            y += LINE_SPACING;
+			x = grd_curcanv->cv_bitmap.bm_w - 5;
+			gr_get_string_size(damage_for, &sw, &sh, &aw);
+			x -= sw;
+			gr_printf(x, y, damage_for);
+			y += LINE_SPACING;
 
-            dtt = First_damage_taken_previous_totals[kle->killed_id];
-            int i = 0;
+			dtt = First_damage_taken_previous_totals[kle->killed_id];
+			int i = 0;
 
-            while (dtt != NULL && i < 3) {
-                switch (dtt->killer_type) {
-                    case OBJ_WALL:
-                        if (dtt->damage_type == DAMAGE_LAVA) {
-                            sprintf(killer, "Lava");
-                        } else {
-                            sprintf(killer, "Wall");
-                        }
-                        reason[0] = '\0';
-                        break;
-                    case OBJ_ROBOT:
-                        sprintf(killer, "Robot");
-                        reason[0] = '\0';
-                        break;
-                    case OBJ_PLAYER:
-                        sprintf(killer, "%s", Players[dtt->killer_id].callsign);
+			while (dtt != NULL && i < 3) {
+				switch (dtt->killer_type) {
+					case OBJ_WALL:
+						if (dtt->damage_type == DAMAGE_LAVA) {
+							snprintf(killer, sizeof(killer) / sizeof(killer[0]), "Lava");
+						} else {
+							snprintf(killer, sizeof(killer) / sizeof(killer[0]), "Wall");
+						}
+						reason[0] = '\0';
+						break;
+					case OBJ_ROBOT:
+						snprintf(killer, sizeof(killer) / sizeof(killer[0]), "Robot");
+						reason[0] = '\0';
+						break;
+					case OBJ_PLAYER:
+						snprintf(killer, sizeof(killer) / sizeof(killer[0]), "%s",
+							Players[dtt->killer_id].callsign);
 
-                        switch (dtt->damage_type) {
-                            case DAMAGE_WEAPON:
-                            case DAMAGE_BLAST:
-                                if (dtt->source_id == SHIP_EXPLOSION_DAMAGE) {
-                                    sprintf(reason, "Explosion");
-                                } else {
-                                    sprintf(reason, "%s", weapon_id_to_name(dtt->source_id));
-                                }
-                                break;
-                            case DAMAGE_COLLISION:
-                                sprintf(reason, "Ramming");
-                                break;
-                            case DAMAGE_LAVA:
-                                sprintf(reason, "Lava");
-                                break;
-                            case DAMAGE_OVERCHARGE:
-                                sprintf(reason, "Overcharge");
-                                break;
-                        }
-                        break;
-                    case OBJ_CNTRLCEN:
-                        sprintf(killer, "Reactor");
-                        reason[0] = '\0';
-                        break;
-                }
+						switch (dtt->damage_type) {
+							case DAMAGE_WEAPON:
+							case DAMAGE_BLAST:
+								if (dtt->source_id == SHIP_EXPLOSION_DAMAGE) {
+									snprintf(reason, sizeof(reason) / sizeof(reason[0]), "Explosion");
+								} else {
+									snprintf(reason, sizeof(reason) / sizeof(reason[0]), "%s",
+										weapon_id_to_name(dtt->source_id));
+								}
+								break;
+							case DAMAGE_COLLISION:
+								snprintf(reason, sizeof(reason) / sizeof(reason[0]), "Ramming");
+								break;
+							case DAMAGE_LAVA:
+								snprintf(reason, sizeof(reason) / sizeof(reason[0]), "Lava");
+								break;
+							case DAMAGE_OVERCHARGE:
+								snprintf(reason, sizeof(reason) / sizeof(reason[0]), "Overcharge");
+								break;
+						}
+						break;
+					case OBJ_CNTRLCEN:
+						snprintf(killer, sizeof(killer) / sizeof(killer[0]), "Reactor");
+						reason[0] = '\0';
+						break;
+				}
 
-                if (killer[0] == '\0') {
-                    sprintf(damage_for, "%s %0.1f", reason, f2fl(dtt->total_damage));
-                } else if (reason[0] == '\0') {
-                    sprintf(damage_for, "%s %0.1f", killer, f2fl(dtt->total_damage));
-                } else {
-                    sprintf(damage_for, "%s's %s %0.1f", killer, reason, f2fl(dtt->total_damage));
-                }
+				if (killer[0] == '\0') {
+					snprintf(damage_for, sizeof(damage_for) / sizeof(damage_for[0]), "%s %0.1f",
+						reason, f2fl(dtt->total_damage));
+				} else if (reason[0] == '\0') {
+					snprintf(damage_for, sizeof(damage_for) / sizeof(damage_for[0]), "%s %0.1f",
+						killer, f2fl(dtt->total_damage));
+				} else {
+					snprintf(damage_for, sizeof(damage_for) / sizeof(damage_for[0]), "%s's %s %0.1f",
+						killer, reason, f2fl(dtt->total_damage));
+				}
 
-                x = grd_curcanv->cv_bitmap.bm_w - 5;
-                gr_get_string_size(damage_for, &sw, &sh, &aw);
-                x -= sw;
-                gr_printf(x, y, damage_for);
-                y += LINE_SPACING;
+				x = grd_curcanv->cv_bitmap.bm_w - 5;
+				gr_get_string_size(damage_for, &sw, &sh, &aw);
+				x -= sw;
+				gr_printf(x, y, damage_for);
+				y += LINE_SPACING;
 
-                dtt = dtt->next;
-                i++;
-            }
+				dtt = dtt->next;
+				i++;
+			}
 
-            kle = kle->next;
-        }
-    }
+			kle = kle->next;
+		}
+	}
 }
 
 void observer_show_kill_list()
@@ -3829,7 +3848,7 @@ void observer_show_kill_list()
 	observer_maybe_show_team_score();
 
 	// Show the kill graph, which is a line graph of kills over time for each pilot, and kill summaries, which is each pilot's most damaging weapon(s).
-    observer_maybe_show_kill_graph();
+	observer_maybe_show_kill_graph();
 
 	int y = grd_curcanv->cv_bitmap.bm_h - 5;
 
@@ -3842,9 +3861,9 @@ void observer_show_kill_list()
 		y = observer_maybe_show_streaks(y);
 	}
 
-    if (Observer_message_y_start < 49) {
-        Observer_message_y_start = 49;
-    }
+	if (Observer_message_y_start < 49) {
+		Observer_message_y_start = 49;
+	}
 
 	// Show a death log, including who killed who and with what, and death summaries.
 	if (PlayerCfg.ObsShowKillFeed) {

--- a/d1/main/multi.c
+++ b/d1/main/multi.c
@@ -820,6 +820,19 @@ get_team(int pnum)
 		return 0;
 }
 
+int get_team_size(int team_num)
+{
+	int team_size = 0;
+	for (int i = 0; i < Netgame.max_numplayers; i++)
+	{
+		if (is_observer() && Netgame.host_is_obs && i == 0)
+			continue;
+		if (get_team(i) == team_num)
+			team_size++;
+	}
+	return team_size;
+}
+
 void
 multi_new_game(void)
 {

--- a/d1/main/multi.h
+++ b/d1/main/multi.h
@@ -285,6 +285,7 @@ void multi_reset_stuff(void);
 void multi_send_data(unsigned char *buf, int len, int priority);
 void multi_send_obs_data(unsigned char *buf, int len);
 int get_team(int pnum);
+int get_team_size(int team_num);
 int multi_maybe_disable_friendly_fire(object *killer);
 void multi_initiate_save_game();
 void multi_initiate_restore_game();

--- a/d1/main/player.h
+++ b/d1/main/player.h
@@ -58,6 +58,10 @@ COPYRIGHT 1993-1998 PARALLAX SOFTWARE CORPORATION.  ALL RIGHTS RESERVED.
 
 #define PLAYER_STRUCT_VERSION 	16		//increment this every time player struct changes
 
+// defines for teams
+#define TEAM_BLUE   0
+#define TEAM_RED    1
+
 //When this structure changes, increment the constant SAVE_FILE_VERSION
 //in playsave.c
 typedef struct player {

--- a/d2/main/CMakeLists.txt
+++ b/d2/main/CMakeLists.txt
@@ -114,6 +114,11 @@ if(WIN32)
         # MSVC will automatically generate a manifest using this method - which will cause a
         # collision - so we need to tell it not to.
         target_link_options(d2x-redux PRIVATE "/MANIFEST:NO")
+        if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+            # Enable Hot Reload for debug builds
+            target_link_options(${PROJECT_NAME} PRIVATE $<$<CONFIG:Debug>:/INCREMENTAL>)
+            target_compile_options(${PROJECT_NAME} PRIVATE $<$<CONFIG:Debug>:/ZI>)
+        endif()
     endif()
 
     install(FILES

--- a/d2/main/gauges.c
+++ b/d2/main/gauges.c
@@ -3497,22 +3497,24 @@ void observer_maybe_show_kill_graph() {
 #endif
 	} else if (PlayerCfg.ObsShowBreakdown && GameTime64 < Show_graph_until + (PlayerCfg.ObsShowKillGraph ? i2f(15) : 0)) {
 		int drawn_players = n_players - (Netgame.host_is_obs ? 1 : 0);
-		int y = grd_curcanv->cv_bitmap.bm_h - 60;
+		int y = GHEIGHT - (LINE_SPACING * 2); // Make space for the demo indicator
 		int x;
+		int sw, sh, aw;
 		int color;
 		int pnum;
 		char reason[20];
+		char damage_info_text[40];
 
 		if (drawn_players <= 2) {
 			// Show top 3 damage done sources per pilot.
-			y -= (27 * 5);
+			y -= (LINE_SPACING * 5);
 
 			gr_set_fontcolor(BM_XRGB(0, 31, 0), -1);
 			gr_string(0x8000, y, "Top Damaging Weapons");
 
-			y += 27;
+			y += LINE_SPACING;
 
-			x = grd_curcanv->cv_bitmap.bm_w / 2 - 400;
+			x = (GWIDTH / 2) - FSPACX(60);
 
 			for (int i = 0; i < n_players; i++) {
 				int this_y = y;
@@ -3531,9 +3533,10 @@ void observer_maybe_show_kill_graph() {
 				}
 
 				gr_set_fontcolor(color, -1);
-				gr_printf(x, this_y, "%s", Players[pnum].callsign);
+				gr_get_string_size(Players[pnum].callsign, &sw, &sh, &aw);
+				gr_string(x - (sw / 2), this_y, Players[pnum].callsign);
 
-				this_y += 27;
+				this_y += LINE_SPACING;
 
 				if (First_damage_done_totals[pnum] != NULL) {
 					int j = 0;
@@ -3552,31 +3555,36 @@ void observer_maybe_show_kill_graph() {
 								break;
 						}
 
-						gr_printf(x, this_y, "%s: %0.1f", reason, f2fl(ddt->total_damage));
-						this_y += 27;
+						// Center each column
+						sprintf(damage_info_text, "%s: %0.1f", reason, f2fl(ddt->total_damage));
+						gr_get_string_size(damage_info_text, &sw, &sh, &aw);
+						gr_string(x - (sw / 2), this_y, damage_info_text);
+
+						this_y += LINE_SPACING;
 
 						j++;
 						ddt = ddt->next;
 					}
 				} else {
-					gr_string(x, this_y, "No Damage");
+					sprintf(damage_info_text, "No Damage");
+					gr_get_string_size(damage_info_text, &sw, &sh, &aw);
+					gr_string(x - (sw / 2), this_y, damage_info_text);
 				}
 
-				x += 405;
+				x += FSPACX(120);
 			}
 		} else {
 			// Show top 1 damage done source per pilot.
-			y -= (27 * 5);
+			y -= (LINE_SPACING * 5);
 
 			gr_set_fontcolor(BM_XRGB(0, 31, 0), -1);
 			gr_string(0x8000, y, "Top Damaging Weapon");
 
-			y += 27;
-
-			x = grd_curcanv->cv_bitmap.bm_w / 2 - 500;
+			y += LINE_SPACING;
 
 			int this_y = y;
 			int n_drawn = 0;
+			int column_num = 0;
 
 			for (int i = 0; i < n_players; i++) {
 				pnum = player_list[i];
@@ -3608,19 +3616,32 @@ void observer_maybe_show_kill_graph() {
 							break;
 					}
 
-					gr_printf(x, this_y, "%s's %s: %0.1f", Players[pnum].callsign, reason, f2fl(ddt->total_damage));
+					sprintf(damage_info_text, "%s's %s: %0.1f", Players[pnum].callsign, reason, f2fl(ddt->total_damage));
 				} else {
-					gr_printf(x, this_y, "%s: No Damage", Players[pnum].callsign);
+					sprintf(damage_info_text, "%s: No Damage", Players[pnum].callsign);
 				}
+
+				if (column_num == 0)
+				{
+					// First column is right-aligned
+					gr_get_string_size(damage_info_text, &sw, &sh, &aw);
+					x = (GWIDTH / 2) - FSPACX(5) - sw;
+				}
+				else
+				{
+					// Second column is left-aligned
+					x = (GWIDTH / 2) + FSPACX(5);
+				}
+
+				gr_string(x, this_y, damage_info_text);
 
 				n_drawn++;
 
-				if (n_drawn >= drawn_players / 2) {
-					n_drawn = 0 - MAX_PLAYERS;
-					x += 505;
+				if (n_drawn > drawn_players / 2 && column_num == 0) {
+					column_num = 1;
 					this_y = y;
 				} else {
-					this_y += 27;
+					this_y += LINE_SPACING;
 				}
 			}
 		}
@@ -3843,12 +3864,12 @@ int observer_maybe_show_streaks(int startY) {
 	int color;
 
 	while (p_status != NULL) {
-		height += 27;
+		height += LINE_SPACING;
 
 		g_status = p_status->statuses;
 
 		while (g_status != NULL) {
-			height += 27;
+			height += LINE_SPACING;
 
 			g_status = g_status->next;
 		}
@@ -3885,7 +3906,7 @@ int observer_maybe_show_streaks(int startY) {
 		x = grd_curcanv->cv_bitmap.bm_w - w - 5;
 
 		gr_printf(x, y, "%s", Players[pnum].callsign);
-		y += 27;
+		y += LINE_SPACING;
 
 		color = get_color_for_player(pnum, 1);
 		gr_set_fontcolor(BM_XRGB(selected_player_rgb[color].r, selected_player_rgb[color].g, selected_player_rgb[color].b), -1);
@@ -3897,7 +3918,7 @@ int observer_maybe_show_streaks(int startY) {
 			x = grd_curcanv->cv_bitmap.bm_w - w - 5;
 
 			gr_printf(x, y, "%s", g_status->text);
-			y += 27;
+			y += LINE_SPACING;
 
 			g_status = g_status->next;
 		}
@@ -4019,7 +4040,7 @@ void observer_maybe_show_death_log(int y) {
 		}
 
 		kle = kle->next;
-		y += FSPACY(6);
+		y += LINE_SPACING;
 	}
 
 	if (PlayerCfg.ObsShowDeathSummary) {
@@ -4046,7 +4067,7 @@ void observer_maybe_show_death_log(int y) {
 			gr_get_string_size(damage_for, &sw, &sh, &aw);
 			x -= sw;
 			gr_printf(x, y, damage_for);
-			y += FSPACY(6);
+			y += LINE_SPACING;
 
 			dtt = First_damage_taken_previous_totals[kle->killed_id];
 			int i = 0;
@@ -4110,7 +4131,7 @@ void observer_maybe_show_death_log(int y) {
 				gr_get_string_size(damage_for, &sw, &sh, &aw);
 				x -= sw;
 				gr_printf(x, y, damage_for);
-				y += FSPACY(6);
+				y += LINE_SPACING;
 
 				dtt = dtt->next;
 				i++;

--- a/d2/main/gauges.c
+++ b/d2/main/gauges.c
@@ -2782,9 +2782,11 @@ void observer_show_time() {
 	int y = 5;
 
 	if (GameTime64 < 3600 * F1_0)
-		sprintf(time_str, "%02i:%02i", (int)(f2i(GameTime64) / 60 % 60), (int)(f2i(GameTime64) % 60));
+		snprintf(time_str, sizeof(time_str) / sizeof(time_str[0]), "%02i:%02i",
+			(int)(f2i(GameTime64) / 60 % 60), (int)(f2i(GameTime64) % 60));
 	else
-		sprintf(time_str, "%i:%02i:%02i", (int)(f2i(GameTime64) / 3600), (int)(f2i(GameTime64) / 60 % 60), (int)(f2i(GameTime64) % 60));
+		snprintf(time_str, sizeof(time_str) / sizeof(time_str[0]), "%i:%02i:%02i",
+			(int)(f2i(GameTime64) / 3600), (int)(f2i(GameTime64) / 60 % 60), (int)(f2i(GameTime64) % 60));
 
 	gr_set_curfont(MEDIUM3_FONT);
 	gr_get_string_size(time_str, &sw, &sh, &saw);
@@ -2796,7 +2798,8 @@ void observer_show_time() {
 		int w = sw;
 		int h = sh;
 
-		sprintf(decimal_str, ".%02i", (int)(f2i(GameTime64 * 100) % 100));
+		snprintf(decimal_str, sizeof(decimal_str) / sizeof(decimal_str[0]), ".%02i",
+			(int)(f2i(GameTime64 * 100) % 100));
 		while ((t = strchr(decimal_str, '1')) != NULL)
 			* t = '\x84';	//convert to wide '1'
 
@@ -2872,7 +2875,7 @@ int observer_draw_player_card(int pnum, int color, int x, int y) {
 		y += sh + 3;
 	}
 	else {
-		sprintf(score, "%d", Players[pnum].net_kills_total);
+		snprintf(score, sizeof(score) / sizeof(score[0]), "%d", Players[pnum].net_kills_total);
 
 		gr_set_curfont(MEDIUM1_FONT);
 
@@ -2890,7 +2893,8 @@ int observer_draw_player_card(int pnum, int color, int x, int y) {
 			// Shields
 			char shields[7];
 
-			sprintf(shields, "%0.1f%s", f2db(Players[pnum].shields), Players[pnum].shields_certain ? "" : "?");
+			snprintf(shields, sizeof(shields) / sizeof(shields[0]), "%0.1f%s",
+				f2db(Players[pnum].shields), Players[pnum].shields_certain ? "" : "?");
 
 			gr_set_fontcolor(color, -1);
 
@@ -2988,31 +2992,32 @@ int observer_draw_player_card(int pnum, int color, int x, int y) {
 			char primary[8];
 			switch (Players[pnum].primary_weapon) {
 			case 0:
-				sprintf(primary, "%s %i", (Players[pnum].flags & PLAYER_FLAGS_QUAD_LASERS) ? "QUAD" : "LASER", Players[pnum].laser_level + 1);
+				snprintf(primary, sizeof(primary) / sizeof(primary[0]), "%s %i",
+					(Players[pnum].flags & PLAYER_FLAGS_QUAD_LASERS) ? "QUAD" : "LASER", Players[pnum].laser_level + 1);
 				break;
 			case 1:
-				sprintf(primary, "VUL");
+				snprintf(primary, sizeof(primary) / sizeof(primary[0]), "VUL");
 				break;
 			case 2:
-				sprintf(primary, "SPREAD");
+				snprintf(primary, sizeof(primary) / sizeof(primary[0]), "SPREAD");
 				break;
 			case 3:
-				sprintf(primary, "PLASMA");
+				snprintf(primary, sizeof(primary) / sizeof(primary[0]), "PLASMA");
 				break;
 			case 4:
-				sprintf(primary, "FUSION");
+				snprintf(primary, sizeof(primary) / sizeof(primary[0]), "FUSION");
 				break;
 			case 6:
-				sprintf(primary, "GAU");
+				snprintf(primary, sizeof(primary) / sizeof(primary[0]), "GAU");
 				break;
 			case 7:
-				sprintf(primary, "HELIX");
+				snprintf(primary, sizeof(primary) / sizeof(primary[0]), "HELIX");
 				break;
 			case 8:
-				sprintf(primary, "PHOENIX");
+				snprintf(primary, sizeof(primary) / sizeof(primary[0]), "PHOENIX");
 				break;
 			case 9:
-				sprintf(primary, "OMEGA");
+				snprintf(primary, sizeof(primary) / sizeof(primary[0]), "OMEGA");
 				break;
 			}
 
@@ -3032,7 +3037,7 @@ int observer_draw_player_card(int pnum, int color, int x, int y) {
 			// Energy for everything else
 			else {
 				gr_set_fontcolor(BM_XRGB(25, 18, 6), -1);
-				sprintf(primary_ammo, "%i", (int)energy);
+				snprintf(primary_ammo, sizeof(primary_ammo) / sizeof(primary_ammo[0]), "%i", (int)energy);
 			}
 
 			gr_get_string_size(primary_ammo, &sw, &sh, &saw);
@@ -3046,34 +3051,34 @@ int observer_draw_player_card(int pnum, int color, int x, int y) {
 			char secondary[7];
 			switch (Players[pnum].secondary_weapon) {
 			case 0:
-				sprintf(secondary, "CONC");
+				snprintf(secondary, sizeof(secondary) / sizeof(secondary[0]), "CONC");
 				break;
 			case 1:
-				sprintf(secondary, "HOMING");
+				snprintf(secondary, sizeof(secondary) / sizeof(secondary[0]), "HOMING");
 				break;
 			case 2:
-				sprintf(secondary, "PROX");
+				snprintf(secondary, sizeof(secondary) / sizeof(secondary[0]), "PROX");
 				break;
 			case 3:
-				sprintf(secondary, "SMART");
+				snprintf(secondary, sizeof(secondary) / sizeof(secondary[0]), "SMART");
 				break;
 			case 4:
-				sprintf(secondary, "MEGA");
+				snprintf(secondary, sizeof(secondary) / sizeof(secondary[0]), "MEGA");
 				break;
 			case 5:
-				sprintf(secondary, "FLASH");
+				snprintf(secondary, sizeof(secondary) / sizeof(secondary[0]), "FLASH");
 				break;
 			case 6:
-				sprintf(secondary, "GUIDED");
+				snprintf(secondary, sizeof(secondary) / sizeof(secondary[0]), "GUIDED");
 				break;
 			case 7:
-				sprintf(secondary, "SMINE");
+				snprintf(secondary, sizeof(secondary) / sizeof(secondary[0]), "SMINE");
 				break;
 			case 8:
-				sprintf(secondary, "MERC");
+				snprintf(secondary, sizeof(secondary) / sizeof(secondary[0]), "MERC");
 				break;
 			case 9:
-				sprintf(secondary, "SHAKER");
+				snprintf(secondary, sizeof(secondary) / sizeof(secondary[0]), "SHAKER");
 				break;
 			}
 
@@ -3084,7 +3089,8 @@ int observer_draw_player_card(int pnum, int color, int x, int y) {
 
 			// Secondary ammo
 			char secondary_ammo[3];
-			sprintf(secondary_ammo, "%i", Players[pnum].secondary_ammo[Players[pnum].secondary_weapon]);
+			snprintf(secondary_ammo, sizeof(secondary_ammo) / sizeof(secondary_ammo[0]), "%i",
+				Players[pnum].secondary_ammo[Players[pnum].secondary_weapon]);
 
 			gr_get_string_size(secondary_ammo, &sw, &sh, &saw);
 			gr_printf(x + OBS_PLAYER_CARD_WIDTH - 1 - sw, y, secondary_ammo);
@@ -3119,8 +3125,7 @@ int observer_draw_player_card_in_slot(int pnum, int slot_num, int team_mode, int
 	int color;
 	if (Players[pnum].connected != CONNECT_PLAYING) {
 		color = BM_XRGB(12, 12, 12);
-	}
-	else {
+	} else {
 		int color_for_player = get_color_for_player(pnum, 0);
 		color = BM_XRGB(selected_player_rgb[color_for_player].r, selected_player_rgb[color_for_player].g, selected_player_rgb[color_for_player].b);
 	}
@@ -3130,17 +3135,13 @@ int observer_draw_player_card_in_slot(int pnum, int slot_num, int team_mode, int
 	if (grd_curcanv->cv_bitmap.bm_w < 2 * OBS_PLAYER_CARD_WIDTH_PADDED + OBS_TIME_WIDTH) {
 		num_columns = 2;
 		draw_below_time_text = 1;
-	}
-	else if (grd_curcanv->cv_bitmap.bm_w < 4 * OBS_PLAYER_CARD_WIDTH_PADDED + OBS_TIME_WIDTH) {
+	} else if (grd_curcanv->cv_bitmap.bm_w < 4 * OBS_PLAYER_CARD_WIDTH_PADDED + OBS_TIME_WIDTH) {
 		num_columns = 2;
-	}
-	else if (grd_curcanv->cv_bitmap.bm_w < 6 * OBS_PLAYER_CARD_WIDTH_PADDED + OBS_TIME_WIDTH) {
+	} else if (grd_curcanv->cv_bitmap.bm_w < 6 * OBS_PLAYER_CARD_WIDTH_PADDED + OBS_TIME_WIDTH) {
 		num_columns = 4;
-	}
-	else if (grd_curcanv->cv_bitmap.bm_w < 8 * OBS_PLAYER_CARD_WIDTH_PADDED + OBS_TIME_WIDTH) {
+	} else if (grd_curcanv->cv_bitmap.bm_w < 8 * OBS_PLAYER_CARD_WIDTH_PADDED + OBS_TIME_WIDTH) {
 		num_columns = 6;
-	}
-	else {
+	} else {
 		num_columns = 8;
 	}
 	int ideal_num_columns = team_mode ? (num_drawn_players * 2) : (num_drawn_players + 1) & ~1;
@@ -3148,15 +3149,12 @@ int observer_draw_player_card_in_slot(int pnum, int slot_num, int team_mode, int
 		num_columns = ideal_num_columns;
 
 	int column_num, row_num;
-	if (team_mode)
-	{
+	if (team_mode) {
 		column_num = (abs(slot_num) - 1) % (num_columns / 2);
 		if (slot_num > 0)
 			column_num += num_columns / 2;
 		row_num = (abs(slot_num) - 1) / (num_columns / 2);
-	}
-	else
-	{
+	} else {
 		column_num = slot_num % num_columns;
 		row_num = slot_num / num_columns;
 	}
@@ -3164,10 +3162,13 @@ int observer_draw_player_card_in_slot(int pnum, int slot_num, int team_mode, int
 	int x = (grd_curcanv->cv_bitmap.bm_w - num_columns * OBS_PLAYER_CARD_WIDTH_PADDED) / 2
 		+ OBS_PLAYER_CARD_WIDTH_PADDED * column_num + OBS_PLAYER_CARD_PADDING;
 	int y = obs_player_card_height * row_num;
-	if (draw_below_time_text)
-		y += 53;
-	else
+	if (draw_below_time_text) {
+		// Temporarily switch to time font for measurement
+		gr_set_curfont(MEDIUM3_FONT);
+		y += LINE_SPACING;
+	} else {
 		x += OBS_TIME_WIDTH * (2 * column_num / num_columns) - (OBS_TIME_WIDTH / 2);
+	}
 
 	obs_player_card_height = observer_draw_player_card(pnum, color, x, y);
 
@@ -3189,8 +3190,7 @@ int observer_show_player_cards() {
 		int team_position_blue = 0;
 		int team_position_red = 0;
 
-		for (int i = 0; i < n_players; i++)
-		{
+		for (int i = 0; i < n_players; i++) {
 			int pnum = player_list[i];
 
 			if (Netgame.host_is_obs && pnum == 0)
@@ -3204,8 +3204,7 @@ int observer_show_player_cards() {
 			if (card_max_y > player_cards_max_y)
 				player_cards_max_y = card_max_y;
 		}
-	}
-	else {
+	} else {
 		int pnum;
 		int drawn_players = n_players - (Netgame.host_is_obs ? 1 : 0);
 		bool found_host_as_obs = 0;
@@ -3420,11 +3419,11 @@ void observer_maybe_show_kill_graph() {
 			gridminy = grd_curcanv->cv_bitmap.bm_h - 10 - FSPACY(6);
 			gridmaxy = grd_curcanv->cv_bitmap.bm_h - 200;
 
-			sprintf(score, "%i", minscore);
+			snprintf(score, sizeof(score) / sizeof(score[0]), "%i", minscore);
 			gr_get_string_size(score, &sw, &sh, &aw);
 			gridminx = (grd_curcanv->cv_bitmap.bm_w - 1000) / 2 + 5 + sw;
 
-			sprintf(score, "%i", maxscore);
+			snprintf(score, sizeof(score) / sizeof(score[0]), "%i", maxscore);
 			gr_get_string_size(score, &sw, &sh, &aw);
 			gridminx2 = (grd_curcanv->cv_bitmap.bm_w - 1000) / 2 + 5 + sw;
 
@@ -3436,7 +3435,7 @@ void observer_maybe_show_kill_graph() {
 
 			for (int i = trunc((float)minscore / (float)scorescale); i <= maxscore; i += scorescale) {
 				y = gridminy - (int)((float)(gridminy - gridmaxy) * (((float)(i - minscore)) / (float)(maxscore - minscore)));
-				sprintf(score, "%i", i);
+				snprintf(score, sizeof(score) / sizeof(score[0]), "%i", i);
 				gr_get_string_size(score, &sw, &sh, &aw);
 				gr_set_fontcolor(BM_XRGB(31, 31, 31), -1);
 				gr_printf(gridminx - sw, y - sh / 2, "%s", score);
@@ -3447,7 +3446,7 @@ void observer_maybe_show_kill_graph() {
 			for (int i = 0; i2f(i) < GameTime64; i += timescale * 60) {
 				x = gridminx + (int)((float)(gridmaxx - gridminx) * (((float)i2f(i)) / (float)(GameTime64)));
 				if (i > 0) {
-					sprintf(time, "%i", i / 60);
+					snprintf(time, sizeof(time) / sizeof(time[0]), "%i", i / 60);
 					gr_get_string_size(time, &sw, &sh, &aw);
 					gr_set_fontcolor(BM_XRGB(31, 31, 31), -1);
 					gr_printf(x - sw / 2, gridminy + 1, "%s", time);
@@ -3462,8 +3461,7 @@ void observer_maybe_show_kill_graph() {
 					if (Game_mode & GM_TEAM) {
 						color = get_color_for_team(pnum, 0);
 						gr_setcolor(BM_XRGB(selected_player_rgb[color].r, selected_player_rgb[color].g, selected_player_rgb[color].b));
-					}
-					else {
+					} else {
 						color = get_color_for_player(pnum, 0);
 						gr_setcolor(BM_XRGB(selected_player_rgb[color].r, selected_player_rgb[color].g, selected_player_rgb[color].b));
 					}
@@ -3545,18 +3543,20 @@ void observer_maybe_show_kill_graph() {
 					while (j < 3 && ddt != NULL) {
 						switch (ddt->source_id) {
 							case SHIP_EXPLOSION_DAMAGE:
-								sprintf(reason, "Explosion");
+								snprintf(reason, sizeof(reason) / sizeof(reason[0]), "Explosion");
 								break;
 							case SHIP_COLLISION_DAMAGE:
-								sprintf(reason, "Ramming");
+								snprintf(reason, sizeof(reason) / sizeof(reason[0]), "Ramming");
 								break;
 							default:
-								sprintf(reason, "%s", weapon_id_to_name(ddt->source_id));
+								snprintf(reason, sizeof(reason) / sizeof(reason[0]), "%s",
+									weapon_id_to_name(ddt->source_id));
 								break;
 						}
 
 						// Center each column
-						sprintf(damage_info_text, "%s: %0.1f", reason, f2fl(ddt->total_damage));
+						snprintf(damage_info_text, sizeof(damage_info_text) / sizeof(damage_info_text[0]), "%s: %0.1f",
+							reason, f2fl(ddt->total_damage));
 						gr_get_string_size(damage_info_text, &sw, &sh, &aw);
 						gr_string(x - (sw / 2), this_y, damage_info_text);
 
@@ -3566,7 +3566,7 @@ void observer_maybe_show_kill_graph() {
 						ddt = ddt->next;
 					}
 				} else {
-					sprintf(damage_info_text, "No Damage");
+					snprintf(damage_info_text, sizeof(damage_info_text) / sizeof(damage_info_text[0]), "No Damage");
 					gr_get_string_size(damage_info_text, &sw, &sh, &aw);
 					gr_string(x - (sw / 2), this_y, damage_info_text);
 				}
@@ -3606,29 +3606,29 @@ void observer_maybe_show_kill_graph() {
 
 					switch (ddt->source_id) {
 						case SHIP_EXPLOSION_DAMAGE:
-							sprintf(reason, "Explosion");
+							snprintf(reason, sizeof(reason) / sizeof(reason[0]), "Explosion");
 							break;
 						case SHIP_COLLISION_DAMAGE:
-							sprintf(reason, "Ramming");
+							snprintf(reason, sizeof(reason) / sizeof(reason[0]), "Ramming");
 							break;
 						default:
-							sprintf(reason, "%s", weapon_id_to_name(ddt->source_id));
+							snprintf(reason, sizeof(reason) / sizeof(reason[0]), "%s",
+								weapon_id_to_name(ddt->source_id));
 							break;
 					}
 
-					sprintf(damage_info_text, "%s's %s: %0.1f", Players[pnum].callsign, reason, f2fl(ddt->total_damage));
+					snprintf(damage_info_text, sizeof(damage_info_text) / sizeof(damage_info_text[0]), "%s's %s: %0.1f",
+						Players[pnum].callsign, reason, f2fl(ddt->total_damage));
 				} else {
-					sprintf(damage_info_text, "%s: No Damage", Players[pnum].callsign);
+					snprintf(damage_info_text, sizeof(damage_info_text) / sizeof(damage_info_text[0]), "%s: No Damage",
+						Players[pnum].callsign);
 				}
 
-				if (column_num == 0)
-				{
+				if (column_num == 0) {
 					// First column is right-aligned
 					gr_get_string_size(damage_info_text, &sw, &sh, &aw);
 					x = (GWIDTH / 2) - FSPACX(5) - sw;
-				}
-				else
-				{
+				} else {
 					// Second column is left-aligned
 					x = (GWIDTH / 2) + FSPACX(5);
 				}
@@ -3738,40 +3738,40 @@ int observer_maybe_show_streaks(int startY) {
 		if (((is_anarchy || is_team_anarchy) && Kill_streak[pnum] >= 3) || (is_bounty && pnum == Bounty_target)) {
 			status.type = GST_KILL_STREAK;
 			if (is_bounty) {
-				sprintf(status.text, "Bounty Kill Streak: %i", Kill_streak[pnum]);
-			}
-			else {
-				sprintf(status.text, "Kill Streak: %i", Kill_streak[pnum]);
+				snprintf(status.text, sizeof(status.text) / sizeof(status.text[0]), "Bounty Kill Streak: %i",
+					Kill_streak[pnum]);
+			} else {
+				snprintf(status.text, sizeof(status.text) / sizeof(status.text[0]), "Kill Streak: %i",
+					Kill_streak[pnum]);
 			}
 			add_player_status(pnum, status);
 			remove_player_status(pnum, GST_LAST_KILL);
 			remove_player_status(pnum, GST_LAST_DEATH);
-		}
-		else if ((is_anarchy || is_team_anarchy) && Last_kill[pnum] != NULL && ((diff = GameTime64 - Last_kill[pnum]->timestamp) >= i2f(60))) {
+		} else if ((is_anarchy || is_team_anarchy) && Last_kill[pnum] != NULL && ((diff = GameTime64 - Last_kill[pnum]->timestamp) >= i2f(60))) {
 			status.type = GST_LAST_KILL;
 			if (diff >= i2f(3600)) {
-				sprintf(status.text, "Last Kill: %i:%02i:%02i", (int)(diff / i2f(3600)), (int)(diff / i2f(60)) % 60, (int)(diff / i2f(1)) % 60);
-			}
-			else {
-				sprintf(status.text, "Last Kill: %02i:%02i", (int)(diff / i2f(60)) % 60, (int)(diff / i2f(1)) % 60);
+				snprintf(status.text, sizeof(status.text) / sizeof(status.text[0]), "Last Kill: %i:%02i:%02i",
+					(int)(diff / i2f(3600)), (int)(diff / i2f(60)) % 60, (int)(diff / i2f(1)) % 60);
+			} else {
+				snprintf(status.text, sizeof(status.text) / sizeof(status.text[0]), "Last Kill: %02i:%02i",
+					(int)(diff / i2f(60)) % 60, (int)(diff / i2f(1)) % 60);
 			}
 			add_player_status(pnum, status);
 			remove_player_status(pnum, GST_KILL_STREAK);
 			remove_player_status(pnum, GST_LAST_DEATH);
-		}
-		else if (n_players > 2 + (Netgame.host_is_obs ? 1 : 0) && Last_death[pnum] != NULL && ((diff = GameTime64 - Last_death[pnum]->timestamp) >= i2f(60))) {
+		} else if (n_players > 2 + (Netgame.host_is_obs ? 1 : 0) && Last_death[pnum] != NULL && ((diff = GameTime64 - Last_death[pnum]->timestamp) >= i2f(60))) {
 			status.type = GST_LAST_DEATH;
 			if (diff >= i2f(3600)) {
-				sprintf(status.text, "Last Death: %i:%02i:%02i", (int)(diff / i2f(3600)), (int)(diff / i2f(60)) % 60, (int)(diff / i2f(1)) % 60);
-			}
-			else {
-				sprintf(status.text, "Last Death: %02i:%02i", (int)(diff / i2f(60)) % 60, (int)(diff / i2f(1)) % 60);
+				snprintf(status.text, sizeof(status.text) / sizeof(status.text[0]), "Last Death: %i:%02i:%02i",
+					(int)(diff / i2f(3600)), (int)(diff / i2f(60)) % 60, (int)(diff / i2f(1)) % 60);
+			} else {
+				snprintf(status.text, sizeof(status.text) / sizeof(status.text[0]), "Last Death: %02i:%02i",
+					(int)(diff / i2f(60)) % 60, (int)(diff / i2f(1)) % 60);
 			}
 			add_player_status(pnum, status);
 			remove_player_status(pnum, GST_KILL_STREAK);
 			remove_player_status(pnum, GST_LAST_KILL);
-		}
-		else {
+		} else {
 			remove_player_status(pnum, GST_KILL_STREAK);
 			remove_player_status(pnum, GST_LAST_KILL);
 			remove_player_status(pnum, GST_LAST_DEATH);
@@ -3805,16 +3805,13 @@ int observer_maybe_show_streaks(int startY) {
 						// Both players have a previous event, figure out whose is later.
 						if (ev->prev->timestamp > opp_ev->prev->timestamp) {
 							ev = ev->prev;
-						}
-						else {
+						} else {
 							opp_ev = opp_ev->prev;
 						}
-					}
-					else if (ev->prev == NULL) {
+					} else if (ev->prev == NULL) {
 						// Only the opponent has a previous event.
 						opp_ev = opp_ev->prev;
-					}
-					else if (opp_ev->prev == NULL) {
+					} else if (opp_ev->prev == NULL) {
 						// Only the player has a previous event.
 						ev = ev->prev;
 					}
@@ -3837,18 +3834,19 @@ int observer_maybe_show_streaks(int startY) {
 
 					status.type = GST_RUN;
 					if (diff >= i2f(3600)) {
-						sprintf(status.text, "Run: %i-%i in %i:%02i:%02i", initial_score - last_ev->score, initial_opp_score - last_opp_ev->score, (int)(diff / i2f(3600)), (int)(diff / i2f(60)) % 60, (int)(diff / i2f(1)) % 60);
-					}
-					else {
-						sprintf(status.text, "Run: %i-%i in %02i:%02i", initial_score - last_ev->score, initial_opp_score - last_opp_ev->score, (int)(diff / i2f(60)) % 60, (int)(diff / i2f(1)) % 60);
+						snprintf(status.text, sizeof(status.text) / sizeof(status.text[0]), "Run: %i-%i in %i:%02i:%02i",
+							initial_score - last_ev->score, initial_opp_score - last_opp_ev->score,
+							(int)(diff / i2f(3600)), (int)(diff / i2f(60)) % 60, (int)(diff / i2f(1)) % 60);
+					} else {
+						snprintf(status.text, sizeof(status.text) / sizeof(status.text[0]), "Run: %i-%i in %02i:%02i",
+							initial_score - last_ev->score, initial_opp_score - last_opp_ev->score,
+							(int)(diff / i2f(60)) % 60, (int)(diff / i2f(1)) % 60);
 					}
 					add_player_status(pnum, status);
-				}
-				else {
+				} else {
 					remove_player_status(pnum, GST_RUN);
 				}
-			}
-			else {
+			} else {
 				remove_player_status(pnum, GST_RUN);
 			}
 		}
@@ -3950,7 +3948,8 @@ void observer_maybe_show_death_log(int y) {
 	gr_set_curfont(GAME_FONT);
 
 	while (kle != NULL && GameTime64 - kle->timestamp < i2f(5)) {
-		sprintf(killed, "%s", Players[kle->killed_id].callsign);
+		snprintf(killed, sizeof(killed) / sizeof(killed[0]), "%s",
+			Players[kle->killed_id].callsign);
 
 		color = get_color_for_player(kle->killed_id, 0);
 		killed_color = BM_XRGB(selected_player_rgb[color].r, selected_player_rgb[color].g, selected_player_rgb[color].b);
@@ -3958,21 +3957,21 @@ void observer_maybe_show_death_log(int y) {
 		switch (kle->killer_type) {
 		case OBJ_WALL:
 			// You can't die to a wall, but you can die to lava which is considered a wall.
-			sprintf(killer, "Lava");
+			snprintf(killer, sizeof(killer) / sizeof(killer[0]), "Lava");
 			killer_color = BM_XRGB(12, 12, 12);
 			reason[0] = '\0';
 			break;
 		case OBJ_ROBOT:
-			sprintf(killer, "Robot");
+			snprintf(killer, sizeof(killer) / sizeof(killer[0]), "Robot");
 			killer_color = BM_XRGB(12, 12, 12);
 			reason[0] = '\0';
 			break;
 		case OBJ_PLAYER:
 			if (kle->killer_id == kle->killed_id) {
 				killer[0] = '\0';
-			}
-			else {
-				sprintf(killer, "%s", Players[kle->killer_id].callsign);
+			} else {
+				snprintf(killer, sizeof(killer) / sizeof(killer[0]), "%s",
+					Players[kle->killer_id].callsign);
 				color = get_color_for_player(kle->killer_id, 0);
 				killer_color = BM_XRGB(selected_player_rgb[color].r, selected_player_rgb[color].g, selected_player_rgb[color].b);
 			}
@@ -3981,25 +3980,25 @@ void observer_maybe_show_death_log(int y) {
 			case DAMAGE_WEAPON:
 			case DAMAGE_BLAST:
 				if (kle->source_id == SHIP_EXPLOSION_DAMAGE) {
-					sprintf(reason, "Explosion");
-				}
-				else {
-					sprintf(reason, "%s", weapon_id_to_name(kle->source_id));
+					snprintf(reason, sizeof(reason) / sizeof(reason[0]), "Explosion");
+				} else {
+					snprintf(reason, sizeof(reason) / sizeof(reason[0]), "%s",
+						weapon_id_to_name(kle->source_id));
 				}
 				break;
 			case DAMAGE_COLLISION:
-				sprintf(reason, "Ramming");
+				snprintf(reason, sizeof(reason) / sizeof(reason[0]), "Ramming");
 				break;
 			case DAMAGE_LAVA:
-				sprintf(reason, "Lava");
+				snprintf(reason, sizeof(reason) / sizeof(reason[0]), "Lava");
 				break;
 			case DAMAGE_OVERCHARGE:
-				sprintf(reason, "Overcharge");
+				snprintf(reason, sizeof(reason) / sizeof(reason[0]), "Overcharge");
 				break;
 			}
 			break;
 		case OBJ_CNTRLCEN:
-			sprintf(killer, "Reactor");
+			snprintf(killer, sizeof(killer) / sizeof(killer[0]), "Reactor");
 			killer_color = BM_XRGB(12, 12, 12);
 			reason[0] = '\0';
 			break;
@@ -4061,7 +4060,8 @@ void observer_maybe_show_death_log(int y) {
 			color = get_color_for_player(kle->killed_id, 0);
 			gr_set_fontcolor(BM_XRGB(selected_player_rgb[color].r, selected_player_rgb[color].g, selected_player_rgb[color].b), -1);
 
-			sprintf(damage_for, "Top damage for %s:", Players[kle->killed_id].callsign);
+			snprintf(damage_for, sizeof(damage_for) / sizeof(damage_for[0]), "Top damage for %s:",
+				Players[kle->killed_id].callsign);
 
 			x = grd_curcanv->cv_bitmap.bm_w - 5;
 			gr_get_string_size(damage_for, &sw, &sh, &aw);
@@ -4076,55 +4076,56 @@ void observer_maybe_show_death_log(int y) {
 				switch (dtt->killer_type) {
 				case OBJ_WALL:
 					if (dtt->damage_type == DAMAGE_LAVA) {
-						sprintf(killer, "Lava");
-					}
-					else {
-						sprintf(killer, "Wall");
+						snprintf(killer, sizeof(killer) / sizeof(killer[0]), "Lava");
+					} else {
+						snprintf(killer, sizeof(killer) / sizeof(killer[0]), "Wall");
 					}
 					reason[0] = '\0';
 					break;
 				case OBJ_ROBOT:
-					sprintf(killer, "Robot");
+					snprintf(killer, sizeof(killer) / sizeof(killer[0]), "Robot");
 					reason[0] = '\0';
 					break;
 				case OBJ_PLAYER:
-					sprintf(killer, "%s", Players[dtt->killer_id].callsign);
+					snprintf(killer, sizeof(killer) / sizeof(killer[0]), "%s",
+						Players[dtt->killer_id].callsign);
 
 					switch (dtt->damage_type) {
 					case DAMAGE_WEAPON:
 					case DAMAGE_BLAST:
 						if (dtt->source_id == SHIP_EXPLOSION_DAMAGE) {
-							sprintf(reason, "Explosion");
-						}
-						else {
-							sprintf(reason, "%s", weapon_id_to_name(dtt->source_id));
+							snprintf(reason, sizeof(reason) / sizeof(reason[0]), "Explosion");
+						} else {
+							snprintf(reason, sizeof(reason) / sizeof(reason[0]), "%s",
+								weapon_id_to_name(dtt->source_id));
 						}
 						break;
 					case DAMAGE_COLLISION:
-						sprintf(reason, "Ramming");
+						snprintf(reason, sizeof(reason) / sizeof(reason[0]), "Ramming");
 						break;
 					case DAMAGE_LAVA:
-						sprintf(reason, "Lava");
+						snprintf(reason, sizeof(reason) / sizeof(reason[0]), "Lava");
 						break;
 					case DAMAGE_OVERCHARGE:
-						sprintf(reason, "Overcharge");
+						snprintf(reason, sizeof(reason) / sizeof(reason[0]), "Overcharge");
 						break;
 					}
 					break;
 				case OBJ_CNTRLCEN:
-					sprintf(killer, "Reactor");
+					snprintf(killer, sizeof(killer) / sizeof(killer[0]), "Reactor");
 					reason[0] = '\0';
 					break;
 				}
 
 				if (killer[0] == '\0') {
-					sprintf(damage_for, "%s %0.1f", reason, f2fl(dtt->total_damage));
-				}
-				else if (reason[0] == '\0') {
-					sprintf(damage_for, "%s %0.1f", killer, f2fl(dtt->total_damage));
-				}
-				else {
-					sprintf(damage_for, "%s's %s %0.1f", killer, reason, f2fl(dtt->total_damage));
+					snprintf(damage_for, sizeof(damage_for) / sizeof(damage_for[0]), "%s %0.1f",
+						reason, f2fl(dtt->total_damage));
+				} else if (reason[0] == '\0') {
+					snprintf(damage_for, sizeof(damage_for) / sizeof(damage_for[0]), "%s %0.1f",
+						killer, f2fl(dtt->total_damage));
+				} else {
+					snprintf(damage_for, sizeof(damage_for) / sizeof(damage_for[0]), "%s's %s %0.1f",
+						killer, reason, f2fl(dtt->total_damage));
 				}
 
 				x = grd_curcanv->cv_bitmap.bm_w - 5;


### PR DESCRIPTION
This addresses some text overlap issues we've been seeing in observer mode. The worst affected section was the "top weapon" stats block that appears intermittently at the bottom of the screen; in this case the left text column often overflowed onto the right column. With this change, the text positioning for these elements now accounts for text size, which makes it work better at higher resolutions.

The "player cards" in observer mode still have layout problems at ultra-high resolutions (2K/4K). I am still working on this problem but may not have it fixed in time for 0.5, so I figured I should at least submit fixes for the other bugs, some of which were visible in 1080p or lower as well. I have copied some code over from D2 that was missing in D1, which improves the spacing of player cards somewhat and supports drawing them in team game modes.