### PR TITLE
Rework custom team color selection

### DIFF
--- a/d1/arch/ogl/ogl.c
+++ b/d1/arch/ogl/ogl.c
@@ -1790,7 +1790,7 @@ void ogl_loadpngmask(png_data *pdata, grs_bitmap *bm, int texfilt)
 void ogl_loadbmtexture_f(grs_bitmap *bm, int texfilt, int filter_blueship_wing)
 {
 	unsigned char *buf;
-	const char* bitmapname = NULL;
+	const char* bitmapname = piggy_game_bitmap_name(bm);
 
 	while (bm->bm_parent)
 		bm=bm->bm_parent;
@@ -1798,7 +1798,7 @@ void ogl_loadbmtexture_f(grs_bitmap *bm, int texfilt, int filter_blueship_wing)
 		return;
 	buf=bm->bm_data;
 #ifdef HAVE_LIBPNG
-	if (ogl_allow_png() && (bitmapname = piggy_game_bitmap_name(bm)))
+	if (ogl_allow_png() && bitmapname)
 	{
 		char filename[64];
 		png_data pdata;
@@ -1869,8 +1869,6 @@ void ogl_loadbmtexture_f(grs_bitmap *bm, int texfilt, int filter_blueship_wing)
 		buf=decodebuf;
 
 		if(Game_mode & GM_MULTI && Netgame.BlackAndWhitePyros) {
-			if (!bitmapname)
-				bitmapname = piggy_game_bitmap_name(bm);
 			char is_purple_tex1 = bitmapname && !strcmp(bitmapname, "ship6-4");
 			char is_purple_tex2 = bitmapname && !strcmp(bitmapname, "ship6-5");
 

--- a/d1/main/gamerend.c
+++ b/d1/main/gamerend.c
@@ -304,12 +304,12 @@ void show_netplayerinfo()
 		gr_printf(x,y,"team");
 		gr_printf(x+FSPACX(8)*8,y,"score");
 		y+=LINE_SPACING;
-		color = get_color_for_team(0, 0);
+		color = get_color_for_team(0);
 		gr_set_fontcolor(BM_XRGB(selected_player_rgb[color].r,selected_player_rgb[color].g,selected_player_rgb[color].b),-1 );
 		gr_printf(x,y,"%s:",Netgame.team_name[0]);
 		gr_printf(x+FSPACX(8)*8,y,"%i",team_kills[0]);
 		y+=LINE_SPACING;
-		color = get_color_for_team(1, 0);
+		color = get_color_for_team(1);
 		gr_set_fontcolor(BM_XRGB(selected_player_rgb[color].r,selected_player_rgb[color].g,selected_player_rgb[color].b),-1 );
 		gr_printf(x,y,"%s:",Netgame.team_name[1]);
 		gr_printf(x+FSPACX(8)*8,y,"%i",team_kills[1]);

--- a/d1/main/gauges.c
+++ b/d1/main/gauges.c
@@ -1602,20 +1602,19 @@ void draw_player_ship(int cloak_state,int x, int y)
 
 	grs_bitmap *bm = NULL;
 
+	int color;
 #ifdef NETWORK
 	if (Game_mode & GM_TEAM)
 	{
-		PIGGY_PAGE_IN(Gauges[GAUGE_SHIPS+get_team(pnum)]);
-		bm = &GameBitmaps[Gauges[GAUGE_SHIPS+get_team(pnum)].index];
+		color = get_color_for_team(get_team(pnum));
 	}
 	else
 #endif
 	{
-		int color = Netgame.players[pnum].color;
-
-		PIGGY_PAGE_IN(Gauges[GAUGE_SHIPS+color]);
-		bm = &GameBitmaps[Gauges[GAUGE_SHIPS+color].index];
+		color = Netgame.players[pnum].color;
 	}
+	PIGGY_PAGE_IN(Gauges[GAUGE_SHIPS+color]);
+	bm = &GameBitmaps[Gauges[GAUGE_SHIPS+color].index];
 
 	if (cloak_state)
 	{
@@ -2035,42 +2034,38 @@ extern int allowed_to_fire_laser(void);
 extern int allowed_to_fire_missile(void);
 
 // CED -- shipcolor fix
-const rgb player_rgb[] = {	//{0,0,0}, // black
-							//{4,4,12}, // indigo
-							{15,15,23},    // 0x7878B8 ---> blue
-							//{23, 23, 23}, // white
-							{27,0,0},      // 0xD80000 ---> red
-							{0,23,0},      // 0x00B800 ---> green
-							{30,11,31},    // 0xF058F8 ---> PINK
-							{31,16,0},     // 0xF88000 ---> orange
-							//{0,0,0}, // black
-							//{23, 23, 23}, // white
-							{24,17,6},     // 0xC08830 ---> light orange (PROBLEM)
-							{14,21,12},    // 0x70A860 ---> light green (PROBLEM)
-							{29,29,0}, };  // 0xE8E800 ---> YELLOW
+const rgb player_rgb[] = {
+	{15,15,23}, // 0x7878B8 (blue)
+	{27,0,0},   // 0xD80000 (red)
+	{0,23,0},   // 0x00B800 (green)
+	{30,11,31}, // 0xF058F8 (pink)
+	{31,16,0},  // 0xF88000 (orange)
+	{24,17,6},  // 0xC08830 (tan)
+	{14,21,12}, // 0x70A860 (mint)
+	{29,29,0},  // 0xE8E800 (yellow)
+};
 
 const rgb player_rgb_alt[] = {
-
-							{15,15,23},    // 0x7878B8 ---> blue
-							{27,0,0},      // 0xD80000 ---> red
-							{0,23,0},      // 0x00B800 ---> green
-							{30,11,31},    // 0xF058F8 ---> PINK
-							{31,16,0},     // 0xF88000 ---> orange
-							//{4,4,12}, 		// indigo
-							{12,4,20}, 		// purple
-							{23, 23, 23}, 	// white
-							{29,29,0}, };  // 0xE8E800 ---> YELLOW
+	{15,15,23}, // 0x7878B8 (blue)
+	{27,0,0},   // 0xD80000 (red)
+	{0,23,0},   // 0x00B800 (green)
+	{30,11,31}, // 0xF058F8 (pink)
+	{31,16,0},  // 0xF88000 (orange)
+	{16,4,24},  // 0x8020C0 (purple)
+	{23,23,23}, // 0xB8B8B8 (white)
+	{29,29,0},  // 0xE8E800 (yellow)
+};
 
 const rgb player_rgb_all_blue[] = {
-
-							{15,15,23},    // 0x7878B8 ---> blue
-							{15,15,23},
-							{15,15,23},
-							{15,15,23},
-							{15,15,23},
-							{15,15,23},
-							{15,15,23},
-							{15,15,23}, };
+	{15,15,23}, // 0x7878B8 (blue)
+	{15,15,23},
+	{15,15,23},
+	{15,15,23},
+	{15,15,23},
+	{15,15,23},
+	{15,15,23},
+	{15,15,23},
+};
 
 const rgb* selected_player_rgb;
 
@@ -2378,7 +2373,7 @@ void hud_show_kill_list()
 		if (Show_kill_list != 3 && Players[player_num].connected != CONNECT_PLAYING) {
 			gr_set_fontcolor(BM_XRGB(12, 12, 12), -1);
 		} else if (Game_mode & GM_TEAM) {
-			color = get_color_for_team(team_num, 0);
+			color = get_color_for_team(team_num);
 			gr_set_fontcolor(BM_XRGB(selected_player_rgb[color].r,selected_player_rgb[color].g,selected_player_rgb[color].b),-1 );
 		} else {
 			color = get_color_for_player(player_num, 0);
@@ -2401,7 +2396,7 @@ void hud_show_kill_list()
 
 		if (Show_kill_list == 3 || Players[player_num].connected == CONNECT_PLAYING) {
 			if (Game_mode & GM_TEAM) {
-				color = get_color_for_team(team_num, 1);
+				color = get_color_for_team(team_num);
 				gr_set_fontcolor(BM_XRGB(selected_player_rgb[color].r,selected_player_rgb[color].g,selected_player_rgb[color].b),-1 );
 			} else {
 				color = get_color_for_player(player_num, 1);
@@ -3165,7 +3160,7 @@ void observer_maybe_show_kill_graph() {
 
 				if ((ev = First_event[pnum]) != NULL) {
 					if (Game_mode & GM_TEAM) {
-						color = get_color_for_team(pnum, 0);
+						color = get_color_for_team(pnum);
 						gr_setcolor(BM_XRGB(selected_player_rgb[color].r,selected_player_rgb[color].g,selected_player_rgb[color].b));
 					} else {
 						color = get_color_for_player(pnum, 0);

--- a/d1/main/kmatrix.c
+++ b/d1/main/kmatrix.c
@@ -134,7 +134,7 @@ void kmatrix_draw_names(int *sorted)
 	for (j=0; j<N_players; j++)
 	{
 		if (Game_mode & GM_TEAM)
-			color = get_color_for_team(sorted[j], 0);
+			color = get_color_for_team(sorted[j]);
 		else
 			color = get_color_for_player(sorted[j], 0);//sorted[j];
 
@@ -213,7 +213,7 @@ void kmatrix_redraw(kmatrix_screen *km)
 		for (i=0; i<N_players; i++ )
 		{
 			if (Game_mode & GM_TEAM)
-				color = get_color_for_team(sorted[i], 0);
+				color = get_color_for_team(sorted[i]);
 			else
 				color = get_color_for_player(sorted[i], 0);//sorted[j];
 

--- a/d1/main/menu.c
+++ b/d1/main/menu.c
@@ -1934,46 +1934,87 @@ void do_sound_menu()
 
 int menu_misc_options_handler ( newmenu *menu, d_event *event, void *userdata );
 
-void print_ship_color(char* color_string, int color_value) {
+void get_color_name(char* color_name, int color_name_length, int color_value, int use_alternate_colors)
+{
+	switch (color_value) {
+		case 0:  snprintf(color_name, color_name_length, "%s", "Blue"); break;
+		case 1:  snprintf(color_name, color_name_length, "%s", "Red"); break;
+		case 2:  snprintf(color_name, color_name_length, "%s", "Green"); break;
+		case 3:  snprintf(color_name, color_name_length, "%s", "Pink"); break;
+		case 4:  snprintf(color_name, color_name_length, "%s", "Orange"); break;
+		case 5:
+			if (use_alternate_colors)
+				snprintf(color_name, color_name_length, "%s", "Purple");
+			else
+				snprintf(color_name, color_name_length, "%s", "Tan");
+			break;
+		case 6:
+			if (use_alternate_colors)
+				snprintf(color_name, color_name_length, "%s", "White");
+			else
+				snprintf(color_name, color_name_length, "%s", "Mint");
+			break;
+		case 7:  snprintf(color_name, color_name_length, "%s", "Yellow"); break;
+		default: snprintf(color_name, color_name_length, "%s", "???");
+	}
+}
+
+void print_ship_color(char* color_string, int color_string_length, int color_value)
+{
 	char color[10];
-	switch(color_value) {
-		case 0:  sprintf(color, "%s", "Blue"); break;
-		case 1:  sprintf(color, "%s", "Red"); break;
-		case 2:  sprintf(color, "%s", "Green"); break;
-		case 3:  sprintf(color, "%s", "Pink"); break;
-		case 4:  sprintf(color, "%s", "Orange"); break;
-		case 5:  sprintf(color, "%s", "Purple"); break;
-		case 6:  sprintf(color, "%s", "White"); break;
-		case 7:  sprintf(color, "%s", "Yellow"); break;
-		case 8:  sprintf(color, "%s", "None"); break;
-		default: sprintf(color, "%s", "???"); 
-	}
+	if (color_value == 8)
+		snprintf(color, SDL_arraysize(color), "%s", "Default");
+	else
+		get_color_name(color, SDL_arraysize(color), color_value, 1);
 
-	sprintf( color_string, "Wing Color: %s", color);
+	snprintf(color_string, color_string_length, "Wing Color: %s", color);
 }
 
-void print_missile_color(char* color_string, int color_value) {
+void print_missile_color(char* color_string, int color_string_length, int color_value)
+{
 	char color[11];
-	switch(color_value) {
-		case 0:  sprintf(color, "%s", "Blue"); break;
-		case 1:  sprintf(color, "%s", "Red"); break;
-		case 2:  sprintf(color, "%s", "Green"); break;
-		case 3:  sprintf(color, "%s", "Pink"); break;
-		case 4:  sprintf(color, "%s", "Orange"); break;
-		case 5:  sprintf(color, "%s", "Purple"); break;
-		case 6:  sprintf(color, "%s", "White"); break;
-		case 7:  sprintf(color, "%s", "Yellow"); break;
-		case 8:  sprintf(color, "%s", "Match Ship"); break;
-		default: sprintf(color, "%s", "???"); 
-	}
+	if (color_value == 8)
+		snprintf(color, SDL_arraysize(color), "%s", "Match Ship");
+	else
+		get_color_name(color, SDL_arraysize(color), color_value, 1);
 
-	sprintf( color_string, "Missiles/Guns: %s", color);
+	snprintf(color_string, color_string_length, "Missiles/Guns: %s", color);
 }
+
+void print_my_team_color(char* color_string, int color_string_length, int color_value)
+{
+	char color[10];
+	if (color_value == 8)
+		snprintf(color, SDL_arraysize(color), "%s", "Default");
+	else
+		get_color_name(color, SDL_arraysize(color), color_value, 1);
+
+	snprintf(color_string, color_string_length, "My Team: %s", color);
+}
+
+void print_other_team_color(char* color_string, int color_string_length, int color_value)
+{
+	char color[10];
+	if (color_value == 8)
+		snprintf(color, SDL_arraysize(color), "%s", "Default");
+	else
+		get_color_name(color, SDL_arraysize(color), color_value, 1);
+
+	snprintf(color_string, color_string_length, "Other Team: %s", color);
+}
+
+struct misc_menu_data {
+	char preferred_color[30];
+	char missile_color[30];
+	char my_team_color[30];
+	char other_team_color[30];
+};
 
 void do_misc_menu()
 {
-	newmenu_item m[23];
+	newmenu_item m[30];
 	int i = 0;
+	struct misc_menu_data misc_menu_data;
 
 	do {
 		ADD_CHECK(0, "Ship auto-leveling", PlayerCfg.AutoLeveling);
@@ -2015,26 +2056,64 @@ void do_misc_menu()
 		ADD_CHECK(17, "Ammo Warnings",PlayerCfg.VulcanAmmoWarnings);
 		ADD_CHECK(18, "Shield Warnings",PlayerCfg.ShieldWarnings);
 		ADD_CHECK(19, "Automatically Start Demos",PlayerCfg.AutoDemo);
-		
-		char preferred_color[30];
-		print_ship_color(preferred_color, PlayerCfg.ShipColor); 
-		m[20].type = NM_TYPE_SLIDER; 
-		m[20].value= PlayerCfg.ShipColor; 
-		m[20].text= preferred_color; 
-		m[20].min_value=0; 
-		m[20].max_value=8; 
 
-		char missile_color[30];
-		print_missile_color(missile_color, PlayerCfg.MissileColor); 
-		m[21].type = NM_TYPE_SLIDER; 
-		m[21].value= PlayerCfg.MissileColor; 
-		m[21].text = missile_color; 
-		m[21].min_value=0; 
-		m[21].max_value=8; 		
+		m[20].type = NM_TYPE_TEXT;
+		m[20].text = "";
 
-		ADD_CHECK(22, "Show Custom Ship Colors", PlayerCfg.ShowCustomColors);
+		m[21].type = NM_TYPE_TEXT;
+		m[21].text = "My Ship Colors:";
 
-		i = newmenu_do1( NULL, "Misc Options", sizeof(m)/sizeof(*m), m, menu_misc_options_handler, NULL, i );
+		print_ship_color(misc_menu_data.preferred_color, SDL_arraysize(misc_menu_data.preferred_color),
+			PlayerCfg.ShipColor);
+		m[22].type = NM_TYPE_SLIDER;
+		m[22].value = PlayerCfg.ShipColor;
+		m[22].text = misc_menu_data.preferred_color;
+		m[22].min_value = 0;
+		m[22].max_value = 8;
+
+		print_missile_color(misc_menu_data.missile_color, SDL_arraysize(misc_menu_data.missile_color),
+			PlayerCfg.MissileColor);
+		m[23].type = NM_TYPE_SLIDER;
+		m[23].value = PlayerCfg.MissileColor;
+		m[23].text = misc_menu_data.missile_color;
+		m[23].min_value = 0;
+		m[23].max_value = 8;
+
+		ADD_CHECK(24, "Show Custom Ship Colors", PlayerCfg.ShowCustomColors);
+
+		m[25].type = NM_TYPE_TEXT;
+		m[25].text = "";
+
+		m[26].type = NM_TYPE_TEXT;
+		m[26].text = "Team Colors:";
+
+		print_my_team_color(misc_menu_data.my_team_color, SDL_arraysize(misc_menu_data.my_team_color),
+			PlayerCfg.MyTeamColor);
+		m[27].type = NM_TYPE_SLIDER;
+		m[27].value = PlayerCfg.MyTeamColor;
+		m[27].text = misc_menu_data.my_team_color;
+		m[27].min_value = 0;
+		m[27].max_value = 8;
+
+		print_other_team_color(misc_menu_data.other_team_color, SDL_arraysize(misc_menu_data.other_team_color),
+			PlayerCfg.OtherTeamColor);
+		m[28].type = NM_TYPE_SLIDER;
+		m[28].value = PlayerCfg.OtherTeamColor;
+		m[28].text = misc_menu_data.other_team_color;
+		m[28].min_value = 0;
+		m[28].max_value = 8;
+
+		if (PlayerCfg.MyTeamColor == 8 && PlayerCfg.OtherTeamColor == 8) {
+			// If we're not setting explicit team colors, we don't override what the game host picked
+			m[29].type = NM_TYPE_TEXT;
+			m[29].text = "Ignore Per-Game Team Colors (N/A)";
+		} else {
+			m[29].type = NM_TYPE_CHECK;
+			m[29].text = "Ignore Per-Game Team Colors";
+		}
+		m[29].value = PlayerCfg.PreferMyTeamColors;
+
+		i = newmenu_do1(NULL, "Misc Options", SDL_arraysize(m), m, menu_misc_options_handler, &misc_menu_data, i);
 
 		PlayerCfg.AutoLeveling			= m[0].value;
 		PlayerCfg.PersistentDebris		= m[1].value;
@@ -2057,29 +2136,47 @@ void do_misc_menu()
 		PlayerCfg.VulcanAmmoWarnings = m[17].value; 
 		PlayerCfg.ShieldWarnings = m[18].value; 
 		PlayerCfg.AutoDemo = m[19].value;
-		PlayerCfg.ShowCustomColors = m[22].value;
+		PlayerCfg.ShowCustomColors = m[24].value;
+		PlayerCfg.PreferMyTeamColors = (PlayerCfg.MyTeamColor == 8 && PlayerCfg.OtherTeamColor == 8) ? 0 : m[29].value;
 
 	} while( i>-1 );
 
 }
 
-int menu_misc_options_handler ( newmenu *menu, d_event *event, void *userdata )
+int menu_misc_options_handler(newmenu* menu, d_event* event, void* userdata)
 {
-	
 	newmenu_item *menus = newmenu_get_items(menu);
 	int citem = newmenu_get_citem(menu);
+	struct misc_menu_data* menu_data = (struct misc_menu_data*)userdata;
 	
-	if (event->type == EVENT_NEWMENU_CHANGED)
-	{
-		if (citem == 20) {
-			PlayerCfg.ShipColor = menus[20].value;
-			print_ship_color(menus[20].text, PlayerCfg.ShipColor);
-		} else if (citem == 21) {
-			PlayerCfg.MissileColor = menus[21].value;
-			print_missile_color(menus[21].text, PlayerCfg.MissileColor);
+	if (event->type == EVENT_NEWMENU_CHANGED) {
+		if (citem == 22) {
+			PlayerCfg.ShipColor = menus[22].value;
+			print_ship_color(menu_data->preferred_color, SDL_arraysize(menu_data->preferred_color),
+				PlayerCfg.ShipColor);
+		} else if (citem == 23) {
+			PlayerCfg.MissileColor = menus[23].value;
+			print_missile_color(menu_data->missile_color, SDL_arraysize(menu_data->missile_color),
+				PlayerCfg.MissileColor);
+		} else if (citem == 27) {
+			PlayerCfg.MyTeamColor = menus[27].value;
+			print_my_team_color(menu_data->my_team_color, SDL_arraysize(menu_data->my_team_color),
+				PlayerCfg.MyTeamColor);
+		} else if (citem == 28) {
+			PlayerCfg.OtherTeamColor = menus[28].value;
+			print_other_team_color(menu_data->other_team_color, SDL_arraysize(menu_data->other_team_color),
+				PlayerCfg.OtherTeamColor);
+		}
+
+		if (PlayerCfg.MyTeamColor == 8 && PlayerCfg.OtherTeamColor == 8) {
+			menus[29].type = NM_TYPE_TEXT;
+			menus[29].text = "Ignore Per-Game Team Colors (N/A)";
+		} else {
+			menus[29].type = NM_TYPE_CHECK;
+			menus[29].text = "Ignore Per-Game Team Colors";
 		}
 	}
-	
+
 	return 0;
 }
 

--- a/d1/main/menu.c
+++ b/d1/main/menu.c
@@ -2141,6 +2141,12 @@ void do_misc_menu()
 
 	} while( i>-1 );
 
+	// Update team colors if they were changed during a game
+	if ((Game_mode & GM_TEAM) && (Network_status == NETSTAT_PLAYING)) {
+		for (int i = 0; i < N_players; i++)
+			if (Players[i].connected)
+				multi_reset_object_texture(&Objects[Players[i].objnum]);
+	}
 }
 
 int menu_misc_options_handler(newmenu* menu, d_event* event, void* userdata)

--- a/d1/main/multi.c
+++ b/d1/main/multi.c
@@ -3016,37 +3016,18 @@ void disable_faircolors_if_3_connected() {
 	}
 }
 
-int get_color_for_first_team_player(int team, int missile) {
-	for(int i = 0; i < MAX_PLAYERS; i++) {
-		if(get_team(i) == team) {
-			if(missile) { return Netgame.players[i].missilecolor; }
-			return Netgame.players[i].color;
-		}
-	}
-con_printf(CON_NORMAL, "Couldn't find team color for team %d\n", team);
-	return team; 
-} 
-
 int get_color_for_player(int player, int missile) {
-	int color = 0; 
+	if (Game_mode & GM_TEAM) {
+		return get_color_for_team(get_team(player));
+	}
+
+	int color = 0;
 
 	if((! PlayerCfg.ShowCustomColors) || (! Netgame.AllowPreferredColors)) {
-		if(Game_mode & GM_TEAM) {
-			color = get_team(player);
-		} else {
-			color = player; 
-		}
+		color = player;
 	} else {
-		if(Game_mode & GM_TEAM) {
-			color = get_color_for_first_team_player(get_team(player), missile);
-		} else {
-			if(missile) { color = Netgame.players[player].missilecolor; }
-			else        { color = Netgame.players[player].color;  }
-		}
-	}
-
-	if (Game_mode & GM_TEAM) {
-		return(color); 
+		if(missile) { color = Netgame.players[player].missilecolor; }
+		else        { color = Netgame.players[player].color;  }
 	}
 
 	if(Game_mode & GM_MULTI && Netgame.FairColors && !is_observer()) {
@@ -3056,14 +3037,23 @@ int get_color_for_player(int player, int missile) {
 	return(color); 
 }
 
-int get_color_for_team(int team, int missile) {
-	for(int i = 0; i < MAX_PLAYERS; i++) {
-		if(get_team(i) == team) {
-			return get_color_for_player(i, missile);
-		}
+int get_color_for_team(int team)
+{
+	int team_color = Netgame.team_color[team];
+	int color = team_color;
+
+	// Are we using the player's preferred team colors?
+	if (!is_observer() && (team_color == 8 || PlayerCfg.PreferMyTeamColors)) {
+		int same_team = get_team(Player_num) == team;
+		color = same_team ? PlayerCfg.MyTeamColor : PlayerCfg.OtherTeamColor;
+		// No color set? Revert to what the game creator specified
+		if (color == 8) color = team_color;
 	}
 
-	return team; 
+	// If the team color is default, 0 is blue, 1 is red
+	if (color == 8) color = team;
+
+	return color;
 }
 
 void multi_reset_object_texture (object *objp)

--- a/d1/main/multi.h
+++ b/d1/main/multi.h
@@ -293,7 +293,7 @@ void multi_disconnect_player(int pnum);
 void multi_object_to_object_rw(object *obj, object_rw *obj_rw);
 void multi_object_rw_to_object(object_rw *obj_rw, object *obj);
 int get_color_for_player(int id, int missile); 
-int get_color_for_team(int team, int missile);
+int get_color_for_team(int team);
 void multi_send_obs_update(ubyte event, ubyte event_data);
 void multi_send_ship_status_for_frame();
 bool is_observing_player();
@@ -472,6 +472,7 @@ typedef struct netgame_info
 	short						ShowEnemyNames;
 	short						BrightPlayers;
 	char						team_name[2][CALLSIGN_LEN+1];
+	ubyte						team_color[2];
 	signed char						TeamKillGoalCount[2]; 
 	int						locations[MAX_PLAYERS];
 	short						kills[MAX_PLAYERS][MAX_PLAYERS];

--- a/d1/main/multi.h
+++ b/d1/main/multi.h
@@ -294,6 +294,7 @@ void multi_object_to_object_rw(object *obj, object_rw *obj_rw);
 void multi_object_rw_to_object(object_rw *obj_rw, object *obj);
 int get_color_for_player(int id, int missile); 
 int get_color_for_team(int team);
+void multi_reset_object_texture(object* objp);
 void multi_send_obs_update(ubyte event, ubyte event_data);
 void multi_send_ship_status_for_frame();
 bool is_observing_player();

--- a/d1/main/multi.h
+++ b/d1/main/multi.h
@@ -472,7 +472,6 @@ typedef struct netgame_info
 	short						ShowEnemyNames;
 	short						BrightPlayers;
 	char						team_name[2][CALLSIGN_LEN+1];
-	ubyte						team_color[2];
 	signed char						TeamKillGoalCount[2]; 
 	int						locations[MAX_PLAYERS];
 	short						kills[MAX_PLAYERS][MAX_PLAYERS];
@@ -511,6 +510,7 @@ typedef struct netgame_info
 	ubyte						AllowCustomModelsTextures;
 	ubyte						ReducedFlash;
 	ubyte						GaussAmmoStyle;
+	ubyte						team_color[2];
 } __pack__ netgame_info;
 
 extern int Host_is_obs; // Reminder for host only that they are an observer.  Do not set for other players or observers.

--- a/d1/main/net_udp.c
+++ b/d1/main/net_udp.c
@@ -2983,6 +2983,8 @@ void net_udp_send_game_info(struct _sockaddr sender_addr, ubyte info_upid, ubyte
 		PUT_INTEL_SHORT(buf + len, Netgame.BrightPlayers);				len += 2;
 		len += 2; // Spawn invul -- no longer used, but don't break tools
 		memcpy(&buf[len], Netgame.team_name, 2*(CALLSIGN_LEN+1));			len += 2*(CALLSIGN_LEN+1);
+		buf[len] = Netgame.team_color[0];						len++;
+		buf[len] = Netgame.team_color[1];						len++;
 		for (i = 0; i < MAX_PLAYERS; i++)
 		{
 			PUT_INTEL_INT(buf + len, Netgame.locations[i]);				len += 4;
@@ -3213,6 +3215,8 @@ int net_udp_process_game_info(ubyte *data, int data_len, struct _sockaddr game_a
 		Netgame.BrightPlayers = GET_INTEL_SHORT(&(data[len]));				len += 2;
 		len += 2; // Spawn invul -- no longer used, but don't break tools
 		memcpy(Netgame.team_name, &(data[len]), 2*(CALLSIGN_LEN+1));			len += 2*(CALLSIGN_LEN+1);
+		Netgame.team_color[0] = data[len];						len++;
+		Netgame.team_color[1] = data[len];						len++;
 		for (i = 0; i < MAX_PLAYERS; i++)
 		{
 			Netgame.locations[i] = GET_INTEL_INT(&(data[len]));			len += 4;
@@ -4828,14 +4832,22 @@ int net_udp_send_sync(void)
 	return 0;
 }
 
+int net_udp_menu_select_teams_handler(newmenu* menu, d_event* event, void* userdata);
+
+struct select_teams_menu_data {
+	char team_names[2][CALLSIGN_LEN + 1];
+	ubyte team_colors[2];
+	int opt_team_a_color;
+	int opt_team_b_color;
+};
 
 int
 net_udp_select_teams(void)
 {
-	newmenu_item m[MAX_PLAYERS+4];
+	newmenu_item m[MAX_PLAYERS+7];
 	int choice, opt, opt_team_b;
 	ubyte team_vector = 0;
-	char team_names[2][CALLSIGN_LEN+1];
+	struct select_teams_menu_data menu_data;
 	int i;
 	int pnums[MAX_PLAYERS+2];
 
@@ -4846,63 +4858,128 @@ net_udp_select_teams(void)
 		team_vector |= (1 << i);
 	}
 
-	sprintf(team_names[0], "%s", TXT_BLUE);
-	sprintf(team_names[1], "%s", TXT_RED);
+	sprintf(menu_data.team_names[0], "%s", TXT_BLUE);
+	sprintf(menu_data.team_names[1], "%s", TXT_RED);
+	menu_data.team_colors[0] = menu_data.team_colors[1] = 8; // 8 = default
 
 	// Here comes da menu
-menu:
-	m[0].type = NM_TYPE_INPUT; m[0].text = team_names[0]; m[0].text_len = CALLSIGN_LEN; 
+	while (1) {
+		opt = 0;
 
-	opt = 1;
-	for (i = 0; i < N_players; i++)
-	{
-		if (!(team_vector & (1 << i)))
-		{
-			m[opt].type = NM_TYPE_MENU; m[opt].text = Netgame.players[i].callsign; pnums[opt] = i; opt++;
-		}
-	}
-	opt_team_b = opt;
-	m[opt].type = NM_TYPE_INPUT; m[opt].text = team_names[1]; m[opt].text_len = CALLSIGN_LEN; opt++;
-	for (i = 0; i < N_players; i++)
-	{
-		if (team_vector & (1 << i))
-		{
-			m[opt].type = NM_TYPE_MENU; m[opt].text = Netgame.players[i].callsign; pnums[opt] = i; opt++;
-		}
-	}
-	m[opt].type = NM_TYPE_TEXT; m[opt].text = ""; opt++;
-	m[opt].type = NM_TYPE_MENU; m[opt].text = TXT_ACCEPT; opt++;
+		menu_data.opt_team_a_color = opt;
+		m[opt].type = NM_TYPE_SLIDER;
+		m[opt].value = menu_data.team_colors[0];
+		m[opt].min_value = 0;
+		m[opt].max_value = 8;
+		m[opt].text = "Team 1 color: ";
+		opt++;
 
-	Assert(opt <= MAX_PLAYERS+4);
+		m[opt].type = NM_TYPE_INPUT;
+		m[opt].text = menu_data.team_names[0];
+		m[opt].text_len = CALLSIGN_LEN;
+		opt++;
+
+		// Team A player list
+		for (i = 0; i < N_players; i++)
+		{
+			if (!(team_vector & (1 << i)))
+			{
+				m[opt].type = NM_TYPE_MENU;
+				m[opt].text = Netgame.players[i].callsign;
+				pnums[opt] = i;
+				opt++;
+			}
+		}
+
+		opt_team_b = opt;
+
+		m[opt].type = NM_TYPE_TEXT;
+		m[opt].text = "";
+		opt++;
+
+		menu_data.opt_team_b_color = opt;
+		m[opt].type = NM_TYPE_SLIDER;
+		m[opt].value = menu_data.team_colors[1];
+		m[opt].min_value = 0;
+		m[opt].max_value = 8;
+		m[opt].text = "Team 2 color: ";
+		opt++;
+
+		m[opt].type = NM_TYPE_INPUT;
+		m[opt].text = menu_data.team_names[1];
+		m[opt].text_len = CALLSIGN_LEN;
+		opt++;
+
+		// Team B player list
+		for (i = 0; i < N_players; i++)
+		{
+			if (team_vector & (1 << i))
+			{
+				m[opt].type = NM_TYPE_MENU;
+				m[opt].text = Netgame.players[i].callsign;
+				pnums[opt] = i;
+				opt++;
+			}
+		}
+
+		m[opt].type = NM_TYPE_TEXT;
+		m[opt].text = "";
+		opt++;
+
+		m[opt].type = NM_TYPE_MENU;
+		m[opt].text = TXT_ACCEPT;
+		opt++;
+
+		Assert(opt <= SDL_arraysize(m));
 	
-	choice = newmenu_do(NULL, TXT_TEAM_SELECTION, opt, m, NULL, NULL);
+		choice = newmenu_do(NULL, TXT_TEAM_SELECTION, opt, m, net_udp_menu_select_teams_handler, &menu_data);
 
-	if (choice == opt-1)
-	{
-#if 0 // no need to wait for other players
-		if ((opt-2-opt_team_b < 2) || (opt_team_b == 1)) 
+		if (choice == opt-1)
 		{
-			nm_messagebox(NULL, 1, TXT_OK, TXT_TEAM_MUST_ONE);
-			#ifdef RELEASE
-			goto menu;
-			#endif
+			Netgame.team_vector = team_vector;
+			strcpy(Netgame.team_name[0], menu_data.team_names[0]);
+			strcpy(Netgame.team_name[1], menu_data.team_names[1]);
+			Netgame.team_color[0] = menu_data.team_colors[0];
+			Netgame.team_color[1] = menu_data.team_colors[1];
+			return 1;
 		}
-#endif
-		Netgame.team_vector = team_vector;
-		strcpy(Netgame.team_name[0], team_names[0]);
-		strcpy(Netgame.team_name[1], team_names[1]);
-		return 1;
+
+		else if ((choice > 0) && (choice < opt_team_b)) {
+			team_vector |= (1 << pnums[choice]);
+		}
+		else if ((choice > opt_team_b) && (choice < opt-2)) {
+			team_vector &= ~(1 << pnums[choice]);
+		}
+		else if (choice == -1)
+			return 0;
+	}
+}
+
+int net_udp_menu_select_teams_handler(newmenu* menu, d_event* event, void* userdata)
+{
+	newmenu_item* menus = newmenu_get_items(menu);
+	int citem = newmenu_get_citem(menu);
+	struct select_teams_menu_data* menu_data = (struct select_teams_menu_data*)userdata;
+
+	if (event->type == EVENT_NEWMENU_CHANGED) {
+		if (citem == menu_data->opt_team_a_color) {
+			menu_data->team_colors[0] = menus[citem].value;
+			if (menu_data->team_colors[0] == 8)
+				sprintf(menu_data->team_names[0], "%s", TXT_BLUE);
+			else
+				get_color_name(menu_data->team_names[0], SDL_arraysize(menu_data->team_names[0]),
+					menu_data->team_colors[0], Netgame.BlackAndWhitePyros);
+		} else if (citem == menu_data->opt_team_b_color) {
+			menu_data->team_colors[1] = menus[citem].value;
+			if (menu_data->team_colors[1] == 8)
+				sprintf(menu_data->team_names[1], "%s", TXT_RED);
+			else
+				get_color_name(menu_data->team_names[1], SDL_arraysize(menu_data->team_names[1]),
+					menu_data->team_colors[1], Netgame.BlackAndWhitePyros);
+		}
 	}
 
-	else if ((choice > 0) && (choice < opt_team_b)) {
-		team_vector |= (1 << pnums[choice]);
-	}
-	else if ((choice > opt_team_b) && (choice < opt-2)) {
-		team_vector &= ~(1 << pnums[choice]);
-	}
-	else if (choice == -1)
-		return 0;
-	goto menu;
+	return 0;
 }
 
 int

--- a/d1/main/net_udp.c
+++ b/d1/main/net_udp.c
@@ -2983,8 +2983,6 @@ void net_udp_send_game_info(struct _sockaddr sender_addr, ubyte info_upid, ubyte
 		PUT_INTEL_SHORT(buf + len, Netgame.BrightPlayers);				len += 2;
 		len += 2; // Spawn invul -- no longer used, but don't break tools
 		memcpy(&buf[len], Netgame.team_name, 2*(CALLSIGN_LEN+1));			len += 2*(CALLSIGN_LEN+1);
-		buf[len] = Netgame.team_color[0];						len++;
-		buf[len] = Netgame.team_color[1];						len++;
 		for (i = 0; i < MAX_PLAYERS; i++)
 		{
 			PUT_INTEL_INT(buf + len, Netgame.locations[i]);				len += 4;
@@ -3043,6 +3041,8 @@ void net_udp_send_game_info(struct _sockaddr sender_addr, ubyte info_upid, ubyte
 		buf[len] = Netgame.AllowCustomModelsTextures; len++;
 		buf[len] = Netgame.ReducedFlash; len++;
 		buf[len] = Netgame.GaussAmmoStyle; len++;
+		buf[len] = Netgame.team_color[0];						len++;
+		buf[len] = Netgame.team_color[1];						len++;
 
 		if(info_upid == UPID_SYNC) {
 			PUT_INTEL_INT(buf + len, player_token); len += 4; 
@@ -3215,8 +3215,6 @@ int net_udp_process_game_info(ubyte *data, int data_len, struct _sockaddr game_a
 		Netgame.BrightPlayers = GET_INTEL_SHORT(&(data[len]));				len += 2;
 		len += 2; // Spawn invul -- no longer used, but don't break tools
 		memcpy(Netgame.team_name, &(data[len]), 2*(CALLSIGN_LEN+1));			len += 2*(CALLSIGN_LEN+1);
-		Netgame.team_color[0] = data[len];						len++;
-		Netgame.team_color[1] = data[len];						len++;
 		for (i = 0; i < MAX_PLAYERS; i++)
 		{
 			Netgame.locations[i] = GET_INTEL_INT(&(data[len]));			len += 4;
@@ -3275,6 +3273,8 @@ int net_udp_process_game_info(ubyte *data, int data_len, struct _sockaddr game_a
 		Netgame.AllowCustomModelsTextures = data[len]; len++;
 		Netgame.ReducedFlash = data[len]; len++;
 		Netgame.GaussAmmoStyle = data[len]; len++;
+		Netgame.team_color[0] = data[len];						len++;
+		Netgame.team_color[1] = data[len];						len++;
 
 		if (Netgame.host_is_obs) {
 			multi_make_player_ghost(0);

--- a/d1/main/net_udp.h
+++ b/d1/main/net_udp.h
@@ -50,7 +50,7 @@ void net_udp_send_obs_quit();
 #define UPID_GAME_INFO_REQ_SIZE			 13
 #define UPID_GAME_INFO_LITE_REQ_SIZE		 11
 #define UPID_GAME_INFO				  3 // Packet containing all info about a netgame.
-#define UPID_GAME_INFO_SIZE			(5 + 4*2 + 365 + (NETGAME_NAME_LEN+1) + (MISSION_NAME_LEN+1) + ((MAX_PLAYERS+4)*(CALLSIGN_LEN+1+1)) + 18*12)
+#define UPID_GAME_INFO_SIZE			(5 + 4*2 + 367 + (NETGAME_NAME_LEN+1) + (MISSION_NAME_LEN+1) + ((MAX_PLAYERS+4)*(CALLSIGN_LEN+1+1)) + 18*12)
 #define UPID_GAME_INFO_LITE_REQ			  4 // Requesting lite info about a netgame. Used for discovering games.
 #define UPID_GAME_INFO_LITE			  5 // Packet containing lite netgame info.
 #define UPID_GAME_INFO_LITE_SIZE		 (31 + (NETGAME_NAME_LEN+1) + (MISSION_NAME_LEN+1))

--- a/d1/main/playsave.c
+++ b/d1/main/playsave.c
@@ -112,10 +112,13 @@ int new_player_config()
 	PlayerCfg.ShieldWarnings = 0; 
 	PlayerCfg.AutoDemo = 1; 
 	PlayerCfg.ShowCustomColors = 1; 
+	PlayerCfg.PreferMyTeamColors = 0;
 	PlayerCfg.QuietPlasma = 1; 
 	PlayerCfg.maxFps = GameArg.SysMaxFPS; 
 	PlayerCfg.ShipColor = 8;
-	PlayerCfg.MissileColor = 8;	
+	PlayerCfg.MissileColor = 8;
+	PlayerCfg.MyTeamColor = 8;
+	PlayerCfg.OtherTeamColor = 8;
 	PlayerCfg.ObsTurbo = 0;
 	PlayerCfg.ObsShowCockpit = 1;
 	PlayerCfg.ObsShowScoreboardShieldText = 1;
@@ -433,6 +436,12 @@ int read_player_d1x(char *filename)
 					PlayerCfg.ShipColor = atoi(line);	
 				if(!strcmp(word,"MISSILECOLOR"))
 					PlayerCfg.MissileColor = atoi(line);
+				if (!strcmp(word, "OVERRIDETEAMCOLORS"))
+					PlayerCfg.PreferMyTeamColors = atoi(line);
+				if (!strcmp(word, "MYTEAMCOLOR"))
+					PlayerCfg.MyTeamColor = atoi(line);
+				if (!strcmp(word, "OTHERTEAMCOLOR"))
+					PlayerCfg.OtherTeamColor = atoi(line);
 				if(!strcmp(word,"OBSTURBO"))
 					PlayerCfg.ObsTurbo = atoi(line);
 				if(!strcmp(word,"OBSSHOWCOCKPIT"))
@@ -839,7 +848,10 @@ int write_player_d1x(char *filename)
 		PHYSFSX_printf(fout,"autodemo=%i\n",PlayerCfg.AutoDemo);					
 		PHYSFSX_printf(fout,"showcustomcolors=%i\n",PlayerCfg.ShowCustomColors);	
 		PHYSFSX_printf(fout,"shipcolor=%i\n",PlayerCfg.ShipColor);	
-		PHYSFSX_printf(fout,"missilecolor=%i\n",PlayerCfg.MissileColor);	
+		PHYSFSX_printf(fout,"missilecolor=%i\n",PlayerCfg.MissileColor);
+		PHYSFSX_printf(fout, "overrideteamcolors=%i\n", PlayerCfg.PreferMyTeamColors);
+		PHYSFSX_printf(fout, "myteamcolor=%i\n", PlayerCfg.MyTeamColor);
+		PHYSFSX_printf(fout, "otherteamcolor=%i\n", PlayerCfg.OtherTeamColor);
 		PHYSFSX_printf(fout,"obsturbo=%i\n",PlayerCfg.ObsTurbo);
 		PHYSFSX_printf(fout,"obsshowcockpit=%i\n",PlayerCfg.ObsShowCockpit);
 		PHYSFSX_printf(fout,"obsshowscoreboardshieldtext=%i\n",PlayerCfg.ObsShowScoreboardShieldText);

--- a/d1/main/playsave.h
+++ b/d1/main/playsave.h
@@ -95,6 +95,7 @@ typedef struct player_config
 	ubyte ShieldWarnings; 
 	ubyte AutoDemo; 
 	ubyte ShowCustomColors; 
+	ubyte PreferMyTeamColors;
 	ubyte QuietPlasma; 
 	int AlphaEffects;
 	int DynLightColor;
@@ -104,6 +105,8 @@ typedef struct player_config
 	int maxFps;
 	int ShipColor; 
 	int MissileColor; 
+	int MyTeamColor;
+	int OtherTeamColor;
 	ubyte ObsTurbo;
 	ubyte ObsShowCockpit;
 	ubyte ObsShowScoreboardShieldText;

--- a/d2/arch/ogl/ogl.c
+++ b/d2/arch/ogl/ogl.c
@@ -1787,7 +1787,7 @@ void ogl_loadpngmask(png_data *pdata, grs_bitmap *bm, int texfilt)
 void ogl_loadbmtexture_f(grs_bitmap *bm, int texfilt, int filter_blueship_wing)
 {
 	unsigned char *buf;
-	const char *bitmapname = NULL;
+	const char *bitmapname = piggy_game_bitmap_name(bm);
 
 	while (bm->bm_parent)
 		bm=bm->bm_parent;
@@ -1795,7 +1795,7 @@ void ogl_loadbmtexture_f(grs_bitmap *bm, int texfilt, int filter_blueship_wing)
 		return;
 	buf=bm->bm_data;
 #ifdef HAVE_LIBPNG
-	if (ogl_allow_png() && (bitmapname = piggy_game_bitmap_name(bm)))
+	if (ogl_allow_png() && bitmapname)
 	{
 		char filename[64];
 		png_data pdata;
@@ -1867,8 +1867,6 @@ void ogl_loadbmtexture_f(grs_bitmap *bm, int texfilt, int filter_blueship_wing)
 
 		if(Game_mode & GM_MULTI && Netgame.BlackAndWhitePyros) {
 			if(bm->bm_w == 64 && bm->bm_h == 64) {
-				if (!bitmapname)
-					bitmapname = piggy_game_bitmap_name(bm);
 				char is_purple_tex1 = bitmapname && !strcmp(bitmapname, "ship6-4");
 				char is_purple_tex2 = bitmapname && !strcmp(bitmapname, "ship6-5");
 

--- a/d2/main/gamerend.c
+++ b/d2/main/gamerend.c
@@ -343,12 +343,12 @@ void show_netplayerinfo()
 		gr_printf(x,y,"team");
 		gr_printf(x+FSPACX(8)*8,y,"score");
 		y+=LINE_SPACING;
-		color = get_color_for_team(0, 0);
+		color = get_color_for_team(0);
 		gr_set_fontcolor(BM_XRGB(selected_player_rgb[color].r,selected_player_rgb[color].g,selected_player_rgb[color].b),-1 );
 		gr_printf(x,y,"%s:",Netgame.team_name[0]);
 		gr_printf(x+FSPACX(8)*8,y,"%i",team_kills[0]);
 		y+=LINE_SPACING;
-		color = get_color_for_team(1, 0);
+		color = get_color_for_team(1);
 		gr_set_fontcolor(BM_XRGB(selected_player_rgb[color].r,selected_player_rgb[color].g,selected_player_rgb[color].b),-1 );
 		gr_printf(x,y,"%s:",Netgame.team_name[1]);
 		gr_printf(x+FSPACX(8)*8,y,"%i",team_kills[1]);

--- a/d2/main/gauges.c
+++ b/d2/main/gauges.c
@@ -1808,19 +1808,19 @@ void draw_player_ship(int cloak_state,int x, int y)
 
 	grs_bitmap *bm = NULL;
 
+	int color;
 #ifdef NETWORK
 	if (Game_mode & GM_TEAM)
 	{
-		PAGE_IN_GAUGE( GAUGE_SHIPS+get_team(pnum) );
-		bm = &GameBitmaps[ GET_GAUGE_INDEX(GAUGE_SHIPS+get_team(pnum)) ];
+		color = get_color_for_team(get_team(pnum));
 	}
 	else
 #endif
 	{
-		int color = Netgame.players[pnum].color;
+		color = Netgame.players[pnum].color;
+	}
 		PAGE_IN_GAUGE( GAUGE_SHIPS+color );
 		bm = &GameBitmaps[ GET_GAUGE_INDEX(GAUGE_SHIPS+color) ];
-	}
 
 	if (cloak_state)
 	{
@@ -2316,36 +2316,38 @@ extern int allowed_to_fire_laser(void);
 extern int allowed_to_fire_missile(void);
 
 // CED -- shipcolor fix
-const rgb player_rgb[MAX_PLAYERS] = {
-							{15,15,23},    // 0x7878B8 ---> blue
-							{27,0,0},      // 0xD80000 ---> red
-							{0,23,0},      // 0x00B800 ---> green
-							{30,11,31},    // 0xF058F8 ---> PINK
-							{31,16,0},     // 0xF88000 ---> orange
-							{24,17,6},     // 0xC08830 ---> light orange (PROBLEM)
-							{14,21,12},    // 0x70A860 ---> light green (PROBLEM)
-							{29,29,0}, };  // 0xE8E800 ---> YELLOW
+const rgb player_rgb[] = {
+	{15,15,23}, // 0x7878B8 (blue)
+	{27,0,0},   // 0xD80000 (red)
+	{0,23,0},   // 0x00B800 (green)
+	{30,11,31}, // 0xF058F8 (pink)
+	{31,16,0},  // 0xF88000 (orange)
+	{24,17,6},  // 0xC08830 (tan)
+	{14,21,12}, // 0x70A860 (mint)
+	{29,29,0},  // 0xE8E800 (yellow)
+};
 
-const rgb player_rgb_alt[MAX_PLAYERS] = {
-							{15,15,23},    // 0x7878B8 ---> blue
-							{27,0,0},      // 0xD80000 ---> red
-							{0,23,0},      // 0x00B800 ---> green
-							{30,11,31},    // 0xF058F8 ---> PINK
-							{31,16,0},     // 0xF88000 ---> orange
-							//{12,4,20},   // purple
-							{16,4,24},     // purple
-							{23, 23, 23},  // white
-							{29,29,0}, };  // 0xE8E800 ---> YELLOW
+const rgb player_rgb_alt[] = {
+	{15,15,23}, // 0x7878B8 (blue)
+	{27,0,0},   // 0xD80000 (red)
+	{0,23,0},   // 0x00B800 (green)
+	{30,11,31}, // 0xF058F8 (pink)
+	{31,16,0},  // 0xF88000 (orange)
+	{16,4,24},  // 0x8020C0 (purple)
+	{23,23,23}, // 0xB8B8B8 (white)
+	{29,29,0},  // 0xE8E800 (yellow)
+};
 
-const rgb player_rgb_all_blue[MAX_PLAYERS] = {
-							{15,15,23},    // 0x7878B8 ---> blue
+const rgb player_rgb_all_blue[] = {
+	{15,15,23}, // 0x7878B8 (blue)
 							{15,15,23},
 							{15,15,23},
 							{15,15,23},
 							{15,15,23},
 							{15,15,23},
 							{15,15,23},
-							{15,15,23}, };
+	{15,15,23},
+};
 
 const rgb* selected_player_rgb;
 
@@ -2653,7 +2655,7 @@ void hud_show_kill_list()
 		if (Show_kill_list != 3 && Players[player_num].connected != CONNECT_PLAYING) {
 			gr_set_fontcolor(BM_XRGB(12, 12, 12), -1);
 		} else if (Game_mode & GM_TEAM) {
-			color = get_color_for_team(team_num, 0);
+			color = get_color_for_team(team_num);
 			gr_set_fontcolor(BM_XRGB(selected_player_rgb[color].r,selected_player_rgb[color].g,selected_player_rgb[color].b),-1 );
 		} else {
 			color = get_color_for_player(player_num, 0);
@@ -2675,7 +2677,7 @@ void hud_show_kill_list()
 
 		if (Show_kill_list == 3 || Players[player_num].connected == CONNECT_PLAYING) {
 			if (Game_mode & GM_TEAM) {
-				color = get_color_for_team(team_num, 1);
+				color = get_color_for_team(team_num);
 				gr_set_fontcolor(BM_XRGB(selected_player_rgb[color].r,selected_player_rgb[color].g,selected_player_rgb[color].b),-1 );
 			} else {
 				color = get_color_for_player(player_num, 1);
@@ -3470,7 +3472,7 @@ void observer_maybe_show_kill_graph() {
 
 				if ((ev = First_event[pnum]) != NULL) {
 					if (Game_mode & GM_TEAM) {
-						color = get_color_for_team(pnum, 0);
+						color = get_color_for_team(pnum);
 						gr_setcolor(BM_XRGB(selected_player_rgb[color].r, selected_player_rgb[color].g, selected_player_rgb[color].b));
 					} else {
 						color = get_color_for_player(pnum, 0);

--- a/d2/main/kmatrix.c
+++ b/d2/main/kmatrix.c
@@ -137,7 +137,7 @@ void kmatrix_draw_names(int *sorted)
 	for (j=0; j<N_players; j++)
 	{
 		if (Game_mode & GM_TEAM)
-			color = get_color_for_team(sorted[j], 0);
+			color = get_color_for_team(sorted[j]);
 		else
 			color = get_color_for_player(sorted[j], 0);//sorted[j];
 
@@ -239,7 +239,7 @@ void kmatrix_redraw(kmatrix_screen *km)
 		for (i=0; i<N_players; i++ )
 		{
 			if (Game_mode & GM_TEAM)
-				color = get_color_for_team(sorted[i], 0);
+				color = get_color_for_team(sorted[i]);
 			else
 				color = get_color_for_player(sorted[i], 0);//sorted[j];
 

--- a/d2/main/menu.c
+++ b/d2/main/menu.c
@@ -1961,48 +1961,87 @@ void do_sound_menu()
 
 int menu_misc_options_handler ( newmenu *menu, d_event *event, void *userdata );
 
-void print_ship_color(char* color_string, int color_value) {
+void get_color_name(char* color_name, int color_name_length, int color_value, int use_alternate_colors)
+{
+	switch (color_value) {
+		case 0:  snprintf(color_name, color_name_length, "%s", "Blue"); break;
+		case 1:  snprintf(color_name, color_name_length, "%s", "Red"); break;
+		case 2:  snprintf(color_name, color_name_length, "%s", "Green"); break;
+		case 3:  snprintf(color_name, color_name_length, "%s", "Pink"); break;
+		case 4:  snprintf(color_name, color_name_length, "%s", "Orange"); break;
+		case 5:
+			if (use_alternate_colors)
+				snprintf(color_name, color_name_length, "%s", "Purple");
+			else
+				snprintf(color_name, color_name_length, "%s", "Tan");
+			break;
+		case 6:
+			if (use_alternate_colors)
+				snprintf(color_name, color_name_length, "%s", "White");
+			else
+				snprintf(color_name, color_name_length, "%s", "Mint");
+			break;
+		case 7:  snprintf(color_name, color_name_length, "%s", "Yellow"); break;
+		default: snprintf(color_name, color_name_length, "%s", "???");
+	}
+}
+
+void print_ship_color(char* color_string, int color_string_length, int color_value)
+{
 	char color[10];
-	switch(color_value) {
-		case 0:  sprintf(color, "%s", "Blue"); break;
-		case 1:  sprintf(color, "%s", "Red"); break;
-		case 2:  sprintf(color, "%s", "Green"); break;
-		case 3:  sprintf(color, "%s", "Pink"); break;
-		case 4:  sprintf(color, "%s", "Orange"); break;
-		case 5:  sprintf(color, "%s", "Purple"); break;
-		case 6:  sprintf(color, "%s", "White"); break;
-		case 7:  sprintf(color, "%s", "Yellow"); break;
-		case 8:  sprintf(color, "%s", "None"); break;
-		default: sprintf(color, "%s", "???"); 
-	}
+	if (color_value == 8)
+		snprintf(color, SDL_arraysize(color), "%s", "Default");
+	else
+		get_color_name(color, SDL_arraysize(color), color_value, 1);
 
-
-	sprintf( color_string, "Wing Color: %s", color);
+	snprintf(color_string, color_string_length, "Wing Color: %s", color);
 }
 
-void print_missile_color(char* color_string, int color_value) {
+void print_missile_color(char* color_string, int color_string_length, int color_value)
+{
 	char color[11];
-	switch(color_value) {
-		case 0:  sprintf(color, "%s", "Blue"); break;
-		case 1:  sprintf(color, "%s", "Red"); break;
-		case 2:  sprintf(color, "%s", "Green"); break;
-		case 3:  sprintf(color, "%s", "Pink"); break;
-		case 4:  sprintf(color, "%s", "Orange"); break;
-		case 5:  sprintf(color, "%s", "Purple"); break;
-		case 6:  sprintf(color, "%s", "White"); break;
-		case 7:  sprintf(color, "%s", "Yellow"); break;
-		case 8:  sprintf(color, "%s", "Match Ship"); break;
-		default: sprintf(color, "%s", "???"); 
-	}
+	if (color_value == 8)
+		snprintf(color, SDL_arraysize(color), "%s", "Match Ship");
+	else
+		get_color_name(color, SDL_arraysize(color), color_value, 1);
 
-
-	sprintf( color_string, "Missiles/Guns: %s", color);
+	snprintf(color_string, color_string_length, "Missiles/Guns: %s", color);
 }
+
+void print_my_team_color(char* color_string, int color_string_length, int color_value)
+{
+	char color[10];
+	if (color_value == 8)
+		snprintf(color, SDL_arraysize(color), "%s", "Default");
+	else
+		get_color_name(color, SDL_arraysize(color), color_value, 1);
+
+	snprintf(color_string, color_string_length, "My Team: %s", color);
+}
+
+void print_other_team_color(char* color_string, int color_string_length, int color_value)
+{
+	char color[10];
+	if (color_value == 8)
+		snprintf(color, SDL_arraysize(color), "%s", "Default");
+	else
+		get_color_name(color, SDL_arraysize(color), color_value, 1);
+
+	snprintf(color_string, color_string_length, "Other Team: %s", color);
+}
+
+struct misc_menu_data {
+	char preferred_color[30];
+	char missile_color[30];
+	char my_team_color[30];
+	char other_team_color[30];
+};
 
 void do_misc_menu()
 {
-	newmenu_item m[27];
+	newmenu_item m[34];
 	int i = 0;
+	struct misc_menu_data misc_menu_data;
 
 	do {
 		ADD_CHECK(0, "Ship auto-leveling", PlayerCfg.AutoLeveling);
@@ -2049,25 +2088,63 @@ void do_misc_menu()
 		ADD_CHECK(22, "Shield Warnings",PlayerCfg.ShieldWarnings);
 		ADD_CHECK(23, "Automatically Start Demos", PlayerCfg.AutoDemo);
 
-		char preferred_color[30];
-		print_ship_color(preferred_color, PlayerCfg.ShipColor); 
-		m[24].type = NM_TYPE_SLIDER; 
-		m[24].value= PlayerCfg.ShipColor; 
-		m[24].text= preferred_color; 
-		m[24].min_value=0; 
-		m[24].max_value=8; 
+		m[24].type = NM_TYPE_TEXT;
+		m[24].text = "";
 
-		char missile_color[30];
-		print_missile_color(missile_color, PlayerCfg.MissileColor); 
-		m[25].type = NM_TYPE_SLIDER; 
-		m[25].value= PlayerCfg.MissileColor; 
-		m[25].text= missile_color; 
-		m[25].min_value=0; 
-		m[25].max_value=8; 
+		m[25].type = NM_TYPE_TEXT;
+		m[25].text = "My Ship Colors:";
 
-		ADD_CHECK(26, "Show Custom Ship Colors", PlayerCfg.ShowCustomColors);
+		print_ship_color(misc_menu_data.preferred_color, SDL_arraysize(misc_menu_data.preferred_color),
+			PlayerCfg.ShipColor);
+		m[26].type = NM_TYPE_SLIDER;
+		m[26].value = PlayerCfg.ShipColor;
+		m[26].text = misc_menu_data.preferred_color;
+		m[26].min_value = 0;
+		m[26].max_value = 8;
 
-		i = newmenu_do1( NULL, "Misc Options", sizeof(m)/sizeof(*m), m, menu_misc_options_handler, NULL, i );
+		print_missile_color(misc_menu_data.missile_color, SDL_arraysize(misc_menu_data.missile_color),
+			PlayerCfg.MissileColor);
+		m[27].type = NM_TYPE_SLIDER;
+		m[27].value = PlayerCfg.MissileColor;
+		m[27].text = misc_menu_data.missile_color;
+		m[27].min_value = 0;
+		m[27].max_value = 8;
+
+		ADD_CHECK(28, "Show Custom Ship Colors", PlayerCfg.ShowCustomColors);
+
+		m[29].type = NM_TYPE_TEXT;
+		m[29].text = "";
+
+		m[30].type = NM_TYPE_TEXT;
+		m[30].text = "Team Colors:";
+
+		print_my_team_color(misc_menu_data.my_team_color, SDL_arraysize(misc_menu_data.my_team_color),
+			PlayerCfg.MyTeamColor);
+		m[31].type = NM_TYPE_SLIDER;
+		m[31].value = PlayerCfg.MyTeamColor;
+		m[31].text = misc_menu_data.my_team_color;
+		m[31].min_value = 0;
+		m[31].max_value = 8;
+
+		print_other_team_color(misc_menu_data.other_team_color, SDL_arraysize(misc_menu_data.other_team_color),
+			PlayerCfg.OtherTeamColor);
+		m[32].type = NM_TYPE_SLIDER;
+		m[32].value = PlayerCfg.OtherTeamColor;
+		m[32].text = misc_menu_data.other_team_color;
+		m[32].min_value = 0;
+		m[32].max_value = 8;
+
+		if (PlayerCfg.MyTeamColor == 8 && PlayerCfg.OtherTeamColor == 8) {
+			// If we're not setting explicit team colors, we don't override what the game host picked
+			m[33].type = NM_TYPE_TEXT;
+			m[33].text = "Ignore Per-Game Team Colors (N/A)";
+		} else {
+			m[33].type = NM_TYPE_CHECK;
+			m[33].text = "Ignore Per-Game Team Colors";
+		}
+		m[33].value = PlayerCfg.PreferMyTeamColors;
+
+		i = newmenu_do1(NULL, "Misc Options", SDL_arraysize(m), m, menu_misc_options_handler, &misc_menu_data, i);
 
 		PlayerCfg.AutoLeveling			= m[0].value;
 		PlayerCfg.MissileViewEnabled   		= m[1].value;
@@ -2096,29 +2173,45 @@ void do_misc_menu()
 		PlayerCfg.VulcanAmmoWarnings = m[21].value; 
 		PlayerCfg.ShieldWarnings = m[22].value;
 		PlayerCfg.AutoDemo = m[23].value;
-		PlayerCfg.ShowCustomColors = m[26].value;
+		PlayerCfg.ShowCustomColors = m[28].value;
+		PlayerCfg.PreferMyTeamColors = (PlayerCfg.MyTeamColor == 8 && PlayerCfg.OtherTeamColor == 8) ? 0 : m[33].value;
 
 	} while( i>-1 );
 
 }
 
-int menu_misc_options_handler ( newmenu *menu, d_event *event, void *userdata )
+int menu_misc_options_handler(newmenu* menu, d_event* event, void* userdata)
 {
 	newmenu_item *menus = newmenu_get_items(menu);
 	int citem = newmenu_get_citem(menu);
+	struct misc_menu_data* menu_data = (struct misc_menu_data*)userdata;
 	
-	if (event->type == EVENT_NEWMENU_CHANGED)
-	{
-		if (citem == 24) {
-			PlayerCfg.ShipColor = menus[24].value;
-			print_ship_color(menus[24].text, PlayerCfg.ShipColor);
-			
-		} else if (citem == 25) {
-			PlayerCfg.MissileColor = menus[25].value;
-			print_missile_color(menus[25].text, PlayerCfg.MissileColor);
-			
+	if (event->type == EVENT_NEWMENU_CHANGED) {
+		if (citem == 26) {
+			PlayerCfg.ShipColor = menus[26].value;
+			print_ship_color(menu_data->preferred_color, SDL_arraysize(menu_data->preferred_color),
+				PlayerCfg.ShipColor);
+		} else if (citem == 27) {
+			PlayerCfg.MissileColor = menus[27].value;
+			print_missile_color(menu_data->missile_color, SDL_arraysize(menu_data->missile_color),
+				PlayerCfg.MissileColor);
+		} else if (citem == 31) {
+			PlayerCfg.MyTeamColor = menus[31].value;
+			print_my_team_color(menu_data->my_team_color, SDL_arraysize(menu_data->my_team_color),
+				PlayerCfg.MyTeamColor);
+		} else if (citem == 32) {
+			PlayerCfg.OtherTeamColor = menus[32].value;
+			print_other_team_color(menu_data->other_team_color, SDL_arraysize(menu_data->other_team_color),
+				PlayerCfg.OtherTeamColor);
 		}
 
+		if (PlayerCfg.MyTeamColor == 8 && PlayerCfg.OtherTeamColor == 8) {
+			menus[33].type = NM_TYPE_TEXT;
+			menus[33].text = "Ignore Per-Game Team Colors (N/A)";
+		} else {
+			menus[33].type = NM_TYPE_CHECK;
+			menus[33].text = "Ignore Per-Game Team Colors";
+		}
 	}
 
 	return 0;

--- a/d2/main/menu.c
+++ b/d2/main/menu.c
@@ -2178,6 +2178,12 @@ void do_misc_menu()
 
 	} while( i>-1 );
 
+	// Update team colors if they were changed during a game
+	if ((Game_mode & GM_TEAM) && (Network_status == NETSTAT_PLAYING)) {
+		for (int i = 0; i < N_players; i++)
+			if (Players[i].connected)
+				multi_reset_object_texture(&Objects[Players[i].objnum]);
+	}
 }
 
 int menu_misc_options_handler(newmenu* menu, d_event* event, void* userdata)

--- a/d2/main/multi.h
+++ b/d2/main/multi.h
@@ -531,7 +531,6 @@ typedef struct netgame_info
 	short						ShowEnemyNames;
 	short						BrightPlayers;
 	char						team_name[2][CALLSIGN_LEN+1];
-	ubyte						team_color[2];
 	signed char						TeamKillGoalCount[2]; 
 	int						locations[MAX_PLAYERS];
 	short						kills[MAX_PLAYERS][MAX_PLAYERS];
@@ -574,6 +573,7 @@ typedef struct netgame_info
 	ubyte						AllowCustomModelsTextures;
 	ubyte						ReducedFlash;
 	ubyte						DisableGaussSplash;
+	ubyte						team_color[2];
 } __pack__ netgame_info;
 
 extern int Host_is_obs; // Reminder for host only that they are an observer.  Do not set for other players or observers.

--- a/d2/main/multi.h
+++ b/d2/main/multi.h
@@ -335,6 +335,7 @@ void multi_object_to_object_rw(object *obj, object_rw *obj_rw);
 void multi_object_rw_to_object(object_rw *obj_rw, object *obj);
 int get_color_for_player(int id, int missile);
 int get_color_for_team(int team);
+void multi_reset_object_texture(object* objp);
 void multi_send_obs_update(ubyte event, ubyte event_data);
 void multi_send_ship_status_for_frame();
 bool is_observing_player();

--- a/d2/main/multi.h
+++ b/d2/main/multi.h
@@ -334,7 +334,7 @@ void multi_disconnect_player(int pnum);
 void multi_object_to_object_rw(object *obj, object_rw *obj_rw);
 void multi_object_rw_to_object(object_rw *obj_rw, object *obj);
 int get_color_for_player(int id, int missile);
-int get_color_for_team(int team, int missile);
+int get_color_for_team(int team);
 void multi_send_obs_update(ubyte event, ubyte event_data);
 void multi_send_ship_status_for_frame();
 bool is_observing_player();
@@ -531,6 +531,7 @@ typedef struct netgame_info
 	short						ShowEnemyNames;
 	short						BrightPlayers;
 	char						team_name[2][CALLSIGN_LEN+1];
+	ubyte						team_color[2];
 	signed char						TeamKillGoalCount[2]; 
 	int						locations[MAX_PLAYERS];
 	short						kills[MAX_PLAYERS][MAX_PLAYERS];

--- a/d2/main/net_udp.c
+++ b/d2/main/net_udp.c
@@ -2998,6 +2998,8 @@ void net_udp_send_game_info(struct _sockaddr sender_addr, ubyte info_upid, ubyte
 		PUT_INTEL_SHORT(buf + len, Netgame.BrightPlayers);				len += 2;
 		len += 2; // Spawn invul -- no longer used, but don't break tools
 		memcpy(&buf[len], Netgame.team_name, 2*(CALLSIGN_LEN+1));			len += 2*(CALLSIGN_LEN+1);
+		buf[len] = Netgame.team_color[0];						len++;
+		buf[len] = Netgame.team_color[1];						len++;
 		for (i = 0; i < MAX_PLAYERS; i++)
 		{
 			PUT_INTEL_INT(buf + len, Netgame.locations[i]);				len += 4;
@@ -3246,6 +3248,8 @@ int net_udp_process_game_info(ubyte *data, int data_len, struct _sockaddr game_a
 		Netgame.BrightPlayers = GET_INTEL_SHORT(&(data[len]));				len += 2;
 		len += 2; // Spawn invul -- no longer used, but don't break tools
 		memcpy(Netgame.team_name, &(data[len]), 2*(CALLSIGN_LEN+1));			len += 2*(CALLSIGN_LEN+1);
+		Netgame.team_color[0] = data[len];						len++;
+		Netgame.team_color[1] = data[len];						len++;
 		for (i = 0; i < MAX_PLAYERS; i++)
 		{
 			Netgame.locations[i] = GET_INTEL_INT(&(data[len]));			len += 4;
@@ -4898,13 +4902,22 @@ int net_udp_send_sync(void)
 	return 0;
 }
 
+int net_udp_menu_select_teams_handler(newmenu* menu, d_event* event, void* userdata);
+
+struct select_teams_menu_data {
+	char team_names[2][CALLSIGN_LEN + 1];
+	ubyte team_colors[2];
+	int opt_team_a_color;
+	int opt_team_b_color;
+};
+
 int
 net_udp_select_teams(void)
 {
-	newmenu_item m[MAX_PLAYERS+4];
+	newmenu_item m[MAX_PLAYERS+7];
 	int choice, opt, opt_team_b;
 	ubyte team_vector = 0;
-	char team_names[2][CALLSIGN_LEN+1];
+	struct select_teams_menu_data menu_data;
 	int i;
 	int pnums[MAX_PLAYERS+2];
 
@@ -4915,63 +4928,128 @@ net_udp_select_teams(void)
 		team_vector |= (1 << i);
 	}
 
-	sprintf(team_names[0], "%s", TXT_BLUE);
-	sprintf(team_names[1], "%s", TXT_RED);
+	sprintf(menu_data.team_names[0], "%s", TXT_BLUE);
+	sprintf(menu_data.team_names[1], "%s", TXT_RED);
+	menu_data.team_colors[0] = menu_data.team_colors[1] = 8; // 8 = default
 
 	// Here comes da menu
-menu:
-	m[0].type = NM_TYPE_INPUT; m[0].text = team_names[0]; m[0].text_len = CALLSIGN_LEN; 
+	while (1) {
+		opt = 0;
 
-	opt = 1;
-	for (i = 0; i < N_players; i++)
-	{
-		if (!(team_vector & (1 << i)))
-		{
-			m[opt].type = NM_TYPE_MENU; m[opt].text = Netgame.players[i].callsign; pnums[opt] = i; opt++;
-		}
-	}
-	opt_team_b = opt;
-	m[opt].type = NM_TYPE_INPUT; m[opt].text = team_names[1]; m[opt].text_len = CALLSIGN_LEN; opt++;
-	for (i = 0; i < N_players; i++)
-	{
-		if (team_vector & (1 << i))
-		{
-			m[opt].type = NM_TYPE_MENU; m[opt].text = Netgame.players[i].callsign; pnums[opt] = i; opt++;
-		}
-	}
-	m[opt].type = NM_TYPE_TEXT; m[opt].text = ""; opt++;
-	m[opt].type = NM_TYPE_MENU; m[opt].text = TXT_ACCEPT; opt++;
+		menu_data.opt_team_a_color = opt;
+		m[opt].type = NM_TYPE_SLIDER;
+		m[opt].value = menu_data.team_colors[0];
+		m[opt].min_value = 0;
+		m[opt].max_value = 8;
+		m[opt].text = "Team 1 color: ";
+		opt++;
 
-	Assert(opt <= MAX_PLAYERS+4);
+		m[opt].type = NM_TYPE_INPUT;
+		m[opt].text = menu_data.team_names[0];
+		m[opt].text_len = CALLSIGN_LEN;
+		opt++;
+
+		// Team A player list
+		for (i = 0; i < N_players; i++)
+		{
+			if (!(team_vector & (1 << i)))
+			{
+				m[opt].type = NM_TYPE_MENU;
+				m[opt].text = Netgame.players[i].callsign;
+				pnums[opt] = i;
+				opt++;
+			}
+		}
+
+		opt_team_b = opt;
+
+		m[opt].type = NM_TYPE_TEXT;
+		m[opt].text = "";
+		opt++;
+
+		menu_data.opt_team_b_color = opt;
+		m[opt].type = NM_TYPE_SLIDER;
+		m[opt].value = menu_data.team_colors[1];
+		m[opt].min_value = 0;
+		m[opt].max_value = 8;
+		m[opt].text = "Team 2 color: ";
+		opt++;
+
+		m[opt].type = NM_TYPE_INPUT;
+		m[opt].text = menu_data.team_names[1];
+		m[opt].text_len = CALLSIGN_LEN;
+		opt++;
+
+		// Team B player list
+		for (i = 0; i < N_players; i++)
+		{
+			if (team_vector & (1 << i))
+			{
+				m[opt].type = NM_TYPE_MENU;
+				m[opt].text = Netgame.players[i].callsign;
+				pnums[opt] = i;
+				opt++;
+			}
+		}
+
+		m[opt].type = NM_TYPE_TEXT;
+		m[opt].text = "";
+		opt++;
+
+		m[opt].type = NM_TYPE_MENU;
+		m[opt].text = TXT_ACCEPT;
+		opt++;
+
+		Assert(opt <= SDL_arraysize(m));
 	
-	choice = newmenu_do(NULL, TXT_TEAM_SELECTION, opt, m, NULL, NULL);
+		choice = newmenu_do(NULL, TXT_TEAM_SELECTION, opt, m, net_udp_menu_select_teams_handler, &menu_data);
 
-	if (choice == opt-1)
-	{
-#if 0 // no need to wait for other players
-		if ((opt-2-opt_team_b < 2) || (opt_team_b == 1)) 
+		if (choice == opt-1)
 		{
-			nm_messagebox(NULL, 1, TXT_OK, TXT_TEAM_MUST_ONE);
-			#ifdef RELEASE
-			goto menu;
-			#endif
+			Netgame.team_vector = team_vector;
+			strcpy(Netgame.team_name[0], menu_data.team_names[0]);
+			strcpy(Netgame.team_name[1], menu_data.team_names[1]);
+			Netgame.team_color[0] = menu_data.team_colors[0];
+			Netgame.team_color[1] = menu_data.team_colors[1];
+			return 1;
 		}
-#endif
-		Netgame.team_vector = team_vector;
-		strcpy(Netgame.team_name[0], team_names[0]);
-		strcpy(Netgame.team_name[1], team_names[1]);
-		return 1;
+
+		else if ((choice > 0) && (choice < opt_team_b)) {
+			team_vector |= (1 << pnums[choice]);
+		}
+		else if ((choice > opt_team_b) && (choice < opt-2)) {
+			team_vector &= ~(1 << pnums[choice]);
+		}
+		else if (choice == -1)
+			return 0;
+	}
+}
+
+int net_udp_menu_select_teams_handler(newmenu* menu, d_event* event, void* userdata)
+{
+	newmenu_item* menus = newmenu_get_items(menu);
+	int citem = newmenu_get_citem(menu);
+	struct select_teams_menu_data* menu_data = (struct select_teams_menu_data*)userdata;
+
+	if (event->type == EVENT_NEWMENU_CHANGED) {
+		if (citem == menu_data->opt_team_a_color) {
+			menu_data->team_colors[0] = menus[citem].value;
+			if (menu_data->team_colors[0] == 8)
+				sprintf(menu_data->team_names[0], "%s", TXT_BLUE);
+			else
+				get_color_name(menu_data->team_names[0], SDL_arraysize(menu_data->team_names[0]),
+					menu_data->team_colors[0], Netgame.BlackAndWhitePyros);
+		} else if (citem == menu_data->opt_team_b_color) {
+			menu_data->team_colors[1] = menus[citem].value;
+			if (menu_data->team_colors[1] == 8)
+				sprintf(menu_data->team_names[1], "%s", TXT_RED);
+			else
+				get_color_name(menu_data->team_names[1], SDL_arraysize(menu_data->team_names[1]),
+					menu_data->team_colors[1], Netgame.BlackAndWhitePyros);
+		}
 	}
 
-	else if ((choice > 0) && (choice < opt_team_b)) {
-		team_vector |= (1 << pnums[choice]);
-	}
-	else if ((choice > opt_team_b) && (choice < opt-2)) {
-		team_vector &= ~(1 << pnums[choice]);
-	}
-	else if (choice == -1)
-		return 0;
-	goto menu;
+	return 0;
 }
 
 int

--- a/d2/main/net_udp.c
+++ b/d2/main/net_udp.c
@@ -2998,8 +2998,6 @@ void net_udp_send_game_info(struct _sockaddr sender_addr, ubyte info_upid, ubyte
 		PUT_INTEL_SHORT(buf + len, Netgame.BrightPlayers);				len += 2;
 		len += 2; // Spawn invul -- no longer used, but don't break tools
 		memcpy(&buf[len], Netgame.team_name, 2*(CALLSIGN_LEN+1));			len += 2*(CALLSIGN_LEN+1);
-		buf[len] = Netgame.team_color[0];						len++;
-		buf[len] = Netgame.team_color[1];						len++;
 		for (i = 0; i < MAX_PLAYERS; i++)
 		{
 			PUT_INTEL_INT(buf + len, Netgame.locations[i]);				len += 4;
@@ -3061,6 +3059,8 @@ void net_udp_send_game_info(struct _sockaddr sender_addr, ubyte info_upid, ubyte
 		buf[len] = Netgame.AllowCustomModelsTextures; len++;
 		buf[len] = Netgame.ReducedFlash; len++;
 		buf[len] = Netgame.DisableGaussSplash; len++;
+		buf[len] = Netgame.team_color[0];						len++;
+		buf[len] = Netgame.team_color[1];						len++;
 
 		if(info_upid == UPID_SYNC) {
 			PUT_INTEL_INT(buf + len, player_tokens[to_player]); len += 4; 
@@ -3248,8 +3248,6 @@ int net_udp_process_game_info(ubyte *data, int data_len, struct _sockaddr game_a
 		Netgame.BrightPlayers = GET_INTEL_SHORT(&(data[len]));				len += 2;
 		len += 2; // Spawn invul -- no longer used, but don't break tools
 		memcpy(Netgame.team_name, &(data[len]), 2*(CALLSIGN_LEN+1));			len += 2*(CALLSIGN_LEN+1);
-		Netgame.team_color[0] = data[len];						len++;
-		Netgame.team_color[1] = data[len];						len++;
 		for (i = 0; i < MAX_PLAYERS; i++)
 		{
 			Netgame.locations[i] = GET_INTEL_INT(&(data[len]));			len += 4;
@@ -3312,6 +3310,8 @@ int net_udp_process_game_info(ubyte *data, int data_len, struct _sockaddr game_a
 		Netgame.AllowCustomModelsTextures = data[len]; len++;
 		Netgame.ReducedFlash = data[len]; len++;
 		Netgame.DisableGaussSplash = data[len]; len++;
+		Netgame.team_color[0] = data[len];						len++;
+		Netgame.team_color[1] = data[len];						len++;
 
 		if (Netgame.host_is_obs) {
 			multi_make_player_ghost(0);

--- a/d2/main/net_udp.h
+++ b/d2/main/net_udp.h
@@ -50,7 +50,7 @@ void net_udp_send_obs_quit();
 #define UPID_GAME_INFO_REQ_SIZE			 13
 #define UPID_GAME_INFO_LITE_REQ_SIZE		 11
 #define UPID_GAME_INFO				  3 // Packet containing all info about a netgame.
-#define UPID_GAME_INFO_SIZE			(6 + 4*2 + 365 + (NETGAME_NAME_LEN+1) + (MISSION_NAME_LEN+1) + ((MAX_PLAYERS+4)*(CALLSIGN_LEN+1)) + 20*12)
+#define UPID_GAME_INFO_SIZE			(6 + 4*2 + 367 + (NETGAME_NAME_LEN+1) + (MISSION_NAME_LEN+1) + ((MAX_PLAYERS+4)*(CALLSIGN_LEN+1)) + 20*12)
 #define UPID_GAME_INFO_LITE_REQ			  4 // Requesting lite info about a netgame. Used for discovering games.
 #define UPID_GAME_INFO_LITE			  5 // Packet containing lite netgame info.
 #define UPID_GAME_INFO_LITE_SIZE		 (31 + (NETGAME_NAME_LEN+1) + (MISSION_NAME_LEN+1))

--- a/d2/main/playsave.c
+++ b/d2/main/playsave.c
@@ -134,10 +134,13 @@ int new_player_config()
 	PlayerCfg.ShieldWarnings = 0; 
 	PlayerCfg.AutoDemo = 1;
 	PlayerCfg.ShowCustomColors = 1;
+	PlayerCfg.PreferMyTeamColors = 0;
 	PlayerCfg.QuietPlasma = 1; 
 	PlayerCfg.maxFps = GameArg.SysMaxFPS; 
 	PlayerCfg.ShipColor = 8;
 	PlayerCfg.MissileColor = 8;
+	PlayerCfg.MyTeamColor = 8;
+	PlayerCfg.OtherTeamColor = 8;
 	PlayerCfg.ObsTurbo = 0;
 	PlayerCfg.ObsShowCockpit = 1;
 	PlayerCfg.ObsShowScoreboardShieldText = 1;
@@ -401,9 +404,15 @@ int read_player_d2x(char *filename)
 				if(!strcmp(word,"SHOWCUSTOMCOLORS"))
 					PlayerCfg.ShowCustomColors = atoi(line);
 				if(!strcmp(word,"SHIPCOLOR"))
-					PlayerCfg.ShipColor = atoi(line);	
+					PlayerCfg.ShipColor = atoi(line);
 				if(!strcmp(word,"MISSILECOLOR"))
 					PlayerCfg.MissileColor = atoi(line);
+				if (!strcmp(word, "OVERRIDETEAMCOLORS"))
+					PlayerCfg.PreferMyTeamColors = atoi(line);
+				if (!strcmp(word, "MYTEAMCOLOR"))
+					PlayerCfg.MyTeamColor = atoi(line);
+				if (!strcmp(word, "OTHERTEAMCOLOR"))
+					PlayerCfg.OtherTeamColor = atoi(line);
 				if(!strcmp(word,"OBSTURBO"))
 					PlayerCfg.ObsTurbo = atoi(line);
 				if (!strcmp(word, "OBSSHOWCOCKPIT"))
@@ -626,6 +635,9 @@ int write_player_d2x(char *filename)
 		PHYSFSX_printf(fout,"showcustomcolors=%i\n",PlayerCfg.ShowCustomColors);
 		PHYSFSX_printf(fout,"shipcolor=%i\n",PlayerCfg.ShipColor);	
 		PHYSFSX_printf(fout,"missilecolor=%i\n",PlayerCfg.MissileColor);
+		PHYSFSX_printf(fout, "overrideteamcolors=%i\n", PlayerCfg.PreferMyTeamColors);
+		PHYSFSX_printf(fout, "myteamcolor=%i\n", PlayerCfg.MyTeamColor);
+		PHYSFSX_printf(fout, "otherteamcolor=%i\n", PlayerCfg.OtherTeamColor);
 		PHYSFSX_printf(fout,"obsturbo=%i\n",PlayerCfg.ObsTurbo);
 		PHYSFSX_printf(fout,"obsshowcockpit=%i\n",PlayerCfg.ObsShowCockpit);
 		PHYSFSX_printf(fout,"obsshowscoreboardshieldtext=%i\n",PlayerCfg.ObsShowScoreboardShieldText);

--- a/d2/main/playsave.h
+++ b/d2/main/playsave.h
@@ -85,18 +85,21 @@ typedef struct player_config
 	ubyte NoFireAutoselect;
 	ubyte CycleAutoselectOnly;
 	ubyte VulcanAmmoWarnings;
-	ubyte ShieldWarnings; 
+	ubyte ShieldWarnings;
 	ubyte AutoDemo;
 	ubyte ShowCustomColors;
-	ubyte QuietPlasma; 	
+	ubyte PreferMyTeamColors;
+	ubyte QuietPlasma;
 	int AlphaEffects;
 	int DynLightColor;
-	ubyte DisableCockpit;  /* DisableCockpit */ 
-	ubyte StickyRearview; /* StickyRearview */ 
-	ubyte SelectAfterFire; /* SelectAfterFire */ 	
+	ubyte DisableCockpit;  /* DisableCockpit */
+	ubyte StickyRearview; /* StickyRearview */
+	ubyte SelectAfterFire; /* SelectAfterFire */
 	int maxFps;
-	int ShipColor;	
+	int ShipColor;
 	int MissileColor;
+	int MyTeamColor;
+	int OtherTeamColor;
 	ubyte ObsTurbo;
 	ubyte ObsShowCockpit;
 	ubyte ObsShowScoreboardShieldText;


### PR DESCRIPTION
Custom team colors were technically supported by Redux, but were chosen based on the custom ship color of the first player encountered from that team, which is a difficult system to understand (to many players, maybe even most, it seems like a bug). I asked a few people how they would prefer the system to work, and got a couple main answers, so I decided to support both.

1. Game hosts can now choose the color they want each team to use. The right-most value reverts to defaults (blue for team 1, red for team 2). Other values force specific team colors. It is possible to set both teams to use the same color; however, it's difficult to do so by accident, so I didn't see a reason to prevent people from doing this if they really want to.
2. I added an option to the Misc Settings menu where players can specify team color settings they want to see instead of the defaults. This system lets you set your teammates to a constant color, and your opponents to a constant color - regardless of whether you are on team 1 or 2. The OLMod extension for Overload uses this system, and it has proven popular for team games there. There is a toggle box giving you the option to override the game host's team color choices if you want; otherwise, it will only apply if they select defaults.

Resolves #35.