### PR TITLE
Add observer option to show proximity bomb / smart mine timeouts

### DIFF
--- a/d1/main/gauges.c
+++ b/d1/main/gauges.c
@@ -3902,6 +3902,75 @@ int see_object(int objnum)
 	return (hit_type == HIT_OBJECT && hit_data.hit_object == objnum);
 }
 
+// Show bomb highlights in observer mode
+void observer_show_bomb_highlights()
+{
+	if (!is_observer() || !PlayerCfg.ObsShowBombTimes)
+	{
+		return;
+	}
+
+	// Find oldest bomb for each player
+	// Technically it'd be more efficient to cache this and update it when a bomb is created or
+	// destroyed, but it'd also be a lot more cumbersome to implement, and this seems fast enough.
+	int oldest_bomb[MAX_PLAYERS];
+	for (int i = 0; i < MAX_PLAYERS; i++)
+		oldest_bomb[i] = -1;
+
+	for (int i = 0; i <= Highest_object_index; i++)
+	{
+		if (Objects[i].type == OBJ_WEAPON && Objects[i].id == PROXIMITY_ID)
+		{
+			if (Objects[i].ctype.laser_info.parent_type == OBJ_PLAYER)
+			{
+				int pnum = Objects[i].ctype.laser_info.parent_num;
+				if (pnum >= 0 && pnum < MAX_PLAYERS)
+				{
+					if (oldest_bomb[pnum] == -1 || Objects[i].lifeleft < Objects[oldest_bomb[pnum]].lifeleft)
+						oldest_bomb[pnum] = i;
+				}
+			}
+		}
+	}
+
+	// Display time remaining below each oldest bomb
+	for (int i = 0; i < MAX_PLAYERS; i++)
+	{
+		if (oldest_bomb[i] != -1)
+		{
+			int objnum = oldest_bomb[i];
+			g3s_point bomb_pos;
+			g3_rotate_point(&bomb_pos, &Objects[objnum].pos);
+
+			if (bomb_pos.p3_codes == 0) // on screen
+			{
+				g3_project_point(&bomb_pos);
+
+				if (!(bomb_pos.p3_flags & PF_OVERFLOW))
+				{
+					fix x, y, dy;
+					char s[20];
+					int w, h, aw, x1, y1;
+
+					x = bomb_pos.p3_sx;
+					y = bomb_pos.p3_sy;
+					dy = -fixmuldiv(fixmul(Objects[objnum].size, Matrix_scale.y), i2f(grd_curcanv->cv_bitmap.bm_h) / 2, bomb_pos.p3_z);
+
+					memset(&s, '\0', 20);
+					// Display time remaining in minutes and seconds
+					snprintf(s, sizeof(s), "%i:%02i", f2i(Objects[objnum].lifeleft) / 60, f2i(Objects[objnum].lifeleft) % 60);
+
+					gr_get_string_size(s, &w, &h, &aw);
+					gr_set_fontcolor(BM_XRGB(31, 0, 0), -1);
+					x1 = f2i(x) - w / 2;
+					y1 = f2i(y - dy) + FSPACY(1);
+					gr_string(x1, y1, s);
+				}
+			}
+		}
+	}
+}
+
 void show_HUD_names()
 {
 	int is_friend = 0, show_friend_name = 0, show_enemy_name = 0, show_name = 0, show_name_through_walls = 0,
@@ -4101,6 +4170,8 @@ void show_HUD_names()
 			}
 		}
 	}
+
+	observer_show_bomb_highlights();
 }
 
 //draw all the things on the HUD

--- a/d1/main/gauges.c
+++ b/d1/main/gauges.c
@@ -3902,75 +3902,6 @@ int see_object(int objnum)
 	return (hit_type == HIT_OBJECT && hit_data.hit_object == objnum);
 }
 
