### PR TITLE
Suppress kill/death messages w/ observer death log

### DIFF
--- a/d1/main/hud.c
+++ b/d1/main/hud.c
@@ -120,6 +120,11 @@ static int is_worth_showing(int class_flag)
 
 	if (PlayerCfg.MultiMessages && (Game_mode & GM_MULTI) && !(class_flag & HM_MULTI))
 		return 0;
+
+	// Don't show kill feed messages if the observer death log is active; they're redundant
+	if (is_observer() && PlayerCfg.ObsShowKillFeed && (class_flag & HM_KILLFEED))
+		return 0;
+
 	return 1;
 }
 

--- a/d1/main/hudmsg.h
+++ b/d1/main/hudmsg.h
@@ -12,6 +12,7 @@
 #define HM_MULTI		2 // a message related to multiplayer (game and player messages)
 #define HM_REDUNDANT		4 // "you already have..."-type messages. stuff a player is able to supress
 #define HM_MAYDUPL		8 // messages that might appear once per frame. for these we want to check all messages we have  in queue and supress it if so
+#define HM_KILLFEED		0x10 // messages describing multiplayer kills/deaths
 
 extern int HUD_toolong;
 extern void HUD_clear_messages();

--- a/d1/main/multi.c
+++ b/d1/main/multi.c
@@ -1137,13 +1137,13 @@ void multi_compute_kill(int killer, int killed)
 
 		if (killed_pnum == Player_num)
 		{
-			HUD_init_message(HM_MULTI, "%s %s.", TXT_YOU_WERE, TXT_KILLED_BY_NONPLAY);
+			HUD_init_message(HM_MULTI | HM_KILLFEED, "%s %s.", TXT_YOU_WERE, TXT_KILLED_BY_NONPLAY);
 			multi_add_lifetime_killed ();
 
 			robo_anarchy_suicide_penalty();
 		}
 		else
-			HUD_init_message(HM_MULTI, "%s %s %s.", killed_name, TXT_WAS, TXT_KILLED_BY_NONPLAY );
+			HUD_init_message(HM_MULTI | HM_KILLFEED, "%s %s %s.", killed_name, TXT_WAS, TXT_KILLED_BY_NONPLAY );
 		
 		add_observatory_stat(killed_pnum, OBSEV_DEATH | OBSEV_REACTOR);
 
@@ -1154,13 +1154,13 @@ void multi_compute_kill(int killer, int killed)
 	{
 			if (killed_pnum == Player_num)
 			{
-				HUD_init_message(HM_MULTI, "%s %s.", TXT_YOU_WERE, TXT_KILLED_BY_ROBOT);
+				HUD_init_message(HM_MULTI | HM_KILLFEED, "%s %s.", TXT_YOU_WERE, TXT_KILLED_BY_ROBOT);
 				multi_add_lifetime_killed();
 
 				robo_anarchy_suicide_penalty();
 			}
 			else
-				HUD_init_message(HM_MULTI, "%s %s %s.", killed_name, TXT_WAS, TXT_KILLED_BY_ROBOT );
+				HUD_init_message(HM_MULTI | HM_KILLFEED, "%s %s %s.", killed_name, TXT_WAS, TXT_KILLED_BY_ROBOT );
 		Players[killed_pnum].net_killed_total++;
 
 		add_observatory_stat(killed_pnum, OBSEV_DEATH | OBSEV_ROBOT);
@@ -1200,11 +1200,11 @@ void multi_compute_kill(int killer, int killed)
 		kill_matrix[killed_pnum][killed_pnum] += 1; // # of suicides
 		if (killer_pnum == Player_num)
 		{
-			HUD_init_message(HM_MULTI, "%s %s %s!", TXT_YOU, TXT_KILLED, TXT_YOURSELF );
+			HUD_init_message(HM_MULTI | HM_KILLFEED, "%s %s %s!", TXT_YOU, TXT_KILLED, TXT_YOURSELF );
 			multi_add_lifetime_killed();
 		}
 		else
-			HUD_init_message(HM_MULTI, "%s %s", killed_name, TXT_SUICIDE);
+			HUD_init_message(HM_MULTI | HM_KILLFEED, "%s %s", killed_name, TXT_SUICIDE);
 
 		/* Bounty mode needs some lovin' */
 		if( Game_mode & GM_BOUNTY && killed_pnum == Bounty_target && multi_i_am_master() )
@@ -1278,7 +1278,7 @@ void multi_compute_kill(int killer, int killed)
 		}
 
 		if (killer_pnum == Player_num) {
-			HUD_init_message(HM_MULTI, "%s %s %s!", TXT_YOU, TXT_KILLED, killed_name);
+			HUD_init_message(HM_MULTI | HM_KILLFEED, "%s %s %s!", TXT_YOU, TXT_KILLED, killed_name);
 			multi_add_lifetime_kills();
 			if ((Game_mode & GM_MULTI_COOP) && (Players[Player_num].score >= 1000))
 				add_points_to_score(-1000);
@@ -1288,11 +1288,11 @@ void multi_compute_kill(int killer, int killed)
 		}
 		else if (killed_pnum == Player_num)
 		{
-			HUD_init_message(HM_MULTI, "%s %s %s!", killer_name, TXT_KILLED, TXT_YOU);
+			HUD_init_message(HM_MULTI | HM_KILLFEED, "%s %s %s!", killer_name, TXT_KILLED, TXT_YOU);
 			multi_add_lifetime_killed();
 		}
 		else
