### PR TITLE
Fix D2 rear view MFDs in observer mode

### DIFF
--- a/d1/main/object.c
+++ b/d1/main/object.c
@@ -763,7 +763,7 @@ void reset_player_object()
 
 	//Init render info
 
-	ConsoleObject->render_type = RT_POLYOBJ;
+	ConsoleObject->render_type = is_observer() ? RT_NONE : RT_POLYOBJ;
 	ConsoleObject->rtype.pobj_info.model_num = Player_ship->model_num;		//what model is this?
 	ConsoleObject->rtype.pobj_info.subobj_flags = 0;		//zero the flags
 	ConsoleObject->rtype.pobj_info.tmap_override = -1;		//no tmap override!

--- a/d2/main/game.c
+++ b/d2/main/game.c
@@ -1938,3 +1938,13 @@ void flickering_light_write(flickering_light *fl, PHYSFS_file *fp)
 bool is_observer() {
 	return (Game_mode & GM_OBSERVER) != 0;
 }
+
+object* get_player_view_object()
+{
+	// If we're observing a player, ConsoleObject may not actually be their location if we're in chase cam.
+	// But we still want to show extra views from their real location, so correct it
+	if (is_observer() && is_observing_player())
+		return &Objects[Players[Current_obs_player].objnum];
+	else
+		return ConsoleObject;
+}

--- a/d2/main/game.h
+++ b/d2/main/game.h
@@ -238,6 +238,7 @@ void game_render_frame_mono(int flip);
 void game_leave_menus(void);
 
 bool is_observer();
+struct object* get_player_view_object();
 
 //Cheats
 typedef struct game_cheats

--- a/d2/main/gamerend.c
+++ b/d2/main/gamerend.c
@@ -638,7 +638,7 @@ void show_extra_views()
 			DemoDoingLeft=DemoDoLeft;
 
 			if (DemoDoLeft==3)
-				do_cockpit_window_view(0,ConsoleObject,1,WBU_REAR,"REAR");
+				do_cockpit_window_view(0,get_player_view_object(),1,WBU_REAR,"REAR");
 			else
 				do_cockpit_window_view(0,&DemoLeftExtra,DemoRearCheck[DemoDoLeft],DemoWBUType[DemoDoLeft],DemoExtraMessage[DemoDoLeft]);
 		}
@@ -650,7 +650,7 @@ void show_extra_views()
 			DemoDoingRight=DemoDoRight;
 			
 			if (DemoDoRight==3)
-				do_cockpit_window_view(1,ConsoleObject,1,WBU_REAR,"REAR");
+				do_cockpit_window_view(1,get_player_view_object(),1,WBU_REAR,"REAR");
 			else
 			{
 				do_cockpit_window_view(1,&DemoRightExtra,DemoRearCheck[DemoDoRight],DemoWBUType[DemoDoRight],DemoExtraMessage[DemoDoRight]);
@@ -719,11 +719,11 @@ void show_extra_views()
 			case CV_REAR:
 				if (Rear_view) {		//if big window is rear view, show front here
 					RenderingType=3+(w<<4);				
-					do_cockpit_window_view(w,ConsoleObject,0,WBU_REAR,"FRONT");
+					do_cockpit_window_view(w,get_player_view_object(),0,WBU_REAR,"FRONT");
 				}
 				else {					//show normal rear view
 					RenderingType=3+(w<<4);				
-					do_cockpit_window_view(w,ConsoleObject,1,WBU_REAR,"REAR");
+					do_cockpit_window_view(w,get_player_view_object(),1,WBU_REAR,"REAR");
 				}
 			 	break;
 			case CV_ESCORT: {

--- a/d2/main/object.c
+++ b/d2/main/object.c
@@ -866,7 +866,7 @@ void reset_player_object()
 
 	//Init render info
 
-	ConsoleObject->render_type = RT_POLYOBJ;
+	ConsoleObject->render_type = is_observer() ? RT_NONE : RT_POLYOBJ;
 	ConsoleObject->rtype.pobj_info.model_num = Player_ship->model_num;		//what model is this?
 	ConsoleObject->rtype.pobj_info.subobj_flags = 0;		//zero the flags
 	ConsoleObject->rtype.pobj_info.tmap_override = -1;		//no tmap override!

--- a/d2/main/render.c
+++ b/d2/main/render.c
@@ -1643,7 +1643,7 @@ void render_frame(fix eye_offset, int window_num)
 	if (start_seg_num==-1)
 		start_seg_num = Viewer->segnum;
 
-	if (Rear_view && (Viewer==ConsoleObject)) {
+	if (Rear_view && (Viewer==get_player_view_object())) {
 		vms_matrix headm,viewm;
 		Player_head_angles.p = Player_head_angles.b = 0;
 		Player_head_angles.h = 0x7fff;


### PR DESCRIPTION
There were some rear view glitches we spotted during the D2 observer test that this aims to fix.

1. When in chase cam mode, the rear view was drawn from the observer, rather than the player being observed, which gives a misleading picture of what they can see.
2. After fixing that, the observer ship is actually drawn in the rear view MFD. Would probably show up in guided missile views as well if we drew those. This was caused by the render type of ConsoleObject being forced to RT_POLYOBJ, which is inappropriate in observer mode. Since this issue is present in D1 as well - albeit with no consequences we've seen so far - I fixed it there too.