### PR TITLE
Fix observer crash if host left game

### DIFF
--- a/d1/main/inferno.c
+++ b/d1/main/inferno.c
@@ -459,6 +459,7 @@ int main(int argc, char *argv[])
 	newmenu_free_background();
 	free_mission();
 	PHYSFSX_removeArchiveContent();
+	reset_observatory_stats();
 
 	return(0);		//presumably successful exit
 }

--- a/d1/main/multi.c
+++ b/d1/main/multi.c
@@ -1518,8 +1518,6 @@ multi_leave_game(void)
 	}
 
 	plyr_save_stats();
-
-	reset_observatory_stats();
 }
 		
 void 

--- a/d1/main/multi.h
+++ b/d1/main/multi.h
@@ -668,4 +668,6 @@ extern kill_log_event* Kill_log;
 // Adds a damage stat for observatory UI.
 void add_observatory_damage_stat(int player_num, fix shields_delta, fix new_shields, fix old_shields, ubyte killer_type, ubyte killer_id, ubyte damage_type, ubyte source_id);
 
+void reset_observatory_stats();
+
 #endif /* _MULTI_H */

--- a/d2/main/inferno.c
+++ b/d2/main/inferno.c
@@ -494,6 +494,7 @@ int main(int argc, char *argv[])
 	newmenu_free_background();
 	free_mission();
 	PHYSFSX_removeArchiveContent();
+	reset_observatory_stats();
 
 	return(0);		//presumably successful exit
 }

--- a/d2/main/multi.c
+++ b/d2/main/multi.c
@@ -1556,8 +1556,6 @@ multi_leave_game(void)
 				break;
 		}
 	}
-
-	reset_observatory_stats();
 }
 
 void

--- a/d2/main/multi.h
+++ b/d2/main/multi.h
@@ -730,4 +730,6 @@ extern kill_log_event* Kill_log;
 // Adds a damage stat for observatory UI.
 void add_observatory_damage_stat(int player_num, fix shields_delta, fix new_shields, fix old_shields, ubyte killer_type, ubyte killer_id, ubyte damage_type, ubyte source_id);
 
+void reset_observatory_stats();
+
 #endif /* _MULTI_H */


### PR DESCRIPTION
Function reset_observatory_stats was called to soon, causing a crash in the observer gauges code.

Fixes: efcdd99 ("Free observatory stats memory after match")