### PR TITLE
Speed up build_segment_list

### DIFF
--- a/d1/main/render.c
+++ b/d1/main/render.c
@@ -1440,6 +1440,7 @@ void build_segment_list(int start_seg_num)
 	int	lcnt,scnt,ecnt;
 	int	l,c;
 	int	ch;
+	int	obs = is_observer();
 
 	memset(visited, 0, sizeof(visited[0])*(Highest_segment_index+1));
 	memset(render_pos, -1, sizeof(render_pos[0])*(Highest_segment_index+1));
@@ -1467,6 +1468,7 @@ void build_segment_list(int start_seg_num)
 	//build list
 
 	for (l=0;l<Render_depth;l++) {
+		int reprocess = 0;
 
 		//while (scnt < ecnt) {
 		for (scnt=0;scnt < ecnt;scnt++) {
@@ -1501,9 +1503,9 @@ void build_segment_list(int start_seg_num)
 
 				// Only add side if it doesn't block rendering of the child segment
 				// (in observer mode, add side as long as it has a child)
-				if ((wid & WID_RENDPAST_FLAG) || (is_observer() && (ch >= 0))) {
+				if ((wid & WID_RENDPAST_FLAG) || (obs && (ch >= 0))) {
 					// Skip sides that are behind the camera (except in observer mode)
-					if (!is_observer()) {
+					if (!obs) {
 						sbyte *sv = Side_to_verts[c];
 						ubyte codes_and=0xff;
 						int i;
@@ -1567,11 +1569,11 @@ void build_segment_list(int start_seg_num)
 
 					}
 
-					if (is_observer() || no_proj_flag || (!codes_and_3d && !codes_and_2d)) {	//maybe add this segment
+					if (obs || no_proj_flag || (!codes_and_3d && !codes_and_2d)) {	//maybe add this segment
 						int rp = render_pos[ch];
 						rect *new_w = &render_windows[lcnt];
 
-						if (is_observer() || no_proj_flag) *new_w = *check_w;
+						if (obs || no_proj_flag) *new_w = *check_w;
 						else {
 							new_w->left  = max(check_w->left,min_x);
 							new_w->right = min(check_w->right,max_x);
@@ -1595,6 +1597,7 @@ void build_segment_list(int start_seg_num)
 								Render_list[lcnt] = -1;
 								render_windows[rp] = *new_w;		//get updated window
 								processed[rp] = 0;		//force reprocess
+								reprocess = 1;
 							}
 							
 							goto no_add;
@@ -1612,6 +1615,9 @@ no_add:
 				}
 			}
 		}
+
+		if (lcnt == ecnt && !reprocess) // no changes
+			break;
 
 		scnt = ecnt;
 		ecnt = lcnt;


### PR DESCRIPTION
Stop processing if no new segments have been added and no entries were marked for reprocessing. Significantly reduces cpu load now that MAX_RENDER_SEGS is increased to 9000.
Also hoists is_observer() out of the loops (although that's probably unnecessary).

Fixes: 6caf5e5 ("Increase MAX_RENDER_SEGS so that observers can see"...)