-// Show bomb highlights in observer mode
-void observer_show_bomb_highlights()
-{
-	if (!is_observer() || !PlayerCfg.ObsShowBombTimes)
-	{
-		return;
-	}
-
-	// Find oldest bomb for each player
-	// Technically it'd be more efficient to cache this and update it when a bomb is created or
-	// destroyed, but it'd also be a lot more cumbersome to implement, and this seems fast enough.
-	int oldest_bomb[MAX_PLAYERS];
-	for (int i = 0; i < MAX_PLAYERS; i++)
-		oldest_bomb[i] = -1;
-
-	for (int i = 0; i <= Highest_object_index; i++)
-	{
-		if (Objects[i].type == OBJ_WEAPON && Objects[i].id == PROXIMITY_ID)
-		{
-			if (Objects[i].ctype.laser_info.parent_type == OBJ_PLAYER)
-			{
-				int pnum = Objects[i].ctype.laser_info.parent_num;
-				if (pnum >= 0 && pnum < MAX_PLAYERS)
-				{
-					if (oldest_bomb[pnum] == -1 || Objects[i].lifeleft < Objects[oldest_bomb[pnum]].lifeleft)
-						oldest_bomb[pnum] = i;
-				}
-			}
-		}
-	}
-
-	// Display time remaining below each oldest bomb
-	for (int i = 0; i < MAX_PLAYERS; i++)
-	{
-		if (oldest_bomb[i] != -1)
-		{
-			int objnum = oldest_bomb[i];
-			g3s_point bomb_pos;
-			g3_rotate_point(&bomb_pos, &Objects[objnum].pos);
-
-			if (bomb_pos.p3_codes == 0) // on screen
-			{
-				g3_project_point(&bomb_pos);
-
-				if (!(bomb_pos.p3_flags & PF_OVERFLOW))
-				{
-					fix x, y, dy;
-					char s[20];
-					int w, h, aw, x1, y1;
-
-					x = bomb_pos.p3_sx;
-					y = bomb_pos.p3_sy;
-					dy = -fixmuldiv(fixmul(Objects[objnum].size, Matrix_scale.y), i2f(grd_curcanv->cv_bitmap.bm_h) / 2, bomb_pos.p3_z);
-
-					memset(&s, '\0', 20);
-					// Display time remaining in minutes and seconds
-					snprintf(s, sizeof(s), "%i:%02i", f2i(Objects[objnum].lifeleft) / 60, f2i(Objects[objnum].lifeleft) % 60);
-
-					gr_get_string_size(s, &w, &h, &aw);
-					gr_set_fontcolor(BM_XRGB(31, 0, 0), -1);
-					x1 = f2i(x) - w / 2;
-					y1 = f2i(y - dy) + FSPACY(1);
-					gr_string(x1, y1, s);
-				}
-			}
-		}
-	}
-}
-
 void show_HUD_names()
 {
 	int is_friend = 0, show_friend_name = 0, show_enemy_name = 0, show_name = 0, show_name_through_walls = 0,
@@ -4170,8 +4101,75 @@ void show_HUD_names()
 			}
 		}
 	}
+}
 
-	observer_show_bomb_highlights();
+// Show bomb highlights in observer mode
+void observer_show_bomb_highlights()
+{
+	if (!is_observer() || !PlayerCfg.ObsShowBombTimes)
+	{
+		return;
+	}
+
+	// Find oldest bomb for each player
+	// Technically it'd be more efficient to cache this and update it when a bomb is created or
+	// destroyed, but it'd also be a lot more cumbersome to implement, and this seems fast enough.
+	int oldest_bomb[MAX_PLAYERS];
+	for (int i = 0; i < MAX_PLAYERS; i++)
+		oldest_bomb[i] = -1;
+
+	for (int i = 0; i <= Highest_object_index; i++)
+	{
+		if (Objects[i].type == OBJ_WEAPON && Objects[i].id == PROXIMITY_ID)
+		{
+			if (Objects[i].ctype.laser_info.parent_type == OBJ_PLAYER)
+			{
+				int pnum = Objects[i].ctype.laser_info.parent_num;
+				if (pnum >= 0 && pnum < MAX_PLAYERS)
+				{
+					if (oldest_bomb[pnum] == -1 || Objects[i].lifeleft < Objects[oldest_bomb[pnum]].lifeleft)
+						oldest_bomb[pnum] = i;
+				}
+			}
+		}
+	}
+
+	// Display time remaining below each oldest bomb
+	for (int i = 0; i < MAX_PLAYERS; i++)
+	{
+		if (oldest_bomb[i] != -1)
+		{
+			int objnum = oldest_bomb[i];
+			g3s_point bomb_pos;
+			g3_rotate_point(&bomb_pos, &Objects[objnum].pos);
+
+			if (bomb_pos.p3_codes == 0) // on screen
+			{
+				g3_project_point(&bomb_pos);
+
+				if (!(bomb_pos.p3_flags & PF_OVERFLOW))
+				{
+					fix x, y, dy;
+					char s[20];
+					int w, h, aw, x1, y1;
+
+					x = bomb_pos.p3_sx;
+					y = bomb_pos.p3_sy;
+					dy = -fixmuldiv(fixmul(Objects[objnum].size, Matrix_scale.y), i2f(grd_curcanv->cv_bitmap.bm_h) / 2, bomb_pos.p3_z);
+
+					memset(&s, '\0', 20);
+					// Display time remaining in minutes and seconds
+					snprintf(s, sizeof(s), "%i:%02i", f2i(Objects[objnum].lifeleft) / 60, f2i(Objects[objnum].lifeleft) % 60);
+
+					gr_get_string_size(s, &w, &h, &aw);
+					gr_set_fontcolor(BM_XRGB(31, 0, 0), -1);
+					x1 = f2i(x) - w / 2;
+					y1 = f2i(y - dy) + FSPACY(1);
+					gr_string(x1, y1, s);
+				}
+			}
+		}
+	}
 }
 
 //draw all the things on the HUD
