### PR TITLE
Add afterburner charge reporting and rendering in observer mode

### DIFF
--- a/d2/main/ai.c
+++ b/d2/main/ai.c
@@ -243,7 +243,7 @@ void init_ai_frame(void)
 
 	Dist_to_last_fired_upon_player_pos = vm_vec_dist_quick(&Last_fired_upon_player_pos, &Believed_player_pos);
 
-	ab_state = Afterburner_charge && Controls.afterburner_state && (Players[Player_num].flags & PLAYER_FLAGS_AFTERBURNER);
+	ab_state = Players[Player_num].afterburner_charge && Controls.afterburner_state && (Players[Player_num].flags & PLAYER_FLAGS_AFTERBURNER);
 
 	if (!(Players[Player_num].flags & PLAYER_FLAGS_CLOAKED) || (Players[Player_num].flags & PLAYER_FLAGS_HEADLIGHT_ON) || ab_state) {
 		ai_do_cloak_stuff();

--- a/d2/main/controls.c
+++ b/d2/main/controls.c
@@ -144,8 +144,12 @@ void read_flying_controls( object * obj )
 
 				new_count = (Players[Player_num].afterburner_charge / (DROP_DELTA_TIME/AFTERBURNER_USE_SECS));
 
-				if (old_count != new_count)
+				if (old_count != new_count) {
 					Drop_afterburner_blob_flag = 1;	//drop blob (after physics called)
+
+					if (Game_mode & GM_MULTI)
+						multi_send_ship_status();
+				}
 			}
 		}
 		else {
@@ -162,6 +166,9 @@ void read_flying_controls( object * obj )
 			Players[Player_num].afterburner_charge += charge_up;
 	
 			Players[Player_num].energy -= charge_up * 100 / 10;	//full charge uses 10% of energy
+
+			if (charge_up > 0 && (Game_mode & GM_MULTI))
+				multi_send_ship_status();
 		}
 	}
 

--- a/d2/main/controls.c
+++ b/d2/main/controls.c
@@ -46,8 +46,6 @@ COPYRIGHT 1993-1999 PARALLAX SOFTWARE CORPORATION.  ALL RIGHTS RESERVED.
 //look at keyboard, mouse, joystick, CyberMan, whatever, and set 
 //physics vars rotvel, velocity
 
-fix Afterburner_charge=f1_0;
-
 #define AFTERBURNER_USE_SECS	3				//use up in 3 seconds
 #define DROP_DELTA_TIME			(f1_0/15)	//drop 3 per second
 
@@ -133,18 +131,18 @@ void read_flying_controls( object * obj )
 				int old_count,new_count;
 	
 				//add in value from 0..1
-				afterburner_scale = f1_0 + min(f1_0/2,Afterburner_charge) * 2;
+				afterburner_scale = f1_0 + min(f1_0/2, Players[Player_num].afterburner_charge) * 2;
 	
 				forward_thrust_time = fixmul(FrameTime,afterburner_scale);	//based on full thrust
 	
-				old_count = (Afterburner_charge / (DROP_DELTA_TIME/AFTERBURNER_USE_SECS));
+				old_count = (Players[Player_num].afterburner_charge / (DROP_DELTA_TIME/AFTERBURNER_USE_SECS));
 
-				Afterburner_charge -= FrameTime/AFTERBURNER_USE_SECS;
+				Players[Player_num].afterburner_charge -= FrameTime/AFTERBURNER_USE_SECS;
 
-				if (Afterburner_charge < 0)
-					Afterburner_charge = 0;
+				if (Players[Player_num].afterburner_charge < 0)
+					Players[Player_num].afterburner_charge = 0;
 
-				new_count = (Afterburner_charge / (DROP_DELTA_TIME/AFTERBURNER_USE_SECS));
+				new_count = (Players[Player_num].afterburner_charge / (DROP_DELTA_TIME/AFTERBURNER_USE_SECS));
 
 				if (old_count != new_count)
 					Drop_afterburner_blob_flag = 1;	//drop blob (after physics called)
@@ -154,14 +152,14 @@ void read_flying_controls( object * obj )
 			fix cur_energy,charge_up;
 	
 			//charge up to full
-			charge_up = min(FrameTime/8,f1_0 - Afterburner_charge);	//recharge over 8 seconds
+			charge_up = min(FrameTime/8,f1_0 - Players[Player_num].afterburner_charge);	//recharge over 8 seconds
 	
 			cur_energy = max(Players[Player_num].energy-i2f(10),0);	//don't drop below 10
 
 			//maybe limit charge up by energy
 			charge_up = min(charge_up,cur_energy/10);
 	
