### PR TITLE
Fix flat color in D2 g3_draw_morphing_model

### DIFF
--- a/d2/3d/interp.c
+++ b/d2/3d/interp.c
@@ -588,7 +588,7 @@ bool g3_draw_morphing_model(ubyte *p,grs_bitmap **model_bitmaps,vms_angvec *anim
 				int nv = w(p+2);
 				int i,ntris;
 
-				gr_setcolor(w(p+28));
+				gr_setcolor(gr_find_closest_color_15bpp(w(p + 28)));
 				
 				for (i=0;i<2;i++)
 					point_list[i] = Interp_point_list + wp(p+30)[i];


### PR DESCRIPTION
In D2 the color in polymodels is stored in a 15bpp palette independent format. It looks like the OP_FLATPOLY case in the Mac D1 g3_draw_morphing_model code was never adjusted properly for D2.

This caused an out of bounds read in g3_draw_poly.