@@ -4189,6 +4187,9 @@ void draw_hud()
 
 		// Show game messages
 		HUD_render_message_frame();
+
+		// Show bomb countdown timers
+		observer_show_bomb_highlights();
 
 		if (is_observing_player() && PlayerCfg.ObsShowCockpit && !Obs_at_distance) {
 			if (PlayerCfg.CockpitMode[1]==CM_STATUS_BAR || PlayerCfg.CockpitMode[1]==CM_FULL_SCREEN)

--- a/d1/main/menu.c
+++ b/d1/main/menu.c
@@ -2190,7 +2190,7 @@ int menu_obs_options_handler ( newmenu *menu, d_event *event, void *userdata );
 
 void do_obs_menu()
 {
-	newmenu_item m[25];
+	newmenu_item m[26];
 	int i = 0;
 
 	do {
@@ -2232,8 +2232,9 @@ void do_obs_menu()
 		ADD_CHECK(20, "Kills over Time Graph", PlayerCfg.ObsShowKillGraph);
 		ADD_CHECK(21, "Damage Breakdown", PlayerCfg.ObsShowBreakdown);
 		ADD_CHECK(22, "List of Observers", PlayerCfg.ObsShowObs);
-        ADD_CHECK(23, "Observer Chat", PlayerCfg.ObsChat);
-        ADD_CHECK(24, "Player Chat", PlayerCfg.ObsPlayerChat);
+		ADD_CHECK(23, "Observer Chat", PlayerCfg.ObsChat);
+		ADD_CHECK(24, "Player Chat", PlayerCfg.ObsPlayerChat);
+		ADD_CHECK(25, "Bomb/Mine Countdowns", PlayerCfg.ObsShowBombTimes);
 
 		i = newmenu_do1( NULL, "JinX Mode Options", sizeof(m)/sizeof(*m), m, menu_obs_options_handler, NULL, i );
 
@@ -2254,8 +2255,9 @@ void do_obs_menu()
 		PlayerCfg.ObsShowKillGraph = m[20].value;
 		PlayerCfg.ObsShowBreakdown = m[21].value;
 		PlayerCfg.ObsShowObs = m[22].value;
-        PlayerCfg.ObsChat = m[23].value;
-        PlayerCfg.ObsPlayerChat = m[24].value;
+		PlayerCfg.ObsChat = m[23].value;
+		PlayerCfg.ObsPlayerChat = m[24].value;
+		PlayerCfg.ObsShowBombTimes = m[25].value;
 	} while( i>-1 );
 }
 

--- a/d1/main/playsave.c
+++ b/d1/main/playsave.c
@@ -138,6 +138,7 @@ int new_player_config()
 	PlayerCfg.ObsShowObs = 1;
     PlayerCfg.ObsChat = 1;
     PlayerCfg.ObsPlayerChat = 1;
+	PlayerCfg.ObsShowBombTimes = 0;
 
 	// Default taunt macros
 	#ifdef NETWORK
@@ -480,6 +481,8 @@ int read_player_d1x(char *filename)
 					PlayerCfg.ObsChat = atoi(line);
 				if(!strcmp(word,"OBSPLAYERCHAT"))
 					PlayerCfg.ObsPlayerChat = atoi(line);
+				if(!strcmp(word,"OBSSHOWBOMBTIMES"))
+					PlayerCfg.ObsShowBombTimes = atoi(line);
 
 				//if(!strcmp(word,"QUIETPLASMA"))
 				//	PlayerCfg.QuietPlasma = atoi(line);							
@@ -871,6 +874,7 @@ int write_player_d1x(char *filename)
 		PHYSFSX_printf(fout,"obsshowobs=%i\n",PlayerCfg.ObsShowObs);
 		PHYSFSX_printf(fout,"obschat=%i\n",PlayerCfg.ObsChat);
 		PHYSFSX_printf(fout,"obsplayerchat=%i\n",PlayerCfg.ObsPlayerChat);
+		PHYSFSX_printf(fout,"obsshowbombtimes=%i\n",PlayerCfg.ObsShowBombTimes);
 		//PHYSFSX_printf(fout,"quietplasma=%i\n",PlayerCfg.QuietPlasma);	
 		PHYSFSX_printf(fout,"maxfps=%i\n",PlayerCfg.maxFps);	
 		PHYSFSX_printf(fout,"[end]\n");

--- a/d1/main/playsave.h
+++ b/d1/main/playsave.h
@@ -126,6 +126,7 @@ typedef struct player_config
 	ubyte ObsShowObs;
     ubyte ObsChat;
     ubyte ObsPlayerChat;
+	ubyte ObsShowBombTimes;
 } __pack__ player_config;
 
 extern struct player_config PlayerCfg;

