### PR TITLE
Make sure dead letterbox stays on exit trigger

### DIFF
--- a/d1/main/endlevel.c
+++ b/d1/main/endlevel.c
@@ -210,6 +210,9 @@ void start_endlevel_sequence()
 #endif
 	int exit_side,tunnel_length;
 
+	if (Player_is_dead || ConsoleObject->flags&OF_SHOULD_BE_DEAD)
+		return;				//don't start if dead!
+
 	reset_rear_view(); //turn off rear view if set - NOTE: make sure this happens before we pause demo recording!!
 
 	if (Newdemo_state == ND_STATE_RECORDING)		// stop demo recording
@@ -217,9 +220,6 @@ void start_endlevel_sequence()
 
 	if (Newdemo_state == ND_STATE_PLAYBACK)		// don't do this if in playback mode
 		return;
-
-	if (Player_is_dead || ConsoleObject->flags&OF_SHOULD_BE_DEAD)
-		return;				//don't start if dead!
 
 	Players[Player_num].homing_object_dist = -F1_0; // Turn off homing sound.
 

--- a/d2/main/endlevel.c
+++ b/d2/main/endlevel.c
@@ -293,6 +293,9 @@ void start_endlevel_sequence()
 	int	i;
 	
 
+	if (Player_is_dead || ConsoleObject->flags&OF_SHOULD_BE_DEAD)
+		return;				//don't start if dead!
+
 	reset_rear_view(); //turn off rear view if set - NOTE: make sure this happens before we pause demo recording!!
 
 	if (Newdemo_state == ND_STATE_RECORDING)		// stop demo recording
@@ -308,9 +311,6 @@ void start_endlevel_sequence()
 		strcpy(last_palette_loaded,"");		//force palette load next time
 		return;
 	}
-
-	if (Player_is_dead || ConsoleObject->flags&OF_SHOULD_BE_DEAD)
-		return;				//don't start if dead!
 
 	//	Dematerialize Buddy!
 	for (i=0; i<=Highest_object_index; i++)


### PR DESCRIPTION
Triggering the exit trigger while dead used to make the cockpit re-appear.

Fix it by doing the is-dead check in start_endlevel_sequence before calling reset_rear_view.

Resolves #93