### PR TITLE
Log exit message before invoking extra function

### DIFF
--- a/d1/misc/error.c
+++ b/d1/misc/error.c
@@ -54,11 +54,11 @@ void clear_warn_func(void (*f)(char *s))
 
 void print_exit_message(const char *exit_message)
 {
+		con_printf(CON_CRITICAL, "\n%s\n",exit_message);
 		if (ErrorPrintFunc)
 		{
 			(*ErrorPrintFunc)(exit_message);
 		}
-		con_printf(CON_CRITICAL, "\n%s\n",exit_message);
 }
 
 //terminates with error code 1, printing message

--- a/d2/misc/error.c
+++ b/d2/misc/error.c
@@ -54,11 +54,11 @@ void clear_warn_func(void (*f)(char *s))
 
 void print_exit_message(const char *exit_message)
 {
+		con_printf(CON_CRITICAL, "\n%s\n",exit_message);
 		if (ErrorPrintFunc)
 		{
 			(*ErrorPrintFunc)(exit_message);
 		}
-		con_printf(CON_CRITICAL, "\n%s\n",exit_message);
 }
 
 //terminates with error code 1, printing message


### PR DESCRIPTION
The extra function might crash, so should be better to write the exit error message to the log file/console first.