### PR TITLE
Fix xmodel __pack__ warnings

### DIFF
--- a/d1/xmodel/tga.h
+++ b/d1/xmodel/tga.h
@@ -31,7 +31,7 @@ typedef struct {
     uint16_t height;            // image height in pixels
     char   bits;              // image bits per pixel 8,16,24,32
     char   descriptor;        // image descriptor bits (vh flip bits)
-} __pack__ tTGAHeader;
+} __xpack__ tTGAHeader;
 
 
 class CTGAHeader {

--- a/d1/xmodel/xdescent.h
+++ b/d1/xmodel/xdescent.h
@@ -6,20 +6,20 @@
 
 static inline int Max(int a, int b) { return a > b ? a : b; }
 
-#define __pack__
+#define __xpack__
 typedef union tTexCoord2f {
 	float a [2];
 	struct {
 		float	u, v;
 		} v;
-	} __pack__ tTexCoord2f;
+	} __xpack__ tTexCoord2f;
 
 typedef union tTexCoord3f {
 	float a [3];
 	struct {
 		float	u, v, l;
 		} v;
-	} __pack__ tTexCoord3f;
+	} __xpack__ tTexCoord3f;
 
 
 #define MAX_THRUSTERS		16
@@ -124,19 +124,19 @@ public:
 
 typedef struct tBGR {
 	uint8_t	b,g,r;
-} __pack__ tBGR;
+} __xpack__ tBGR;
 
 typedef struct tBGRA {
 	uint8_t	b,g,r,a;
-} __pack__ tBGRA;
+} __xpack__ tBGRA;
 
 typedef struct tRGB {
 	uint8_t	r,g,b;
-} __pack__ tRGB;
+} __xpack__ tRGB;
 
 typedef struct tRGBA {
 	uint8_t	r,g,b,a;
-} __pack__ tRGBA;
+} __xpack__ tRGBA;
 class CRGBColor {
 	public:
 		uint8_t	r, g, b;

--- a/d1/xmodel/xmaths.h
+++ b/d1/xmodel/xmaths.h
@@ -37,7 +37,7 @@ typedef struct tQuadInt {// integer 64 bit, previously called "quad"
 	uint32_t low;
    int32_t high;
 #endif
-} __pack__ tQuadInt;
+} __xpack__ tQuadInt;
 
 #define WORLDSCALE	1000	// one world unit (65536 in fixed point arithmetic) corresponds to 1000 mm (1 m) of the real world
 

--- a/d1/xmodel/xpstypes.h
+++ b/d1/xmodel/xpstypes.h
@@ -56,16 +56,16 @@ COPYRIGHT 1993-1999 PARALLAX SOFTWARE CORPORATION.  ALL RIGHTS RESERVED.
 #endif
 
 #if 1 // packing no longer needed
-#define __pack__
+#define __xpack__
 #else
 // the following stuff has nothing to do with types but needed everywhere,
 // and since this file is included everywhere, it's here.
 #ifdef __GNUC__
-# define __pack__ __attribute__((packed))
+# define __xpack__ __attribute__((packed))
 #elif defined(_WIN32)
 # pragma pack(push, packing)
 # pragma pack(1)
-# define __pack__
+# define __xpack__
 #else
 # error d2x will not work without packed structures
 #endif

--- a/d1/xmodel/xvecmat.h
+++ b/d1/xmodel/xvecmat.h
@@ -53,10 +53,10 @@ class CFloatMatrix;
 //------------------------------------------------------------------------------
 //------------------------------------------------------------------------------
 /**
- * \class __pack__ CFixVector
+ * \class CFixVector
  * A 3 element fixed-point vector.
  */
