### PR TITLE
Fix was_original_object with signed chars

### DIFF
--- a/d1/main/multi.c
+++ b/d1/main/multi.c
@@ -3976,7 +3976,7 @@ int is_dupable_secondary(int id) {
 
 int multi_received_objects = 0; 
 
-char original_object_types[MAX_OBJECTS];
+ubyte original_object_types[MAX_OBJECTS];
 void save_original_objects() {
 	for (int i=0; i<MAX_OBJECTS; i++) {
 		original_object_types[i] = Objects[i].type; 

--- a/d2/main/multi.c
+++ b/d2/main/multi.c
@@ -4322,7 +4322,7 @@ int is_dupable_secondary(int id) {
 
 int multi_received_objects = 0; 
 
-char original_object_types[MAX_OBJECTS];
+ubyte original_object_types[MAX_OBJECTS];
 void save_original_objects() {
 	for (int i=0; i<MAX_OBJECTS; i++) {
 		original_object_types[i] = Objects[i].type; 


### PR DESCRIPTION
If original_object_types is a char array, was_original_object compares a char to OBJ_NONE (255), which is always false with signed chars.