### PR TITLE
Remove version check for game list

### DIFF
--- a/d1/main/net_udp.c
+++ b/d1/main/net_udp.c
@@ -3115,9 +3115,6 @@ int net_udp_process_game_info(ubyte *data, int data_len, struct _sockaddr game_a
 		recv_game.program_iver[1] = GET_INTEL_SHORT(&(data[len]));			len += 2;
 		recv_game.program_iver[2] = GET_INTEL_SHORT(&(data[len]));			len += 2;
 		
-		if ((recv_game.program_iver[0] != DXX_VERSION_MAJORi) || (recv_game.program_iver[1] != DXX_VERSION_MINORi) || (recv_game.program_iver[2] != DXX_VERSION_MICROi))
-			return 0;
-
 		recv_game.GameID = GET_INTEL_INT(&(data[len]));					len += 4;
 		memcpy(&recv_game.game_name, &(data[len]), NETGAME_NAME_LEN+1);			len += (NETGAME_NAME_LEN+1);
 		memcpy(&recv_game.mission_title, &(data[len]), MISSION_NAME_LEN+1);		len += (MISSION_NAME_LEN+1);

--- a/d2/main/net_udp.c
+++ b/d2/main/net_udp.c
@@ -3133,9 +3133,6 @@ int net_udp_process_game_info(ubyte *data, int data_len, struct _sockaddr game_a
 		recv_game.program_iver[1] = GET_INTEL_SHORT(&(data[len]));			len += 2;
 		recv_game.program_iver[2] = GET_INTEL_SHORT(&(data[len]));			len += 2;
 		
-		if ((recv_game.program_iver[0] != DXX_VERSION_MAJORi) || (recv_game.program_iver[1] != DXX_VERSION_MINORi) || (recv_game.program_iver[2] != DXX_VERSION_MICROi))
-			return 0;
-
 		recv_game.GameID = GET_INTEL_INT(&(data[len]));					len += 4;
 		memcpy(&recv_game.game_name, &(data[len]), NETGAME_NAME_LEN+1);			len += (NETGAME_NAME_LEN+1);
 		memcpy(&recv_game.mission_title, &(data[len]), MISSION_NAME_LEN+1);		len += (MISSION_NAME_LEN+1);


### PR DESCRIPTION
A consequence of using the version number fields is that games from a different version don't show up in the game list. Restore the previous behaviour by removing the version check when adding a game to the list (the version is still checked when actually joining).