### PR TITLE
D2X-Redux autodemo feature was dropping level numbers

### DIFF
--- a/d2/main/gameseq.c
+++ b/d2/main/gameseq.c
@@ -731,6 +731,14 @@ void LoadLevel(int level_num,int page_in_textures)
 
 	save_player = Players[Player_num];
 
+	if (Newdemo_state == ND_STATE_PLAYBACK && level_num == 0) {
+		// Workaround for Redux bug. We're hoping that the demo was recorded in a one-level
+		// mission; otherwise we don't have a good way to guess which one to load.
+		level_num = 1;
+		nm_messagebox(NULL, 1, TXT_OK, "This demo was recorded in\nan old version of D2X-Redux.\n"
+			"Some game information\nmay be missing.");
+	}
+
 	Assert(level_num <= Last_level  && level_num >= Last_secret_level  && level_num != 0);
 
 	if (level_num<0)		//secret level
@@ -1522,11 +1530,6 @@ void StartNewLevelSub(int level_num, int page_in_textures, int secret_flag)
 	if (Newdemo_state == ND_STATE_RECORDING) {
 		newdemo_set_new_level(level_num);
 		newdemo_record_start_frame(FrameTime );
-	}
-	else {
-		if (Game_mode & GM_MULTI && PlayerCfg.AutoDemo) {
-			newdemo_start_recording();
-		}
 	}
 
 	LoadLevel(level_num,page_in_textures);


### PR DESCRIPTION
Due to a bad port of commit 19346c4cd73f7c8eea7e39793e56bfdd36e7ed4f (in commit eee7990d886d005c96103b8ae1673f59d1ceb569), D2X-Redux has been starting automatic demo recording before the level was fully loaded. This led to invalid information being recorded at the beginning of the demo - most crucially the level number - which prevented playback.
I've removed the section of code that was moved to the end of the StartNewLevelSub function in D1.

I've also added a workaround to LoadLevel that allows the demos Lee sent me to play back - although e.g. one of the pilot names is still missing from the scoreboard, and it's possible a few other things aren't there as well. I'm not so sure about this change, however, since it might just crash if the demo was recorded in the second or subsequent level of a multi-level set. Let me know what you think.