### PR TITLE
Fix playing SP levels with <8 player positions

### DIFF
--- a/d1/main/gameseq.c
+++ b/d1/main/gameseq.c
@@ -211,22 +211,24 @@ gameseq_init_network_players()
 
 	NumNetPlayerPositions = k;
 
-	// Ensure we have 8 starting locations, even if there aren't 8 in the file.  This makes observer mode work in all levels.
-	for (; k < MAX_PLAYERS; k++) {
-		i = obj_allocate();
+	if (Game_mode & GM_MULTI) {
+		// Ensure we have 8 starting locations, even if there aren't 8 in the file.  This makes observer mode work in all levels.
+		for (; k < MAX_PLAYERS; k++) {
+			i = obj_allocate();
 
-		Objects[i].type=OBJ_PLAYER;
+			Objects[i].type = OBJ_PLAYER;
 
-		Player_init[k].pos = Objects[k % NumNetPlayerPositions].pos;
-		Player_init[k].orient = Objects[k % NumNetPlayerPositions].orient;
-		Player_init[k].segnum = Objects[k % NumNetPlayerPositions].segnum;
-		Players[k].objnum = i;
-		Objects[i].id = k;
+			Player_init[k].pos = Objects[k % NumNetPlayerPositions].pos;
+			Player_init[k].orient = Objects[k % NumNetPlayerPositions].orient;
+			Player_init[k].segnum = Objects[k % NumNetPlayerPositions].segnum;
+			Players[k].objnum = i;
+			Objects[i].id = k;
 
-		Objects[i].attached_obj = -1;
+			Objects[i].attached_obj = -1;
+		}
+
+		NumNetPlayerPositions = MAX_PLAYERS;
 	}
-
-	NumNetPlayerPositions = MAX_PLAYERS;
 }
 
 void gameseq_remove_unused_players()

--- a/d2/main/gameseq.c
+++ b/d2/main/gameseq.c
@@ -229,22 +229,24 @@ gameseq_init_network_players()
 	}
 	NumNetPlayerPositions = k;
 
-	// Ensure we have 8 starting locations, even if there aren't 8 in the file.  This makes observer mode work in all levels.
-	for (; k < MAX_PLAYERS; k++) {
-		i = obj_allocate();
+	if (Game_mode & GM_MULTI) {
+		// Ensure we have 8 starting locations, even if there aren't 8 in the file.  This makes observer mode work in all levels.
+		for (; k < MAX_PLAYERS; k++) {
+			i = obj_allocate();
 
-		Objects[i].type = OBJ_PLAYER;
+			Objects[i].type = OBJ_PLAYER;
 
-		Player_init[k].pos = Objects[k % NumNetPlayerPositions].pos;
-		Player_init[k].orient = Objects[k % NumNetPlayerPositions].orient;
-		Player_init[k].segnum = Objects[k % NumNetPlayerPositions].segnum;
-		Players[k].objnum = i;
-		Objects[i].id = k;
+			Player_init[k].pos = Objects[k % NumNetPlayerPositions].pos;
+			Player_init[k].orient = Objects[k % NumNetPlayerPositions].orient;
+			Player_init[k].segnum = Objects[k % NumNetPlayerPositions].segnum;
+			Players[k].objnum = i;
+			Objects[i].id = k;
 
-		Objects[i].attached_obj = -1;
+			Objects[i].attached_obj = -1;
+		}
+
+		NumNetPlayerPositions = MAX_PLAYERS;
 	}
-
-	NumNetPlayerPositions = MAX_PLAYERS;
 }
 
 void gameseq_remove_unused_players()


### PR DESCRIPTION
Observer fix for adding player positions breaks in SP, since the new positions are not linked correctly to the segment when obj_delete is called to remove all extra player positions.

Add check to only add the positions in MP.