### PR TITLE
More usable linux AppImage package

### DIFF
--- a/.github/workflows/package-linux.yml
+++ b/.github/workflows/package-linux.yml
@@ -24,13 +24,13 @@ jobs:
           sudo apt-get install -y cmake libphysfs-dev libsdl1.2-dev libsdl-mixer1.2-dev libpng-dev libglew-dev
 
       - name: Configure D1
-        run: cmake -S d1 -B buildd1 -DCMAKE_BUILD_TYPE=RelWithDebInfo
+        run: cmake -S d1 -B buildd1 -DCMAKE_BUILD_TYPE=RelWithDebInfo -DOpenGL_GL_PREFERENCE=LEGACY
 
       - name: Build D1
         run: cmake --build buildd1
 
       - name: Configure D2
-        run: cmake -S d2 -B buildd2 -DCMAKE_BUILD_TYPE=RelWithDebInfo
+        run: cmake -S d2 -B buildd2 -DCMAKE_BUILD_TYPE=RelWithDebInfo -DOpenGL_GL_PREFERENCE=LEGACY
 
       - name: Build D2
         run: cmake --build buildd2

--- a/contrib/packaging/linux/build_package.sh
+++ b/contrib/packaging/linux/build_package.sh
@@ -21,6 +21,10 @@ chmod a+x appimagetool-x86_64.AppImage
 curl -s -L -O https://github.com/AppImage/AppImageKit/releases/download/continuous/AppRun-x86_64 || exit 3
 chmod a+x AppRun-x86_64
 
+# And linuxdeploy
+curl -s -L -O https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage || exit 3
+chmod a+x linuxdeploy-x86_64.AppImage
+
 
 build_appimage() {
     name="$1"
@@ -55,6 +59,9 @@ build_appimage() {
     ## Package
     cp AppRun-x86_64 ${appdir}/AppRun
 
+    # Dependencies
+    ./linuxdeploy-x86_64.AppImage --appdir "${appdir}"
+
     # Package!
     ./appimagetool-x86_64.AppImage --no-appstream --verbose "${appdir}" "${appimagename}"
 
@@ -66,4 +73,4 @@ build_appimage "d1x-redux" "d1x-redux"
 build_appimage "d2x-redux" "d2x-redux"
 
 # Clean
-#rm -f appimagetool* AppRun*
+rm -f appimagetool* AppRun* linuxdeploy-*


### PR DESCRIPTION
Include dependencies with linuxdeploy tool. Also use legacy opengl config in cmake for better distribution compatibility.