--- a/d2/main/gauges.c
+++ b/d2/main/gauges.c
@@ -4215,76 +4215,6 @@ int see_object(int objnum)
 	return (hit_type == HIT_OBJECT && hit_data.hit_object == objnum);
 }
 
-// Show bomb highlights in observer mode
-void observer_show_bomb_highlights()
-{
-	if (!is_observer() || !PlayerCfg.ObsShowBombTimes)
-	{
-		return;
-	}
-
-	// Find oldest bomb for each player (also include smart mines in D2)
-	// Technically it'd be more efficient to cache this and update it when a bomb is created or
-	// destroyed, but it'd also be a lot more cumbersome to implement, and this seems fast enough.
-	int oldest_bomb[MAX_PLAYERS];
-	for (int i = 0; i < MAX_PLAYERS; i++)
-		oldest_bomb[i] = -1;
-
-	for (int i = 0; i <= Highest_object_index; i++)
-	{
-		if (Objects[i].type == OBJ_WEAPON && (Objects[i].id == PROXIMITY_ID || Objects[i].id == SUPERPROX_ID))
-		{
-			if (Objects[i].ctype.laser_info.parent_type == OBJ_PLAYER)
-			{
-				int pnum = Objects[i].ctype.laser_info.parent_num;
-				if (pnum >= 0 && pnum < MAX_PLAYERS)
-				{
-					if (oldest_bomb[pnum] == -1 || Objects[i].lifeleft < Objects[oldest_bomb[pnum]].lifeleft)
-						oldest_bomb[pnum] = i;
-				}
-			}
-		}
-	}
-
-	// Display time remaining below each oldest bomb
-	for (int i = 0; i < MAX_PLAYERS; i++)
-	{
-		if (oldest_bomb[i] != -1)
-		{
-			int objnum = oldest_bomb[i];
-			g3s_point bomb_pos;
-			g3_rotate_point(&bomb_pos, &Objects[objnum].pos);
-
-			if (bomb_pos.p3_codes == 0) // on screen
-			{
-				g3_project_point(&bomb_pos);
-
-				if (!(bomb_pos.p3_flags & PF_OVERFLOW))
-				{
-					fix x, y, dy;
-					char s[20];
-					int w, h, aw, x1, y1;
-
-					x = bomb_pos.p3_sx;
-					y = bomb_pos.p3_sy;
-					dy = -fixmuldiv(fixmul(Objects[objnum].size, Matrix_scale.y), i2f(grd_curcanv->cv_bitmap.bm_h) / 2, bomb_pos.p3_z);
-
-					memset(&s, '\0', 20);
-					// Display time remaining in minutes and seconds
-					snprintf(s, sizeof(s), "%i:%02i", f2i(Objects[objnum].lifeleft) / 60, f2i(Objects[objnum].lifeleft) % 60);
-
-					gr_get_string_size(s, &w, &h, &aw);
-					// Red if it's a proximity bomb, yellow if it's a smart mine
-					gr_set_fontcolor(Objects[objnum].id == PROXIMITY_ID ? BM_XRGB(31, 0, 0) : BM_XRGB(31, 31, 0), -1);
-					x1 = f2i(x) - w / 2;
-					y1 = f2i(y - dy) + FSPACY(1);
-					gr_string(x1, y1, s);
-				}
-			}
-		}
-	}
-}
-
 #ifdef NETWORK
 //show names of teammates & players carrying flags
 void show_HUD_names()
