### PR TITLE
Observer mode: Count all laser types as the same category for damage summary

### DIFF
--- a/d1/main/multi.c
+++ b/d1/main/multi.c
@@ -280,6 +280,12 @@ void add_observatory_damage_stat(int player_num, fix shields_delta, fix new_shie
         source_id = SHIP_COLLISION_DAMAGE;
     }
 
+	// Combine different laser levels into the same source_id. They aren't named differently in
+	// weapon_id_to_name, so we don't want them split up in summaries.
+	if (killer_type == OBJ_PLAYER && damage_type == DAMAGE_WEAPON && source_id > LASER_ID_L1 && source_id <= LASER_ID_L4) {
+		source_id = LASER_ID_L1;
+	}
+
 	// Record player's damage over time.
 	shield_status* sta = (shield_status*)d_malloc(sizeof(shield_status));
 	sta->timestamp = GameTime64;

--- a/d1/main/multi.h
+++ b/d1/main/multi.h
@@ -604,16 +604,16 @@ typedef struct shield_status {
 	struct shield_status* next;
 } __pack__ shield_status;
 
-// The first shield status for the current point.
+// The beginning of the shield status list for the current point.
 extern shield_status* First_current_shield_status[MAX_PLAYERS];
 
-// The last shield status for the current point.  Used to append the next status.
+// The end of the shield status list for the current point.  Used to append the next status.
 extern shield_status* Last_current_shield_status[MAX_PLAYERS];
 
-// The first shield status for the previous point.
+// The beginning of the shield status list for the previous point.
 extern shield_status* First_previous_shield_status[MAX_PLAYERS];
 
-// The last shield status for the current point.  Used to display the killing blow.
+// The end of the shield status list for the current point.  Used to display the killing blow.
 extern shield_status* Last_previous_shield_status[MAX_PLAYERS];
 
 // When to show the death summary until.
@@ -633,13 +633,13 @@ typedef struct damage_taken_totals {
 	struct damage_taken_totals* prev;
 } __pack__ damage_taken_totals;
 
-// The first damage taken totals overall.
+// The beginning of the list of overall (for the whole game) damage taken totals.
 extern damage_taken_totals* First_damage_taken_totals[MAX_PLAYERS];
 
-// The first damage taken totals for the current point.
+// The beginning of the list of damage taken totals for the current point.
 extern damage_taken_totals* First_damage_taken_current_totals[MAX_PLAYERS];
 
-// The first damage taken totals for the previous point.
+// The beginning of the list of damage taken totals for the previous point.
 extern damage_taken_totals* First_damage_taken_previous_totals[MAX_PLAYERS];
 
 // Defines damage done totals for a single source.  Doubly linked list.
@@ -650,7 +650,7 @@ typedef struct damage_done_totals {
 	struct damage_done_totals* prev;
 } __pack__ damage_done_totals;
 
-// The first damage done totals.
+// The beginning of the list of damage done totals.
 extern damage_done_totals* First_damage_done_totals[MAX_PLAYERS];
 
 // Defines a kill for the kill log.  Singly linked list.

