### PR TITLE
Add a soundfont to the linux AppImage binary

### DIFF
--- a/contrib/packaging/linux/build_package.sh
+++ b/contrib/packaging/linux/build_package.sh
@@ -25,6 +25,8 @@ chmod a+x AppRun-x86_64
 curl -s -L -O https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage || exit 3
 chmod a+x linuxdeploy-x86_64.AppImage
 
+# And the soundfont
+curl -s -L -O https://github.com/arbruijn/TimGM6mb/releases/download/v20100822/TimGM6mb.sf2 || exit 3
 
 build_appimage() {
     name="$1"
@@ -58,6 +60,11 @@ build_appimage() {
     mkdir -p ${appdir}/usr/share/applications
     cp ${dir}/${name}.desktop ${appdir}/usr/share/applications
     cp ${dir}/${name}.desktop ${appdir}/
+
+    # Soundfont
+
+    mkdir -p ${appdir}/usr/share/sounds/sf3
+    cp -p TimGM6mb.sf2 ${appdir}/usr/share/sounds/sf3/default-GM.sf3
 
     ## Package
     cp AppRun-x86_64 ${appdir}/AppRun

--- a/d1/arch/sdl/digi_mixer.c
+++ b/d1/arch/sdl/digi_mixer.c
@@ -48,6 +48,17 @@ static inline int fix2byte(fix f) { return (f / 256) % 256; }
 Mix_Chunk SoundChunks[MAX_SOUNDS];
 ubyte channels[MAX_SOUND_SLOTS];
 
+#ifdef __linux__
+static int digi_mixer_check_soundfont(const char *path, void *data)
+{
+	FILE *file = fopen(path, "r");
+	if (!file)
+		return 0;
+	fclose(file);
+	return 1;
+}
+#endif
+
 /* Initialise audio */
 int digi_mixer_init()
 {
@@ -55,6 +66,18 @@ int digi_mixer_init()
 
 	if (MIX_DIGI_DEBUG) con_printf(CON_DEBUG,"digi_init %d (SDL_Mixer)\n", MAX_SOUNDS);
 	if (SDL_InitSubSystem(SDL_INIT_AUDIO) < 0) Error("SDL audio initialisation failed: %s.", SDL_GetError());
+
+	#ifdef __linux__
+	// Use the soundfont in the AppImage if no other sound font specified
+	Mix_Init(0); // hack to set soundfont_paths on Debian patched SDL-mixer
+	if (!Mix_EachSoundFont(digi_mixer_check_soundfont, NULL) && getenv("APPDIR"))
+	{
+		char soundfonts[PATH_MAX];
+		snprintf(soundfonts, sizeof(soundfonts),
+			"%s/usr/share/sounds/sf3/default-GM.sf3", getenv("APPDIR"));
+		Mix_SetSoundFonts(soundfonts);
+	}
+	#endif
 
 	if (Mix_OpenAudio(digi_sample_rate, MIX_OUTPUT_FORMAT, MIX_OUTPUT_CHANNELS, SOUND_BUFFER_SIZE))
 	{


### PR DESCRIPTION
To have midi music on linux without extra installation steps. The Soundfont is TimGM6mb, small and default in Debian/Ubuntu.