-			Afterburner_charge += charge_up;
+			Players[Player_num].afterburner_charge += charge_up;
 	
 			Players[Player_num].energy -= charge_up * 100 / 10;	//full charge uses 10% of energy
 		}

--- a/d2/main/controls.h
+++ b/d2/main/controls.h
@@ -28,6 +28,4 @@ void read_flying_controls( object * obj );
 extern ubyte Controls_stopped;
 extern ubyte Controls_always_move;
 
-extern fix Afterburner_charge;
-
 #endif

--- a/d2/main/game.c
+++ b/d2/main/game.c
@@ -578,7 +578,7 @@ void do_afterburner_stuff(void)
 	static sbyte func_play = 0;
 
 	if (!(Players[Player_num].flags & PLAYER_FLAGS_AFTERBURNER))
-		Afterburner_charge = 0;
+		Players[Player_num].afterburner_charge = 0;
 
 	if (Endlevel_sequence || Player_is_dead)
 	{
@@ -592,9 +592,9 @@ void do_afterburner_stuff(void)
 #endif
 	}
 
-	if ((Controls.afterburner_state != Last_afterburner_state && Last_afterburner_charge) || (Last_afterburner_state && Last_afterburner_charge && !Afterburner_charge)) {
+	if ((Controls.afterburner_state != Last_afterburner_state && Last_afterburner_charge) || (Last_afterburner_state && Last_afterburner_charge && !Players[Player_num].afterburner_charge)) {
 
-		if (Afterburner_charge && Controls.afterburner_state && (Players[Player_num].flags & PLAYER_FLAGS_AFTERBURNER)) {
+		if (Players[Player_num].afterburner_charge && Controls.afterburner_state && (Players[Player_num].flags & PLAYER_FLAGS_AFTERBURNER)) {
 			digi_link_sound_to_object3( SOUND_AFTERBURNER_IGNITE, Players[Player_num].objnum, 1, F1_0, i2f(256), AFTERBURNER_LOOP_START, AFTERBURNER_LOOP_END );
 #ifdef NETWORK
 			if (Game_mode & GM_MULTI)
@@ -620,7 +620,7 @@ void do_afterburner_stuff(void)
 	//@@	afterburner_shake();
 
 	Last_afterburner_state = Controls.afterburner_state;
-	Last_afterburner_charge = Afterburner_charge;
+	Last_afterburner_charge = Players[Player_num].afterburner_charge;
 }
 
 // -- //	------------------------------------------------------------------------------------

--- a/d2/main/gameseq.c
+++ b/d2/main/gameseq.c
@@ -436,7 +436,6 @@ void init_player_stats_new_ship(ubyte pnum)
 			Dead_player_camera = 0;
 
 		Global_laser_firing_count=0;
-		Afterburner_charge = 0;
 		Controls.afterburner_state = 0;
 		Last_afterburner_state = 0;
 		Missile_viewer=NULL; //reset missile camera if out there
@@ -457,6 +456,7 @@ void init_player_stats_new_ship(ubyte pnum)
 	Players[pnum].secondary_ammo[0] = 2 + NDL - Difficulty_level;
 	Players[pnum].primary_weapon_flags = HAS_LASER_FLAG;
 	Players[pnum].secondary_weapon_flags = HAS_CONCUSSION_FLAG;
+	Players[pnum].afterburner_charge = 0;
 	Players[pnum].flags &= ~( PLAYER_FLAGS_QUAD_LASERS | PLAYER_FLAGS_AFTERBURNER | PLAYER_FLAGS_CLOAKED | PLAYER_FLAGS_INVULNERABLE | PLAYER_FLAGS_MAP_ALL | PLAYER_FLAGS_CONVERTER | PLAYER_FLAGS_AMMO_RACK | PLAYER_FLAGS_HEADLIGHT | PLAYER_FLAGS_HEADLIGHT_ON | PLAYER_FLAGS_FLAG);
 	Players[pnum].cloak_time = 0;
 	Players[pnum].invulnerable_time = 0;
@@ -468,8 +468,7 @@ void init_player_stats_new_ship(ubyte pnum)
 #ifdef NETWORK
 	if(Game_mode & GM_MULTI && Netgame.BornWithBurner && !is_observer()) {
 		Players[pnum].flags |= PLAYER_FLAGS_AFTERBURNER;
-		if (pnum == Player_num)
-			Afterburner_charge = f1_0;
+		Players[pnum].afterburner_charge = f1_0;
 	}
 #endif
 	digi_kill_sound_linked_to_object(Players[pnum].objnum);

--- a/d2/main/gauges.c
+++ b/d2/main/gauges.c
@@ -1067,10 +1067,10 @@ void hud_show_afterburner(void)
 
 	y = (Game_mode & GM_MULTI)?(-7*LINE_SPACING):(-3*LINE_SPACING);
 
-	gr_printf(FSPACX(1), grd_curcanv->cv_bitmap.bm_h+y, "burn: %d%%" , fixmul(Afterburner_charge,100));
+	gr_printf(FSPACX(1), grd_curcanv->cv_bitmap.bm_h+y, "burn: %d%%" , fixmul(Players[pnum].afterburner_charge,100));
 
 	if (Newdemo_state==ND_STATE_RECORDING )
-		newdemo_record_player_afterburner(Afterburner_charge);
+		newdemo_record_player_afterburner(Players[pnum].afterburner_charge);
 }
 
 static inline const char *SECONDARY_WEAPON_NAMES_VERY_SHORT(const unsigned u)
@@ -2222,7 +2222,7 @@ void sb_draw_afterburner()
 	PAGE_IN_GAUGE( SB_GAUGE_AFTERBURNER );
 	hud_bitblt(HUD_SCALE_X(SB_AFTERBURNER_GAUGE_X), HUD_SCALE_Y(SB_AFTERBURNER_GAUGE_Y), &GameBitmaps[GET_GAUGE_INDEX(SB_GAUGE_AFTERBURNER)]);
 
-	erase_height = HUD_SCALE_Y(fixmul((f1_0 - Afterburner_charge),SB_AFTERBURNER_GAUGE_H-1));
+	erase_height = HUD_SCALE_Y(fixmul((f1_0 - Players[pnum].afterburner_charge),SB_AFTERBURNER_GAUGE_H-1));
 	gr_setcolor( 0 );
 	for (i=0;i<erase_height;i++)
 		gr_uline( i2f(HUD_SCALE_X(SB_AFTERBURNER_GAUGE_X-1)), i2f(HUD_SCALE_Y(SB_AFTERBURNER_GAUGE_Y)+i), i2f(HUD_SCALE_X(SB_AFTERBURNER_GAUGE_X+(SB_AFTERBURNER_GAUGE_W))), i2f(HUD_SCALE_Y(SB_AFTERBURNER_GAUGE_Y)+i) );
@@ -2973,6 +2973,7 @@ int observer_draw_player_card(int pnum, int color, int x, int y) {
 
 		double energy = f2db(Players[pnum].energy);
 		double ammo = f2db(Players[pnum].primary_ammo[1]) * VULCAN_AMMO_SCALE;
+		double afterburner = f2db(Players[pnum].afterburner_charge);
 
 		if (PlayerCfg.ObsShowAmmoBars[get_observer_game_mode()]) {
 			if (!PlayerCfg.ObsShowScoreboardShieldBar[get_observer_game_mode()]) {
@@ -2981,6 +2982,7 @@ int observer_draw_player_card(int pnum, int color, int x, int y) {
 
 			int energy_bar_height = FSPACY(0.75);
 			int ammo_bar_height = FSPACY(0.5);
+			int afterburner_bar_height = FSPACY(0.5);
 
 			// Energy display
 			if (energy > 0) {
@@ -2998,6 +3000,14 @@ int observer_draw_player_card(int pnum, int color, int x, int y) {
 			}
 
 			y += ammo_bar_height + 2;
+
+			// Afterburner display
+			if (afterburner > 0) {
+				gr_setcolor(BM_XRGB(25, 0, 0));
+				gr_urect(x + 2, y, min(x + 2 + (int)(afterburner * ((double)OBS_PLAYER_CARD_WIDTH - 4.0)), x + OBS_PLAYER_CARD_WIDTH - 2), y + afterburner_bar_height);
+			}
+
+			y += afterburner_bar_height + 2;
 		}
 
 		if (PlayerCfg.ObsShowPrimary[get_observer_game_mode()]) {
@@ -4708,8 +4718,8 @@ void render_gauges()
 		show_bomb_count(HUD_SCALE_X(BOMB_COUNT_X), HUD_SCALE_Y(BOMB_COUNT_Y), gr_find_closest_color(0, 0, 0), 0, 0);
 
 		if (Newdemo_state==ND_STATE_RECORDING )
-			newdemo_record_player_afterburner(Afterburner_charge);
-		draw_afterburner_bar(Afterburner_charge);
+			newdemo_record_player_afterburner(Players[pnum].afterburner_charge);
+		draw_afterburner_bar(Players[pnum].afterburner_charge);
 
 		draw_player_ship(cloak, SHIP_GAUGE_X, SHIP_GAUGE_Y);
 
@@ -4738,7 +4748,7 @@ void render_gauges()
 			show_bomb_count(HUD_SCALE_X(SB_BOMB_COUNT_X), HUD_SCALE_Y(SB_BOMB_COUNT_Y), gr_find_closest_color(0, 0, 0), 0, 0);
 
 		if (Newdemo_state==ND_STATE_RECORDING )
-			newdemo_record_player_afterburner(Afterburner_charge);
+			newdemo_record_player_afterburner(Players[pnum].afterburner_charge);
 		sb_draw_afterburner();
 
 		draw_player_ship(cloak, SB_SHIP_GAUGE_X, SB_SHIP_GAUGE_Y);

--- a/d2/main/multi.c
+++ b/d2/main/multi.c
@@ -6260,6 +6260,7 @@ void multi_send_ship_status_for_frame()
 	multibuf[30] = (ubyte)Players[Player_num].secondary_weapon;
 	PUT_INTEL_INT(multibuf + 31, Players[Player_num].energy);
 	PUT_INTEL_INT(multibuf + 35, Players[Player_num].homing_object_dist);
+	PUT_INTEL_INT(multibuf + 39, Players[Player_num].afterburner_charge);
 
 	multi_send_data_direct( multibuf, 39, multi_who_is_master(), 2);
 }
@@ -6287,6 +6288,7 @@ void multi_do_ship_status( const ubyte *buf )
 		Players[buf[1]].secondary_weapon = (sbyte)buf[30];
 		Players[buf[1]].energy = GET_INTEL_INT(buf + 31);
 		Players[buf[1]].homing_object_dist = GET_INTEL_INT(buf + 35);
+		Players[buf[1]].afterburner_charge = GET_INTEL_INT(buf + 39);
 	}
 }
 

--- a/d2/main/multi.c
+++ b/d2/main/multi.c
@@ -6262,7 +6262,7 @@ void multi_send_ship_status_for_frame()
 	PUT_INTEL_INT(multibuf + 35, Players[Player_num].homing_object_dist);
 	PUT_INTEL_INT(multibuf + 39, Players[Player_num].afterburner_charge);
 
-	multi_send_data_direct( multibuf, 39, multi_who_is_master(), 2);
+	multi_send_data_direct( multibuf, 43, multi_who_is_master(), 2);
 }
 
 void multi_do_ship_status( const ubyte *buf )

--- a/d2/main/multi.h
+++ b/d2/main/multi.h
@@ -60,7 +60,7 @@ extern int multi_protocol; // set and determinate used protocol
 #define MULTI_PROTO_UDP 1 // UDP protocol
 
 // What version of the multiplayer protocol is this? Increment each time something drastic changes in Multiplayer without the version number changes. Can be reset to 0 each time the version of the game changes
-#define MULTI_PROTO_VERSION 30003 // Redux 0.5
+#define MULTI_PROTO_VERSION 30004 // Redux 1.1
 
 // PROTOCOL VARIABLES AND DEFINES - END
 
@@ -144,7 +144,7 @@ extern int multi_protocol; // set and determinate used protocol
 	VALUE(MULTI_OBS_UPDATE           , 4 + 8*MAX_OBSERVERS)	\
 	VALUE(MULTI_DAMAGE               , 14)  \
 	VALUE(MULTI_REPAIR               , 11)  \
-	VALUE(MULTI_SHIP_STATUS          , 39)  \
+	VALUE(MULTI_SHIP_STATUS          , 43)  \
 	AFTER
 for_each_multiplayer_command(enum {, define_multiplayer_command, });
 

--- a/d2/main/newdemo.c
+++ b/d2/main/newdemo.c
@@ -2169,11 +2169,11 @@ int newdemo_read_frame_information(int rewrite)
 				break;
 			}
 			if ((Newdemo_vcr_state == ND_STATE_PLAYBACK) || (Newdemo_vcr_state == ND_STATE_FASTFORWARD) || (Newdemo_vcr_state == ND_STATE_ONEFRAMEFORWARD)) {
-				Afterburner_charge = afterburner<<9;
+				Players[Player_num].afterburner_charge = afterburner<<9;
 // 				if (Afterburner_charge < 0) Afterburner_charge=f1_0;
 			} else if ((Newdemo_vcr_state == ND_STATE_REWINDING) || (Newdemo_vcr_state == ND_STATE_ONEFRAMEBACKWARD)) {
 				if (!afterburner_updated && old_afterburner != 255) {
-					Afterburner_charge = old_afterburner<<9;
+					Players[Player_num].afterburner_charge = old_afterburner<<9;
 					afterburner_updated = 1;
 				}
 			}

--- a/d2/main/player.h
+++ b/d2/main/player.h
@@ -102,6 +102,7 @@ typedef struct player {
 	ushort  secondary_ammo[MAX_SECONDARY_WEAPONS]; // How much ammo of each type.
 	sbyte   primary_weapon;         // The currently selected primary weapon.
 	sbyte   secondary_weapon;       // The currently selected secondary weapon.
+	fix     afterburner_charge;     // The amount of afterburner charge remaining.
 
 	ushort  pad; // Pad because increased weapon_flags from byte to short -YW 3/22/95
 

--- a/d2/main/powerup.c
+++ b/d2/main/powerup.c
@@ -630,7 +630,7 @@ int do_powerup(object *obj)
 #endif
 				digi_play_sample( Powerup_info[obj->id].hit_sound, F1_0 );
 				powerup_basic(15, 15, 15, 0, "AFTERBURNER!");
-				Afterburner_charge = f1_0;
+				Players[Player_num].afterburner_charge = f1_0;
 				used=1;
 			}
 			break;

--- a/d2/main/powerup.c
+++ b/d2/main/powerup.c
@@ -632,6 +632,10 @@ int do_powerup(object *obj)
 				powerup_basic(15, 15, 15, 0, "AFTERBURNER!");
 				Players[Player_num].afterburner_charge = f1_0;
 				used=1;
+#ifdef NETWORK
+				if (Game_mode & GM_MULTI)
+					multi_send_ship_status();
+#endif
 			}
 			break;
 

--- a/d2/main/state.c
+++ b/d2/main/state.c
@@ -1077,7 +1077,7 @@ int state_save_all_sub(char *filename, char *desc)
 	PHYSFS_write(fp, &Players[0].callsign[0], sizeof(char), (NUM_MARKERS)*(CALLSIGN_LEN+1)); // PHYSFS_write(fp, MarkerOwner, sizeof(MarkerOwner), 1); MarkerOwner is obsolete
 	PHYSFS_write(fp, MarkerMessage, sizeof(MarkerMessage), 1);
 
-	PHYSFS_write(fp, &Afterburner_charge, sizeof(fix), 1);
+	PHYSFS_write(fp, &Players[Player_num].afterburner_charge, sizeof(fix), 1);
 
 	//save last was super information
 	PHYSFS_write(fp, &Primary_last_was_super, sizeof(Primary_last_was_super), 1);
@@ -1575,7 +1575,7 @@ int state_restore_all_sub(char *filename, int secret_restore)
 
 	if (version>=11) {
 		if (secret_restore != 1)
-			Afterburner_charge = PHYSFSX_readSXE32(fp, swap);
+			Players[Player_num].afterburner_charge = PHYSFSX_readSXE32(fp, swap);
 		else {
 			PHYSFSX_readSXE32(fp, swap);
 		}


### PR DESCRIPTION
We noticed during the D2 Observatory session that afterburner state wasn't being synced to first-person observers. The main cause, of course, was that afterburner charge level wasn't transmitted with the ship state.
While working on this I realized that the code would be a lot less bug-prone if afterburner charge were part of the player struct. I really don't know why Parallax didn't do this in the first place. So, I moved it there, although I didn't get too adventurous with game saves etc - even in multiplayer, the player who saves the game is the only one whose afterburner charge gets persisted. But as far as I know nobody's complained about that for the past 30 years, so they're probably not going to start now. :)
I also added a third line to the observer mode "player card" that shows afterburner charge - that was a suggestion from the Observatory crew.