### PR TITLE
Fix wall blast message crash on Windows

### DIFF
--- a/d1/main/fireball.c
+++ b/d1/main/fireball.c
@@ -196,8 +196,9 @@ object *object_create_explosion_sub(object *objp, short segnum, vms_vector * pos
 										multi_send_damage(damage, obj0p->shields, killer->type, killer->id, DAMAGE_BLAST, objp);
 									} else if ((obj0p->id == Player_num) && (! Player_is_dead)) {
 										con_printf(CON_NORMAL, "You took %.1f damage from a %s blast, shields now %.1f\n",
+											f2fl(damage),
 											obj_type == OBJ_WALL ? "wall" : obj_type == OBJ_ROBOT ? "robot" : "unknown",
-											f2fl(damage), f2fl(Players[Player_num].shields - damage));
+											f2fl(Players[Player_num].shields - damage));
 
 										multi_send_damage(damage, obj0p->shields, obj_type, 0, DAMAGE_BLAST, objp);
 									}

--- a/d2/main/fireball.c
+++ b/d2/main/fireball.c
@@ -279,8 +279,9 @@ object *object_create_explosion_sub(object *objp, short segnum, vms_vector * pos
 										multi_send_damage(damage, obj0p->shields, killer->type, killer->id, DAMAGE_BLAST, objp);
 									} else if ((obj0p->id == Player_num) && (! Player_is_dead)) {
 										con_printf(CON_NORMAL, "You took %.1f damage from a %s blast, shields now %.1f\n",
+											f2fl(damage),
 											obj_type == OBJ_WALL ? "wall" : obj_type == OBJ_ROBOT ? "robot" : "unknown",
-											f2fl(damage), f2fl(Players[Player_num].shields - damage));
+											f2fl(Players[Player_num].shields - damage));
 
 										multi_send_damage(damage, obj0p->shields, obj_type, 0, DAMAGE_BLAST, objp);
 									}


### PR DESCRIPTION
The reversed arguments did work on linux because there float and non-float arguments are separate. But it crashed on Windows.