-class __pack__ CFixVector {
+class __xpack__ CFixVector {
 #if 1
 	public:
 		union {
@@ -182,7 +182,7 @@ class __pack__ CFixVector {
 //------------------------------------------------------------------------------
 //------------------------------------------------------------------------------
 /**
- * \class __pack__ CFloatVector
+ * \class CFloatVector
  * A 4 element floating point vector class
  */
 class CFloatVector {
@@ -295,7 +295,7 @@ class CFloatVector {
 //------------------------------------------------------------------------------
 
 /**
- * \class __pack__ CFloatVector3
+ * \class CFloatVector3
  * A 3 element floating point vector class
  */
 class CFloatVector3 {
@@ -385,7 +385,7 @@ class CFloatVector3 {
 
 //Angle vector.  Used to store orientations
 
-class __pack__ CAngleVector {
+class __xpack__ CAngleVector {
 #if 1
 	public:
 		union {
@@ -1438,7 +1438,7 @@ inline const CFixVector CFixVector::operator/ (const fix d) const {
 // -----------------------------------------------------------------------------
 
 /**
- * \class __pack__ CFixMatrix
+ * \class CFixMatrix
  *
  * A 3x3 rotation m.matrix.  Sorry about the numbering starting with one. Ordering
  * is across then down, so <m1,m2,m3> is the first row.
@@ -1449,7 +1449,7 @@ typedef union tFixMatrixData {
 	} dir;
 	CFixVector	mat [3];
 	fix			vec [9];
-} __pack__ tFixMatrixData;
+} __xpack__ tFixMatrixData;
 
 
 class CFixMatrix {
@@ -1631,7 +1631,7 @@ inline void CFixMatrix::CheckAndFix (void)
 
 
 /**
- * \class __pack__ CFloatMatrix
+ * \class CFloatMatrix
  *
  * A 4x4 floating point transformation m.matrix
  */

--- a/d2/xmodel/tga.h
+++ b/d2/xmodel/tga.h
@@ -31,7 +31,7 @@ typedef struct {
     uint16_t height;            // image height in pixels
     char   bits;              // image bits per pixel 8,16,24,32
     char   descriptor;        // image descriptor bits (vh flip bits)
-} __pack__ tTGAHeader;
+} __xpack__ tTGAHeader;
 
 
 class CTGAHeader {

--- a/d2/xmodel/xdescent.h
+++ b/d2/xmodel/xdescent.h
@@ -6,20 +6,20 @@
 
 static inline int Max(int a, int b) { return a > b ? a : b; }
 
-#define __pack__
+#define __xpack__
 typedef union tTexCoord2f {
 	float a [2];
 	struct {
 		float	u, v;
 		} v;
-	} __pack__ tTexCoord2f;
+	} __xpack__ tTexCoord2f;
 
 typedef union tTexCoord3f {
 	float a [3];
 	struct {
 		float	u, v, l;
 		} v;
-	} __pack__ tTexCoord3f;
+	} __xpack__ tTexCoord3f;
 
 
 #define MAX_THRUSTERS		16
@@ -124,19 +124,19 @@ public:
 
 typedef struct tBGR {
 	uint8_t	b,g,r;
-} __pack__ tBGR;
+} __xpack__ tBGR;
 
 typedef struct tBGRA {
 	uint8_t	b,g,r,a;
-} __pack__ tBGRA;
+} __xpack__ tBGRA;
 
 typedef struct tRGB {
 	uint8_t	r,g,b;
-} __pack__ tRGB;
+} __xpack__ tRGB;
 
 typedef struct tRGBA {
 	uint8_t	r,g,b,a;
-} __pack__ tRGBA;
+} __xpack__ tRGBA;
 class CRGBColor {
 	public:
 		uint8_t	r, g, b;

--- a/d2/xmodel/xmaths.h
+++ b/d2/xmodel/xmaths.h
@@ -37,7 +37,7 @@ typedef struct tQuadInt {// integer 64 bit, previously called "quad"
 	uint32_t low;
    int32_t high;
 #endif
-} __pack__ tQuadInt;
+} __xpack__ tQuadInt;
 
 #define WORLDSCALE	1000	// one world unit (65536 in fixed point arithmetic) corresponds to 1000 mm (1 m) of the real world
 

--- a/d2/xmodel/xpstypes.h
+++ b/d2/xmodel/xpstypes.h
@@ -56,16 +56,16 @@ COPYRIGHT 1993-1999 PARALLAX SOFTWARE CORPORATION.  ALL RIGHTS RESERVED.
 #endif
 
 #if 1 // packing no longer needed
-#define __pack__
+#define __xpack__
 #else
 // the following stuff has nothing to do with types but needed everywhere,
 // and since this file is included everywhere, it's here.
 #ifdef __GNUC__
-# define __pack__ __attribute__((packed))
+# define __xpack__ __attribute__((packed))
 #elif defined(_WIN32)
 # pragma pack(push, packing)
 # pragma pack(1)
-# define __pack__
+# define __xpack__
 #else
 # error d2x will not work without packed structures
 #endif

--- a/d2/xmodel/xvecmat.h
+++ b/d2/xmodel/xvecmat.h
@@ -53,10 +53,10 @@ class CFloatMatrix;
 //------------------------------------------------------------------------------
 //------------------------------------------------------------------------------
 /**
- * \class __pack__ CFixVector
+ * \class CFixVector
  * A 3 element fixed-point vector.
  */
-class __pack__ CFixVector {
+class __xpack__ CFixVector {
 #if 1
 	public:
 		union {
@@ -182,7 +182,7 @@ class __pack__ CFixVector {
 //------------------------------------------------------------------------------
 //------------------------------------------------------------------------------
 /**
- * \class __pack__ CFloatVector
+ * \class CFloatVector
  * A 4 element floating point vector class
  */
 class CFloatVector {
@@ -295,7 +295,7 @@ class CFloatVector {
 //------------------------------------------------------------------------------
 
 /**
- * \class __pack__ CFloatVector3
+ * \class CFloatVector3
  * A 3 element floating point vector class
  */
 class CFloatVector3 {
@@ -385,7 +385,7 @@ class CFloatVector3 {
 
 //Angle vector.  Used to store orientations
 
-class __pack__ CAngleVector {
+class __xpack__ CAngleVector {
 #if 1
 	public:
 		union {
@@ -1438,7 +1438,7 @@ inline const CFixVector CFixVector::operator/ (const fix d) const {
 // -----------------------------------------------------------------------------
 
 /**
- * \class __pack__ CFixMatrix
+ * \class CFixMatrix
  *
  * A 3x3 rotation m.matrix.  Sorry about the numbering starting with one. Ordering
  * is across then down, so <m1,m2,m3> is the first row.
@@ -1449,7 +1449,7 @@ typedef union tFixMatrixData {
 	} dir;
 	CFixVector	mat [3];
 	fix			vec [9];
-} __pack__ tFixMatrixData;
+} __xpack__ tFixMatrixData;
 
 
 class CFixMatrix {
@@ -1631,7 +1631,7 @@ inline void CFixMatrix::CheckAndFix (void)
 
 
 /**
- * \class __pack__ CFloatMatrix
+ * \class CFloatMatrix
  *
  * A 4x4 floating point transformation m.matrix
  */


### PR DESCRIPTION
Use a separate __xpack__ define for the xmodel headers.