-			HUD_init_message(HM_MULTI, "%s %s %s!", killer_name, TXT_KILLED, killed_name);
+			HUD_init_message(HM_MULTI | HM_KILLFEED, "%s %s %s!", killer_name, TXT_KILLED, killed_name);
 
 		add_observatory_stat(killed_pnum, OBSEV_DEATH | OBSEV_PLAYER);
 		add_observatory_stat(killer_pnum, OBSEV_KILL | OBSEV_PLAYER);

--- a/d2/main/hud.c
+++ b/d2/main/hud.c
@@ -124,6 +124,11 @@ static int is_worth_showing(int class_flag)
 
 	if (PlayerCfg.MultiMessages && (Game_mode & GM_MULTI) && !(class_flag & HM_MULTI))
 		return 0;
+
+	// Don't show kill feed messages if the observer death log is active; they're redundant
+	if (is_observer() && PlayerCfg.ObsShowKillFeed && (class_flag & HM_KILLFEED))
+		return 0;
+
 	return 1;
 }
 

--- a/d2/main/hudmsg.h
+++ b/d2/main/hudmsg.h
@@ -12,6 +12,7 @@
 #define HM_MULTI		2 // a message related to multiplayer (game and player messages)
 #define HM_REDUNDANT		4 // "you already have..."-type messages. stuff a player is able to supress
 #define HM_MAYDUPL		8 // messages that might appear once per frame. for these we want to check all messages we have  in queue and supress it if so
+#define HM_KILLFEED		0x10 // messages describing multiplayer kills/deaths
 
 extern int HUD_toolong;
 extern void HUD_clear_messages();

--- a/d2/main/multi.c
+++ b/d2/main/multi.c
@@ -1151,13 +1151,13 @@ void multi_compute_kill(int killer, int killed)
 
 		if (killed_pnum == Player_num)
 		{
-			HUD_init_message(HM_MULTI, "%s %s.", TXT_YOU_WERE, TXT_KILLED_BY_NONPLAY);
+			HUD_init_message(HM_MULTI | HM_KILLFEED, "%s %s.", TXT_YOU_WERE, TXT_KILLED_BY_NONPLAY);
 			multi_add_lifetime_killed ();
 
 			robo_anarchy_suicide_penalty();
 		}
 		else
-			HUD_init_message(HM_MULTI, "%s %s %s.", killed_name, TXT_WAS, TXT_KILLED_BY_NONPLAY );
+			HUD_init_message(HM_MULTI | HM_KILLFEED, "%s %s %s.", killed_name, TXT_WAS, TXT_KILLED_BY_NONPLAY );
 
 		add_observatory_stat(killed_pnum, OBSEV_DEATH | OBSEV_REACTOR);
 
