### PR TITLE
Fix LASER_ID constants in D1

### DIFF
--- a/d1/main/laser.c
+++ b/d1/main/laser.c
@@ -263,8 +263,10 @@ int Laser_create_new( vms_vector * direction, vms_vector * position, int segnum,
 			//	Fusion damage was boosted by mk on 3/27 (for reg 1.1 release), but we only want it to apply to single player games.
 			if (Game_mode & GM_MULTI)
 				obj->ctype.laser_info.multiplier /= 2;
-		} else if ((weapon_type == LASER_ID) && (Players[Objects[parent].id].flags & PLAYER_FLAGS_QUAD_LASERS))
-			obj->ctype.laser_info.multiplier = F1_0*3/4;
+		}
+		// This original code was never executed since the LASER_ID constant referred to a robot weapon
+		//	else if ((weapon_type == LASER_ID) && (Players[Objects[parent].id].flags & PLAYER_FLAGS_QUAD_LASERS))
+		//		obj->ctype.laser_info.multiplier = F1_0*3/4;
 	}
 
 

--- a/d1/main/laser.h
+++ b/d1/main/laser.h
@@ -22,9 +22,12 @@ COPYRIGHT 1993-1998 PARALLAX SOFTWARE CORPORATION.  ALL RIGHTS RESERVED.
 
 enum weapon_type_t
 {
+	LASER_ID_L1, //  0..3 are player lasers
+	LASER_ID_L2,
+	LASER_ID_L3,
+	LASER_ID_L4,
 	CONCUSSION_ID = 8,
 	FLARE_ID = 9,   //  NOTE: This MUST correspond to the ID generated at bitmaps.tbl read time.
-	LASER_ID = 10,
 	VULCAN_ID = 11,  //  NOTE: This MUST correspond to the ID generated at bitmaps.tbl read time.
 	XSPREADFIRE_ID = 12,  //  NOTE: This MUST correspond to the ID generated at bitmaps.tbl read time.
 	PLASMA_ID = 13,  //  NOTE: This MUST correspond to the ID generated at bitmaps.tbl read time.


### PR DESCRIPTION
The original D1 code didn't have constants for the player laser weapons. It did have a LASER_ID constant but that one referred to the robot blue laser. This commit adds the LASER_ID_L1 etc. constants from D2.
The LASER_ID constant was used in original code that intended to reduce quad damage, but that never worked since it didn't refer to a player weapon. The LASER_ID constant and the quad damage reduction code is taken out in this commit to prevent further confusion.