### PR TITLE
Show fewer warnings in non-MSVC builds

### DIFF
--- a/d1/CMakeLists.txt
+++ b/d1/CMakeLists.txt
@@ -18,6 +18,10 @@ set(CMAKE_C_FLAGS_MINSIZEREL "${CMAKE_C_FLAGS_MINSIZEREL} -DRELEASE")
 set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -DRELEASE")
 set(CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO} -DRELEASE")
 
+if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-address-of-packed-member -Wno-deprecated-declarations")
+endif()
+
 # Global compile flags (have to be processed before subdirectories by some
 #  CMake implementations - even though the docs say they don't)
 add_definitions(/DNETWORK)

--- a/d2/CMakeLists.txt
+++ b/d2/CMakeLists.txt
@@ -22,6 +22,10 @@ set(CMAKE_C_FLAGS_MINSIZEREL "${CMAKE_C_FLAGS_MINSIZEREL} -DRELEASE")
 set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -DRELEASE")
 set(CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO} -DRELEASE")
 
+if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-address-of-packed-member -Wno-deprecated-declarations")
+endif()
+
 # Global compile flags (have to be processed before subdirectories by some
 #  CMake implementations - even though the docs say they don't)
 add_definitions(/DNETWORK)


### PR DESCRIPTION
Disable the pointer to unaligned field and deprecated declaration warnings for now.