--- a/d1/vcpkg.json
+++ b/d1/vcpkg.json
@@ -1,19 +1,19 @@
 {
-    "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
-    "name": "d1x-redux",
-    "version-semver": "0.9.0",
-    "dependencies": [
-        "physfs",
-        "sdl1",
-        "sdl1-mixer",
-        "libpng",
-        "glew"
-    ],
-    "vcpkg-configuration": {
-        "default-registry": {
-            "kind": "git",
-            "baseline": "2c401863dd54a640aeb26ed736c55489c079323b",
-            "repository": "https://github.com/microsoft/vcpkg"
-        }
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
+  "name": "d1x-redux",
+  "version-semver": "0.9.0",
+  "dependencies": [
+    "physfs",
+    "sdl1",
+    "sdl1-mixer",
+    "libpng",
+    "glew"
+  ],
+  "vcpkg-configuration": {
+    "default-registry": {
+      "kind": "git",
+      "baseline": "2c401863dd54a640aeb26ed736c55489c079323b",
+      "repository": "https://github.com/microsoft/vcpkg"
     }
+  }
 }

--- a/d1/vcpkg.json
+++ b/d1/vcpkg.json
@@ -1,12 +1,19 @@
 {
-  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
-  "name": "d1x-redux",
-  "version-semver": "0.9.0",
-  "dependencies": [
-    "physfs",
-    "sdl1",
-    "sdl1-mixer",
-    "libpng",
-    "glew"
-  ]
+    "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
+    "name": "d1x-redux",
+    "version-semver": "0.9.0",
+    "dependencies": [
+        "physfs",
+        "sdl1",
+        "sdl1-mixer",
+        "libpng",
+        "glew"
+    ],
+    "vcpkg-configuration": {
+        "default-registry": {
+            "kind": "git",
+            "baseline": "2c401863dd54a640aeb26ed736c55489c079323b",
+            "repository": "https://github.com/microsoft/vcpkg"
+        }
+    }
 }

--- a/d2/main/multi.c
+++ b/d2/main/multi.c
@@ -287,6 +287,12 @@ void add_observatory_damage_stat(int player_num, fix shields_delta, fix new_shie
 		source_id = SHIP_COLLISION_DAMAGE;
 	}
 
+	// Combine different laser levels into the same source_id. They aren't named differently in
+	// weapon_id_to_name, so we don't want them split up in summaries.
+	if (killer_type == OBJ_PLAYER && damage_type == DAMAGE_WEAPON && source_id > LASER_ID_L1 && source_id <= LASER_ID_L6) {
+		source_id = LASER_ID_L1;
+	}
+
 	// Record player's damage over time.
 	shield_status* sta = (shield_status*)d_malloc(sizeof(shield_status));
 	sta->timestamp = GameTime64;

--- a/d2/main/multi.c
+++ b/d2/main/multi.c
@@ -289,7 +289,10 @@ void add_observatory_damage_stat(int player_num, fix shields_delta, fix new_shie
 
 	// Combine different laser levels into the same source_id. They aren't named differently in
 	// weapon_id_to_name, so we don't want them split up in summaries.
-	if (killer_type == OBJ_PLAYER && damage_type == DAMAGE_WEAPON && source_id > LASER_ID_L1 && source_id <= LASER_ID_L6) {
+	// There is a gap between normal laser levels and super laser levels, so we have to check
+	// each range separately.
+	if (killer_type == OBJ_PLAYER && damage_type == DAMAGE_WEAPON && 
+		((source_id > LASER_ID_L1 && source_id <= LASER_ID_L4) || (source_id >= LASER_ID_L5 && source_id <= LASER_ID_L6))) {
 		source_id = LASER_ID_L1;
 	}
 

--- a/d2/main/multi.h
+++ b/d2/main/multi.h
@@ -666,16 +666,16 @@ typedef struct shield_status {
 	struct shield_status* next;
 } __pack__ shield_status;
 
-// The first shield status for the current point.
+// The beginning of the shield status list for the current point.
 extern shield_status* First_current_shield_status[MAX_PLAYERS];
 
-// The last shield status for the current point.  Used to append the next status.
+// The end of the shield status list for the current point.  Used to append the next status.
 extern shield_status* Last_current_shield_status[MAX_PLAYERS];
 
-// The first shield status for the previous point.
+// The beginning of the shield status list for the previous point.
 extern shield_status* First_previous_shield_status[MAX_PLAYERS];
 
-// The last shield status for the current point.  Used to display the killing blow.
+// The end of the shield status list for the current point.  Used to display the killing blow.
 extern shield_status* Last_previous_shield_status[MAX_PLAYERS];
 
 // When to show the death summary until.
@@ -695,13 +695,13 @@ typedef struct damage_taken_totals {
 	struct damage_taken_totals* prev;
 } __pack__ damage_taken_totals;
 
-// The first damage taken totals overall.
+// The beginning of the list of overall (for the whole game) damage taken totals.
 extern damage_taken_totals* First_damage_taken_totals[MAX_PLAYERS];
 
-// The first damage taken totals for the current point.
+// The beginning of the list of damage taken totals for the current point.
 extern damage_taken_totals* First_damage_taken_current_totals[MAX_PLAYERS];
 
-// The first damage taken totals for the previous point.
+// The beginning of the list of damage taken totals for the previous point.
 extern damage_taken_totals* First_damage_taken_previous_totals[MAX_PLAYERS];
 
 // Defines damage done totals for a single source.  Doubly linked list.
@@ -712,7 +712,7 @@ typedef struct damage_done_totals {
 	struct damage_done_totals* prev;
 } __pack__ damage_done_totals;
 
-// The first damage done totals.
+// The beginning of the list of damage done totals.
 extern damage_done_totals* First_damage_done_totals[MAX_PLAYERS];
 
 // Defines a kill for the kill log.  Singly linked list.

--- a/d2/vcpkg.json
+++ b/d2/vcpkg.json
@@ -1,19 +1,19 @@
 {
-    "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
-    "name": "d2x-redux",
-    "version-semver": "0.9.0",
-    "dependencies": [
-        "physfs",
-        "sdl1",
-        "sdl1-mixer",
-        "libpng",
-        "glew"
-    ],
-    "vcpkg-configuration": {
-        "default-registry": {
-            "kind": "git",
-            "baseline": "2c401863dd54a640aeb26ed736c55489c079323b",
-            "repository": "https://github.com/microsoft/vcpkg"
-        }
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
+  "name": "d2x-redux",
+  "version-semver": "0.9.0",
+  "dependencies": [
+    "physfs",
+    "sdl1",
+    "sdl1-mixer",
+    "libpng",
+    "glew"
+  ],
+  "vcpkg-configuration": {
+    "default-registry": {
+      "kind": "git",
+      "baseline": "2c401863dd54a640aeb26ed736c55489c079323b",
+      "repository": "https://github.com/microsoft/vcpkg"
     }
+  }
 }

--- a/d2/vcpkg.json
+++ b/d2/vcpkg.json
@@ -1,12 +1,19 @@
 {
-  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
-  "name": "d2x-redux",
-  "version-semver": "0.9.0",
-  "dependencies": [
-    "physfs",
-    "sdl1",
-    "sdl1-mixer",
-    "libpng",
-    "glew"
-  ]
+    "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
+    "name": "d2x-redux",
+    "version-semver": "0.9.0",
+    "dependencies": [
+        "physfs",
+        "sdl1",
+        "sdl1-mixer",
+        "libpng",
+        "glew"
+    ],
+    "vcpkg-configuration": {
+        "default-registry": {
+            "kind": "git",
+            "baseline": "2c401863dd54a640aeb26ed736c55489c079323b",
+            "repository": "https://github.com/microsoft/vcpkg"
+        }
+    }
 }


### PR DESCRIPTION
This change resolves #54. I decided to merge the weapon types together in add_observatory_damage_stat instead of just reporting them together, since there didn't appear to be any observer code that actually needed to consider different laser levels separately.
There is also a minor change where I added a vcpkg-configuration field to vcpkg.json; some recent versions of VS seem to insist on this being present.