@@ -4493,11 +4423,78 @@ void show_HUD_names()
 			}
 		}
 	}
-
-	observer_show_bomb_highlights();
 }
 #endif
 
+// Show bomb highlights in observer mode
+void observer_show_bomb_highlights()
+{
+	if (!is_observer() || !PlayerCfg.ObsShowBombTimes)
+	{
+		return;
+	}
+
+	// Find oldest bomb for each player (also include smart mines in D2)
+	// Technically it'd be more efficient to cache this and update it when a bomb is created or
+	// destroyed, but it'd also be a lot more cumbersome to implement, and this seems fast enough.
+	int oldest_bomb[MAX_PLAYERS];
+	for (int i = 0; i < MAX_PLAYERS; i++)
+		oldest_bomb[i] = -1;
+
+	for (int i = 0; i <= Highest_object_index; i++)
+	{
+		if (Objects[i].type == OBJ_WEAPON && (Objects[i].id == PROXIMITY_ID || Objects[i].id == SUPERPROX_ID))
+		{
+			if (Objects[i].ctype.laser_info.parent_type == OBJ_PLAYER)
+			{
+				int pnum = Objects[i].ctype.laser_info.parent_num;
+				if (pnum >= 0 && pnum < MAX_PLAYERS)
+				{
+					if (oldest_bomb[pnum] == -1 || Objects[i].lifeleft < Objects[oldest_bomb[pnum]].lifeleft)
+						oldest_bomb[pnum] = i;
+				}
+			}
+		}
+	}
+
+	// Display time remaining below each oldest bomb
+	for (int i = 0; i < MAX_PLAYERS; i++)
+	{
+		if (oldest_bomb[i] != -1)
+		{
+			int objnum = oldest_bomb[i];
+			g3s_point bomb_pos;
+			g3_rotate_point(&bomb_pos, &Objects[objnum].pos);
+
+			if (bomb_pos.p3_codes == 0) // on screen
+			{
+				g3_project_point(&bomb_pos);
+
+				if (!(bomb_pos.p3_flags & PF_OVERFLOW))
+				{
+					fix x, y, dy;
+					char s[20];
+					int w, h, aw, x1, y1;
+
+					x = bomb_pos.p3_sx;
+					y = bomb_pos.p3_sy;
+					dy = -fixmuldiv(fixmul(Objects[objnum].size, Matrix_scale.y), i2f(grd_curcanv->cv_bitmap.bm_h) / 2, bomb_pos.p3_z);
+
+					memset(&s, '\0', 20);
+					// Display time remaining in minutes and seconds
+					snprintf(s, sizeof(s), "%i:%02i", f2i(Objects[objnum].lifeleft) / 60, f2i(Objects[objnum].lifeleft) % 60);
+
+					gr_get_string_size(s, &w, &h, &aw);
+					// Red if it's a proximity bomb, yellow if it's a smart mine
+					gr_set_fontcolor(Objects[objnum].id == PROXIMITY_ID ? BM_XRGB(31, 0, 0) : BM_XRGB(31, 31, 0), -1);
+					x1 = f2i(x) - w / 2;
+					y1 = f2i(y - dy) + FSPACY(1);
+					gr_string(x1, y1, s);
+				}
+			}
+		}
+	}
+}
 
 //draw all the things on the HUD
 void draw_hud()
@@ -4522,6 +4519,9 @@ void draw_hud()
 
 		// Show game messages
 		HUD_render_message_frame();