@@ -1169,21 +1169,21 @@ void multi_compute_kill(int killer, int killed)
 		if (killer_id==PMINE_ID && killer_type!=OBJ_ROBOT)
 		{
 			if (killed_pnum == Player_num)
-				HUD_init_message_literal(HM_MULTI, "You were killed by a mine!");
+				HUD_init_message_literal(HM_MULTI | HM_KILLFEED, "You were killed by a mine!");
 			else
-				HUD_init_message(HM_MULTI, "%s was killed by a mine!",killed_name);
+				HUD_init_message(HM_MULTI | HM_KILLFEED, "%s was killed by a mine!",killed_name);
 		}
 		else
 		{
 			if (killed_pnum == Player_num)
 			{
-				HUD_init_message(HM_MULTI, "%s %s.", TXT_YOU_WERE, TXT_KILLED_BY_ROBOT);
+				HUD_init_message(HM_MULTI | HM_KILLFEED, "%s %s.", TXT_YOU_WERE, TXT_KILLED_BY_ROBOT);
 				multi_add_lifetime_killed();
 
 				robo_anarchy_suicide_penalty();
 			}
 			else
-				HUD_init_message(HM_MULTI, "%s %s %s.", killed_name, TXT_WAS, TXT_KILLED_BY_ROBOT );
+				HUD_init_message(HM_MULTI | HM_KILLFEED, "%s %s %s.", killed_name, TXT_WAS, TXT_KILLED_BY_ROBOT );
 		}
 		Players[killed_pnum].net_killed_total++;
 
@@ -1227,11 +1227,11 @@ void multi_compute_kill(int killer, int killed)
 
 		if (killer_pnum == Player_num)
 		{
-			HUD_init_message(HM_MULTI, "%s %s %s!", TXT_YOU, TXT_KILLED, TXT_YOURSELF );
+			HUD_init_message(HM_MULTI | HM_KILLFEED, "%s %s %s!", TXT_YOU, TXT_KILLED, TXT_YOURSELF );
 			multi_add_lifetime_killed();
 		}
 		else
-			HUD_init_message(HM_MULTI, "%s %s", killed_name, TXT_SUICIDE);
+			HUD_init_message(HM_MULTI | HM_KILLFEED, "%s %s", killed_name, TXT_SUICIDE);
 
 		/* Bounty mode needs some lovin' */
 		if( Game_mode & GM_BOUNTY && killed_pnum == Bounty_target && multi_i_am_master() )
@@ -1308,7 +1308,7 @@ void multi_compute_kill(int killer, int killed)
 		}
 
 		if (killer_pnum == Player_num) {
-			HUD_init_message(HM_MULTI, "%s %s %s!", TXT_YOU, TXT_KILLED, killed_name);
+			HUD_init_message(HM_MULTI | HM_KILLFEED, "%s %s %s!", TXT_YOU, TXT_KILLED, killed_name);
 			multi_add_lifetime_kills();
 			if ((Game_mode & GM_MULTI_COOP) && (Players[Player_num].score >= 1000))
 				add_points_to_score(-1000);
@@ -1318,7 +1318,7 @@ void multi_compute_kill(int killer, int killed)
 		}
 		else if (killed_pnum == Player_num)
 		{
-			HUD_init_message(HM_MULTI, "%s %s %s!", killer_name, TXT_KILLED, TXT_YOU);
+			HUD_init_message(HM_MULTI | HM_KILLFEED, "%s %s %s!", killer_name, TXT_KILLED, TXT_YOU);
 			multi_add_lifetime_killed();
 			if (Game_mode & GM_HOARD)
 			{
@@ -1329,7 +1329,7 @@ void multi_compute_kill(int killer, int killed)
 			}
 		}
 		else
-			HUD_init_message(HM_MULTI, "%s %s %s!", killer_name, TXT_KILLED, killed_name);
+			HUD_init_message(HM_MULTI | HM_KILLFEED, "%s %s %s!", killer_name, TXT_KILLED, killed_name);
 
 		add_observatory_stat(killed_pnum, OBSEV_DEATH | OBSEV_PLAYER);
 		add_observatory_stat(killer_pnum, OBSEV_KILL | OBSEV_PLAYER);


### PR DESCRIPTION
Overheard on @roncli 's stream that the "someone killed someone!" messages are kind of redundant when there is a death log / kill feed displayed in observer mode. I agreed, so I added a new flag to the relevant messages to allow is_worth_showing to filter them out when ObsShowKillFeed is enabled.