### PR TITLE
Fix keyboard slide left sensitivity setting

### DIFF
--- a/d1/main/kconfig.c
+++ b/d1/main/kconfig.c
@@ -1594,7 +1594,7 @@ void kconfig_read_controls(d_event *event, int automap_flag)
 	if ( Controls.key_slide_left_state )
 	{
 		if ( Controls.key_slide_left_down_time < F1_0 )
-			Controls.key_slide_left_down_time += (!Controls.key_slide_left_down_time)?F1_0*((float)PlayerCfg.KeyboardSens[1]/16)+1:FrameTime/4;
+			Controls.key_slide_left_down_time += (!Controls.key_slide_left_down_time)?F1_0*((float)PlayerCfg.KeyboardSens[2]/16)+1:FrameTime/4;
 		Controls.sideways_thrust_time -= speed_factor*FrameTime*(Controls.key_slide_left_down_time/F1_0);
 	}
 	else

--- a/d2/main/kconfig.c
+++ b/d2/main/kconfig.c
@@ -1631,7 +1631,7 @@ void kconfig_read_controls(d_event *event, int automap_flag)
 	if ( Controls.key_slide_left_state )
 	{
 		if ( Controls.key_slide_left_down_time < F1_0 )
-			Controls.key_slide_left_down_time += (!Controls.key_slide_left_down_time)?F1_0*((float)PlayerCfg.KeyboardSens[1]/16)+1:FrameTime/4;
+			Controls.key_slide_left_down_time += (!Controls.key_slide_left_down_time)?F1_0*((float)PlayerCfg.KeyboardSens[2]/16)+1:FrameTime/4;
 		Controls.sideways_thrust_time -= speed_factor*FrameTime*(Controls.key_slide_left_down_time/F1_0);
 	}
 	else


### PR DESCRIPTION
Keyboard slide left used the pitch instead of the slide keyboard sensitivity setting.