+
+		// Show bomb/mine countdown timers
+		observer_show_bomb_highlights();
 
 		if (is_observing_player() && PlayerCfg.ObsShowCockpit && !Obs_at_distance) {
 			if (PlayerCfg.CockpitMode[1] == CM_STATUS_BAR || PlayerCfg.CockpitMode[1] == CM_FULL_SCREEN)

--- a/d2/main/menu.c
+++ b/d2/main/menu.c
@@ -2227,7 +2227,7 @@ int menu_obs_options_handler ( newmenu *menu, d_event *event, void *userdata );
 
 void do_obs_menu()
 {
-	newmenu_item m[25];
+	newmenu_item m[26];
 	int i = 0;
 
 	do {
@@ -2271,6 +2271,7 @@ void do_obs_menu()
 		ADD_CHECK(22, "List of Observers", PlayerCfg.ObsShowObs);
 		ADD_CHECK(23, "Observer Chat", PlayerCfg.ObsChat);
 		ADD_CHECK(24, "Player Chat", PlayerCfg.ObsPlayerChat);
+		ADD_CHECK(25, "Bomb/Mine Countdowns", PlayerCfg.ObsShowBombTimes);
 
 		i = newmenu_do1(NULL, "JinX Mode Options", sizeof(m) / sizeof(*m), m, menu_obs_options_handler, NULL, i);
 
@@ -2293,6 +2294,7 @@ void do_obs_menu()
 		PlayerCfg.ObsShowObs = m[22].value;
 		PlayerCfg.ObsChat = m[23].value;
 		PlayerCfg.ObsPlayerChat = m[24].value;
+		PlayerCfg.ObsShowBombTimes = m[25].value;
 	} while (i > -1);
 }
 

--- a/d2/main/playsave.c
+++ b/d2/main/playsave.c
@@ -160,6 +160,7 @@ int new_player_config()
 	PlayerCfg.ObsShowObs = 1;
 	PlayerCfg.ObsChat = 1;
 	PlayerCfg.ObsPlayerChat = 1;
+	PlayerCfg.ObsShowBombTimes = 0;
 
 	// Default taunt macros
 	#ifdef NETWORK
@@ -451,6 +452,8 @@ int read_player_d2x(char *filename)
 					PlayerCfg.ObsChat = atoi(line);
 				if (!strcmp(word, "OBSPLAYERCHAT"))
 					PlayerCfg.ObsPlayerChat = atoi(line);
+				if (!strcmp(word, "OBSSHOWBOMBTIMES"))
+					PlayerCfg.ObsShowBombTimes = atoi(line);
 
 				//if(!strcmp(word,"QUIETPLASMA"))
 				//	PlayerCfg.QuietPlasma = atoi(line);							
@@ -657,6 +660,7 @@ int write_player_d2x(char *filename)
 		PHYSFSX_printf(fout,"obsshowobs=%i\n",PlayerCfg.ObsShowObs);
 		PHYSFSX_printf(fout,"obschat=%i\n",PlayerCfg.ObsChat);
 		PHYSFSX_printf(fout,"obsplayerchat=%i\n",PlayerCfg.ObsPlayerChat);
+		PHYSFSX_printf(fout,"obsshowbombtimes=%i\n",PlayerCfg.ObsShowBombTimes);
 		//PHYSFSX_printf(fout,"quietplasma=%i\n",PlayerCfg.QuietPlasma);	
 		PHYSFSX_printf(fout,"maxfps=%i\n",PlayerCfg.maxFps);	
 		PHYSFSX_printf(fout,"[end]\n");

--- a/d2/main/playsave.h
+++ b/d2/main/playsave.h
@@ -119,6 +119,7 @@ typedef struct player_config
 	ubyte ObsShowObs;
 	ubyte ObsChat;
 	ubyte ObsPlayerChat;
+	ubyte ObsShowBombTimes;
 } __pack__ player_config;
 
 extern struct player_config PlayerCfg;


### PR DESCRIPTION
Another comment from Observatory; they were interested in being able to see when proximity bombs were about to time out.
Because players often tend to drop these in clusters, it didn't make sense to show times for every single bomb; they might become difficult to read. Instead (at @roncli 's suggestion) I set it up to pick the bomb with the lowest time remaining and display a countdown on that one. I note that currently it walks the object list _every frame_ to find which bombs it needs to mark up. I _could_ make it save this info when the list is actually going to change (i.e. a bomb is dropped or explodes) but that would require adding more global state - I'm not honestly sure it's worth it but let me know if you disagree.
I'm not sure everyone will want to see this, so I added an option to the observer settings menu to control it. That would also mitigate any potential perf bug :)
![image](https://github.com/dxx-redux/dxx-redux/assets/21977335/bd9eb5e8-b5a4-442e-a099-d08016f0158e)
