### PR TITLE
Allow switching cockpit mode in D2 observer

### DIFF
--- a/d1/main/endlevel.c
+++ b/d1/main/endlevel.c
@@ -392,7 +392,7 @@ void stop_endlevel_sequence()
 {
 	Interpolation_method = 0;
 
-	select_cockpit(PlayerCfg.CockpitMode[0]);
+	select_cockpit(PlayerCfg.PreferredCockpitMode);
 
 	Endlevel_sequence = EL_OFF;
 

--- a/d1/main/game.h
+++ b/d1/main/game.h
@@ -187,6 +187,7 @@ void game_render_frame_mono(int flip);
 void game_leave_menus(void);
 
 bool is_observer();
+bool can_draw_observer_cockpit();
 
 //Cheats
 typedef struct game_cheats

--- a/d1/main/gamecntl.c
+++ b/d1/main/gamecntl.c
@@ -569,8 +569,12 @@ int HandleSystemKey(int key)
 
 		KEY_MAC(case KEY_COMMAND+KEY_3:)
 		case KEY_F3:
-			if (!Player_is_dead)
+			if ((!Player_is_dead && Viewer->type == OBJ_PLAYER) ||
+				// Alternatively, we can also toggle the cockpit while observing in first-person mode.
+				(is_observer() && can_draw_observer_cockpit()))
+			{
 				toggle_cockpit();
+			}
 			break;
 
 		KEY_MAC(case KEY_COMMAND+KEY_5:)

--- a/d1/main/gamerend.c
+++ b/d1/main/gamerend.c
@@ -85,12 +85,12 @@ void show_framerate()
 	gr_set_curfont(GAME_FONT);
 	gr_set_fontcolor(BM_XRGB(0,31,0),-1);
 
-	if (PlayerCfg.CockpitMode[1] == CM_FULL_SCREEN) {
+	if (PlayerCfg.CurrentCockpitMode == CM_FULL_SCREEN) {
 		if ((Game_mode & GM_MULTI) || (Newdemo_state == ND_STATE_PLAYBACK && Newdemo_game_mode & GM_MULTI))
 			y -= LINE_SPACING * 10;
 		else
 			y -= LINE_SPACING * 4;
-	} else if (PlayerCfg.CockpitMode[1] == CM_STATUS_BAR) {
+	} else if (PlayerCfg.CurrentCockpitMode == CM_STATUS_BAR) {
 		if ((Game_mode & GM_MULTI) || (Newdemo_state == ND_STATE_PLAYBACK && Newdemo_game_mode & GM_MULTI))
 			y -= LINE_SPACING * 6;
 		else
@@ -426,10 +426,10 @@ void game_draw_hud_stuff()
 
 		y = GHEIGHT-(LINE_SPACING*2);
 
-		if (is_observing_player() && !Obs_at_distance && PlayerCfg.ObsShowCockpit[get_observer_game_mode()] && PlayerCfg.CockpitMode[1] == CM_FULL_COCKPIT)
+		if (can_draw_observer_cockpit() && PlayerCfg.CurrentCockpitMode == CM_FULL_COCKPIT)
 			y = grd_curcanv->cv_bitmap.bm_h / 1.2 ;
 
-		if (PlayerCfg.CockpitMode[1] != CM_REAR_VIEW) {
+		if (PlayerCfg.CurrentCockpitMode != CM_REAR_VIEW) {
 			if (PlayerCfg.DemoRecordingIndicator == 0) {
 				gr_string(0x8000, y, message );
 			} else if (PlayerCfg.DemoRecordingIndicator == 1) {
@@ -441,7 +441,7 @@ void game_draw_hud_stuff()
 
 	render_countdown_gauge();
 
-	if (!is_observer() && GameCfg.FPSIndicator && PlayerCfg.CockpitMode[1] != CM_REAR_VIEW)
+	if (!is_observer() && GameCfg.FPSIndicator && PlayerCfg.CurrentCockpitMode != CM_REAR_VIEW)
 		show_framerate();
 
 	if (Newdemo_state == ND_STATE_PLAYBACK)
@@ -473,10 +473,10 @@ void game_render_frame_mono(int flip)
 	if (Newdemo_state == ND_STATE_PLAYBACK)
 		Game_mode = Newdemo_game_mode;
 
-	if (is_observer() && (!is_observing_player() || Obs_at_distance || !PlayerCfg.ObsShowCockpit[get_observer_game_mode()])) {
+	if (is_observer() && !can_draw_observer_cockpit()) {
 		// Do not render gauges.
 	} else {
-		if (PlayerCfg.CockpitMode[1]==CM_FULL_COCKPIT || PlayerCfg.CockpitMode[1]==CM_STATUS_BAR)
+		if (PlayerCfg.CurrentCockpitMode==CM_FULL_COCKPIT || PlayerCfg.CurrentCockpitMode==CM_STATUS_BAR)
 			render_gauges();
 	}
 
@@ -500,7 +500,7 @@ void toggle_cockpit()
 	if (Rear_view || Player_is_dead)
 		return;
 
-	switch (PlayerCfg.CockpitMode[1])
+	switch (PlayerCfg.PreferredCockpitMode)
 	{
 		case CM_FULL_COCKPIT:
 			new_mode = CM_STATUS_BAR;
@@ -518,7 +518,7 @@ void toggle_cockpit()
 
 	select_cockpit(new_mode);
 	HUD_clear_messages();
-	PlayerCfg.CockpitMode[0] = new_mode;
+	PlayerCfg.PreferredCockpitMode = new_mode;
 	write_player_file();
 }
 
@@ -528,17 +528,17 @@ extern void ogl_loadbmtexture(grs_bitmap *bm, int filter_blueship_wing);
 // This actually renders the new cockpit onto the screen.
 void update_cockpits()
 {
-	if (is_observer() && (!is_observing_player() || Obs_at_distance || !PlayerCfg.ObsShowCockpit[get_observer_game_mode()])) {
+	if (is_observer() && !can_draw_observer_cockpit()) {
 		// Do not draw cockpit.
 	} else {
 		grs_bitmap *bm;
 
-		if (PlayerCfg.CockpitMode[1] < N_COCKPIT_BITMAPS) {
-			PIGGY_PAGE_IN(cockpit_bitmap[PlayerCfg.CockpitMode[1]]);
-			bm = &GameBitmaps[cockpit_bitmap[PlayerCfg.CockpitMode[1]].index];
+		if (PlayerCfg.CurrentCockpitMode < N_COCKPIT_BITMAPS) {
+			PIGGY_PAGE_IN(cockpit_bitmap[PlayerCfg.CurrentCockpitMode]);
+			bm = &GameBitmaps[cockpit_bitmap[PlayerCfg.CurrentCockpitMode].index];
 		}
 
-		switch( PlayerCfg.CockpitMode[1] )	{
+		switch( PlayerCfg.CurrentCockpitMode )	{
 			case CM_FULL_COCKPIT:
 				gr_set_current_canvas(NULL);
 	#ifdef OGL
@@ -574,16 +574,16 @@ void update_cockpits()
 
 	gr_set_current_canvas(NULL);
 
-	if (PlayerCfg.CockpitMode[1] != last_drawn_cockpit)
-		last_drawn_cockpit = PlayerCfg.CockpitMode[1];
+	if (PlayerCfg.CurrentCockpitMode != last_drawn_cockpit)
+		last_drawn_cockpit = PlayerCfg.CurrentCockpitMode;
 	else
 		return;
 
-	if (is_observer() && (!is_observing_player() || Obs_at_distance || !PlayerCfg.ObsShowCockpit[get_observer_game_mode()])) {
+	if (is_observer() && !can_draw_observer_cockpit()) {
 		return;
 	}
 
-	if (PlayerCfg.CockpitMode[1]==CM_FULL_COCKPIT || PlayerCfg.CockpitMode[1]==CM_STATUS_BAR)
+	if (PlayerCfg.CurrentCockpitMode==CM_FULL_COCKPIT || PlayerCfg.CurrentCockpitMode==CM_STATUS_BAR)
 		init_gauges();
 }
 

--- a/d1/main/gauges.c
+++ b/d1/main/gauges.c
@@ -1083,7 +1083,7 @@ void hud_show_weapons_mode(int type,int vertical,int x,int y){
 						Players[pnum].laser_level+1);
 					break;
 				case 1:
-				if (PlayerCfg.CockpitMode[1]==CM_FULL_SCREEN)
+				if (PlayerCfg.CurrentCockpitMode==CM_FULL_SCREEN)
 					sprintf(weapon_str,"V%i", f2i(Players[pnum].primary_ammo[1] * VULCAN_AMMO_SCALE));
 				else
 					sprintf(weapon_str,"V%i", f2i(Players[pnum].primary_ammo[1] * VULCAN_AMMO_SCALE));
@@ -1280,7 +1280,7 @@ void hud_show_lives()
 	if (HUD_toolong)
 		return;
 
-	if (PlayerCfg.CockpitMode[1] == CM_FULL_COCKPIT)
+	if (PlayerCfg.CurrentCockpitMode == CM_FULL_COCKPIT)
 		x = HUD_SCALE_X(7);
 	else
 		x = FSPACX(2);
@@ -1514,9 +1514,9 @@ void cockpit_decode_alpha(grs_bitmap *bm)
 
 void draw_wbu_overlay()
 {
-	grs_bitmap * bm = &GameBitmaps[cockpit_bitmap[PlayerCfg.CockpitMode[1]].index];
+	grs_bitmap * bm = &GameBitmaps[cockpit_bitmap[PlayerCfg.CurrentCockpitMode].index];
 
-	PIGGY_PAGE_IN(cockpit_bitmap[PlayerCfg.CockpitMode[1]]);
+	PIGGY_PAGE_IN(cockpit_bitmap[PlayerCfg.CurrentCockpitMode]);
 	cockpit_decode_alpha(bm);
 
 	if (WinBoxOverlay[0] != NULL)
@@ -1770,7 +1770,7 @@ void draw_weapon_info(int weapon_type,int weapon_num)
 
 	if (weapon_type == 0)
 	{
-		if (PlayerCfg.CockpitMode[1] == CM_STATUS_BAR)
+		if (PlayerCfg.CurrentCockpitMode == CM_STATUS_BAR)
 		{
 			draw_weapon_info_sub(Primary_weapon_to_weapon_info[weapon_num],&gauge_boxes[SB_PRIMARY_BOX],SB_PRIMARY_W_PIC_X,SB_PRIMARY_W_PIC_Y,PRIMARY_WEAPON_NAMES_SHORT(weapon_num),SB_PRIMARY_W_TEXT_X,SB_PRIMARY_W_TEXT_Y);
 			x=SB_PRIMARY_AMMO_X;
@@ -1785,7 +1785,7 @@ void draw_weapon_info(int weapon_type,int weapon_num)
 	}
 	else
 	{
-		if (PlayerCfg.CockpitMode[1] == CM_STATUS_BAR)
+		if (PlayerCfg.CurrentCockpitMode == CM_STATUS_BAR)
 		{
 			draw_weapon_info_sub(Secondary_weapon_to_weapon_info[weapon_num],&gauge_boxes[SB_SECONDARY_BOX],SB_SECONDARY_W_PIC_X,SB_SECONDARY_W_PIC_Y,SECONDARY_WEAPON_NAMES_SHORT(weapon_num),SB_SECONDARY_W_TEXT_X,SB_SECONDARY_W_TEXT_Y);
 			x=SB_SECONDARY_AMMO_X;
@@ -1817,7 +1817,7 @@ void draw_ammo_info(int x,int y,int ammo_count,int primary)
 
 void draw_primary_ammo_info(int ammo_count)
 {
-	if (PlayerCfg.CockpitMode[1] == CM_STATUS_BAR)
+	if (PlayerCfg.CurrentCockpitMode == CM_STATUS_BAR)
 		draw_ammo_info(SB_PRIMARY_AMMO_X,SB_PRIMARY_AMMO_Y,ammo_count,1);
 	else
 		draw_ammo_info(PRIMARY_AMMO_X,PRIMARY_AMMO_Y,ammo_count,1);
@@ -1825,7 +1825,7 @@ void draw_primary_ammo_info(int ammo_count)
 
 void draw_secondary_ammo_info(int ammo_count)
 {
-	if (PlayerCfg.CockpitMode[1] == CM_STATUS_BAR)
+	if (PlayerCfg.CurrentCockpitMode == CM_STATUS_BAR)
 		draw_ammo_info(SB_SECONDARY_AMMO_X,SB_SECONDARY_AMMO_Y,ammo_count,0);
 	else
 		draw_ammo_info(SECONDARY_AMMO_X,SECONDARY_AMMO_Y,ammo_count,0);
@@ -1887,7 +1887,7 @@ void draw_weapon_box(int weapon_type,int weapon_num)
 	if (weapon_box_states[weapon_type] != WS_SET)         //fade gauge
 	{
 		int fade_value = f2i(weapon_box_fade_values[weapon_type]);
-		int boxofs = (PlayerCfg.CockpitMode[1]==CM_STATUS_BAR)?SB_PRIMARY_BOX:COCKPIT_PRIMARY_BOX;
+		int boxofs = (PlayerCfg.CurrentCockpitMode==CM_STATUS_BAR)?SB_PRIMARY_BOX:COCKPIT_PRIMARY_BOX;
 
 		gr_settransblend(fade_value, GR_BLEND_NORMAL);
 		gr_rect(HUD_SCALE_X(gauge_boxes[boxofs+weapon_type].left),HUD_SCALE_Y(gauge_boxes[boxofs+weapon_type].top),HUD_SCALE_X(gauge_boxes[boxofs+weapon_type].right),HUD_SCALE_Y(gauge_boxes[boxofs+weapon_type].bot));
@@ -1953,7 +1953,7 @@ void sb_draw_energy_bar(int energy)
 
 void sb_draw_shield_num(int shield)
 {
-	grs_bitmap *bm = &GameBitmaps[cockpit_bitmap[PlayerCfg.CockpitMode[1]].index];
+	grs_bitmap *bm = &GameBitmaps[cockpit_bitmap[PlayerCfg.CurrentCockpitMode].index];
 	int sw, sh, saw;
 
 	//draw numbers
@@ -1961,7 +1961,7 @@ void sb_draw_shield_num(int shield)
 	gr_set_fontcolor(BM_XRGB(14,14,23),-1 );
 
 	//erase old one
-	PIGGY_PAGE_IN( cockpit_bitmap[PlayerCfg.CockpitMode[1]] );
+	PIGGY_PAGE_IN( cockpit_bitmap[PlayerCfg.CurrentCockpitMode] );
 	gr_setcolor(gr_gpixel(bm,SB_SHIELD_NUM_X,SB_SHIELD_NUM_Y-(SM_H(Game_screen_mode)-bm->bm_h)));
 	gr_get_string_size((shield>199)?"200":(shield>99)?"100":(shield>9)?"00":"0",&sw,&sh,&saw);
 	gr_printf((grd_curscreen->sc_w/2.267)-(sw/2),HUD_SCALE_Y(SB_SHIELD_NUM_Y),"%d",shield);
@@ -2008,7 +2008,7 @@ void draw_invulnerable_ship()
 	if (Players[pnum].invulnerable_time+INVULNERABLE_TIME_MAX-GameTime64 > 0 && (Players[pnum].invulnerable_time+INVULNERABLE_TIME_MAX-GameTime64 > F1_0*4 || GameTime64 & 0x8000))
 	{
 
-		if (PlayerCfg.CockpitMode[1] == CM_STATUS_BAR)	{
+		if (PlayerCfg.CurrentCockpitMode == CM_STATUS_BAR)	{
 			PIGGY_PAGE_IN(Gauges[GAUGE_INVULNERABLE+invulnerable_frame]);
 			hud_bitblt( HUD_SCALE_X(SB_SHIELD_GAUGE_X), HUD_SCALE_Y(SB_SHIELD_GAUGE_Y), &GameBitmaps[Gauges[GAUGE_INVULNERABLE+invulnerable_frame].index]);
 		} else {
@@ -2023,7 +2023,7 @@ void draw_invulnerable_ship()
 			if (++invulnerable_frame == N_INVULNERABLE_FRAMES)
 				invulnerable_frame=0;
 		}
-	} else if (PlayerCfg.CockpitMode[1] == CM_STATUS_BAR)
+	} else if (PlayerCfg.CurrentCockpitMode == CM_STATUS_BAR)
 		sb_draw_shield_bar(f2ir(Players[pnum].shields));
 	else
 		draw_shield_bar(f2ir(Players[pnum].shields));
@@ -2283,7 +2283,7 @@ void hud_show_kill_list()
 
 	save_y = y = grd_curcanv->cv_bitmap.bm_h - n_left*(LINE_SPACING);
 
-	if (PlayerCfg.CockpitMode[1] == CM_FULL_COCKPIT) {
+	if (PlayerCfg.CurrentCockpitMode == CM_FULL_COCKPIT) {
 		save_y = y -= FSPACX(6);
 		if ((Game_mode & GM_MULTI_COOP) || (Game_mode & GM_MULTI_ROBOTS))
 			x1 = FSPACX(33);
@@ -2311,7 +2311,7 @@ void hud_show_kill_list()
 		int sw,sh,aw;
 
 		if (i>=n_left) {
-			if (PlayerCfg.CockpitMode[1] == CM_FULL_COCKPIT)
+			if (PlayerCfg.CurrentCockpitMode == CM_FULL_COCKPIT)
 				x0 = grd_curcanv->cv_bitmap.bm_w - FSPACX(53);
 			else
 				x0 = grd_curcanv->cv_bitmap.bm_w - FSPACX(60);
@@ -4191,11 +4191,11 @@ void draw_hud()
 		// Show bomb countdown timers
 		observer_show_bomb_highlights();
 
-		if (is_observing_player() && PlayerCfg.ObsShowCockpit[get_observer_game_mode()] && !Obs_at_distance) {
-			if (PlayerCfg.CockpitMode[1]==CM_STATUS_BAR || PlayerCfg.CockpitMode[1]==CM_FULL_SCREEN)
+		if (can_draw_observer_cockpit()) {
+			if (PlayerCfg.CurrentCockpitMode==CM_STATUS_BAR || PlayerCfg.CurrentCockpitMode==CM_FULL_SCREEN)
 				hud_show_homing_warning();
 
-			if (PlayerCfg.CockpitMode[1]==CM_FULL_SCREEN) {
+			if (PlayerCfg.CurrentCockpitMode==CM_FULL_SCREEN) {
 				hud_show_energy();
 				hud_show_shield();
 				hud_show_weapons();
@@ -4210,9 +4210,9 @@ void draw_hud()
 				}
 			}
 
-			if (PlayerCfg.CockpitMode[1] != CM_LETTERBOX)
+			if (PlayerCfg.CurrentCockpitMode != CM_LETTERBOX)
 				show_reticle(PlayerCfg.ReticleType, 1);
-			if (PlayerCfg.CockpitMode[1] != CM_LETTERBOX && Newdemo_state != ND_STATE_PLAYBACK && (PlayerCfg.MouseControlStyle == MOUSE_CONTROL_FLIGHT_SIM) && PlayerCfg.MouseFSIndicator) /* Old School Mouse */
+			if (PlayerCfg.CurrentCockpitMode != CM_LETTERBOX && Newdemo_state != ND_STATE_PLAYBACK && (PlayerCfg.MouseControlStyle == MOUSE_CONTROL_FLIGHT_SIM) && PlayerCfg.MouseFSIndicator) /* Old School Mouse */
 				show_mousefs_indicator(Controls.raw_mouse_axis[0], Controls.raw_mouse_axis[1], Controls.raw_mouse_axis[2], GWIDTH/2, GHEIGHT/2, GHEIGHT/4);
 		}
 
@@ -4223,19 +4223,19 @@ void draw_hud()
 		return;
 
 	// Cruise speed
-	if ( Player_num > -1 && Viewer->type==OBJ_PLAYER && Viewer->id==Player_num && PlayerCfg.CockpitMode[1] != CM_REAR_VIEW)	{
+	if ( Player_num > -1 && Viewer->type==OBJ_PLAYER && Viewer->id==Player_num && PlayerCfg.CurrentCockpitMode != CM_REAR_VIEW)	{
 		int	x = FSPACX(1);
 		int	y = grd_curcanv->cv_bitmap.bm_h;
 
 		gr_set_curfont( GAME_FONT );
 		gr_set_fontcolor( BM_XRGB(0, 31, 0), -1 );
 		if (Cruise_speed > 0) {
-			if (PlayerCfg.CockpitMode[1]==CM_FULL_SCREEN) {
+			if (PlayerCfg.CurrentCockpitMode==CM_FULL_SCREEN) {
 				if (Game_mode & GM_MULTI)
 					y -= LINE_SPACING * 10;
 				else
 					y -= LINE_SPACING * 6;
-			} else if (PlayerCfg.CockpitMode[1] == CM_STATUS_BAR) {
+			} else if (PlayerCfg.CurrentCockpitMode == CM_STATUS_BAR) {
 				if (Game_mode & GM_MULTI)
 					y -= LINE_SPACING * 6;
 				else
@@ -4252,24 +4252,24 @@ void draw_hud()
 	}
 
 	//	Show score so long as not in rearview
-	if ( !Rear_view && PlayerCfg.CockpitMode[1]!=CM_REAR_VIEW && PlayerCfg.CockpitMode[1]!=CM_STATUS_BAR) {
+	if ( !Rear_view && PlayerCfg.CurrentCockpitMode!=CM_REAR_VIEW && PlayerCfg.CurrentCockpitMode!=CM_STATUS_BAR) {
 		hud_show_score();
 		if (score_time)
 			hud_show_score_added();
 	}
 
-	if ( !Rear_view && PlayerCfg.CockpitMode[1]!=CM_REAR_VIEW)
+	if ( !Rear_view && PlayerCfg.CurrentCockpitMode!=CM_REAR_VIEW)
 		hud_show_timer_count();
 
 	//	Show other stuff if not in rearview or letterbox.
-	if (!Rear_view && PlayerCfg.CockpitMode[1]!=CM_REAR_VIEW)
+	if (!Rear_view && PlayerCfg.CurrentCockpitMode!=CM_REAR_VIEW)
 	{
 		show_HUD_names();
 
-		if (PlayerCfg.CockpitMode[1]==CM_STATUS_BAR || PlayerCfg.CockpitMode[1]==CM_FULL_SCREEN)
+		if (PlayerCfg.CurrentCockpitMode==CM_STATUS_BAR || PlayerCfg.CurrentCockpitMode==CM_FULL_SCREEN)
 			hud_show_homing_warning();
 
-		if (PlayerCfg.CockpitMode[1]==CM_FULL_SCREEN) {
+		if (PlayerCfg.CurrentCockpitMode==CM_FULL_SCREEN) {
 			hud_show_energy();
 			hud_show_shield();
 			hud_show_weapons();
@@ -4290,24 +4290,24 @@ void draw_hud()
 #endif
 		HUD_render_message_frame();
 
-		if (PlayerCfg.CockpitMode[1]!=CM_STATUS_BAR)
+		if (PlayerCfg.CurrentCockpitMode!=CM_STATUS_BAR)
 			hud_show_lives();
 		if (Game_mode&GM_MULTI && Show_kill_list)
 			hud_show_kill_list();
-		if (PlayerCfg.CockpitMode[1] != CM_LETTERBOX)
+		if (PlayerCfg.CurrentCockpitMode != CM_LETTERBOX)
 			show_reticle(PlayerCfg.ReticleType, 1);
-		if (PlayerCfg.CockpitMode[1] != CM_LETTERBOX && Newdemo_state != ND_STATE_PLAYBACK && (PlayerCfg.MouseControlStyle == MOUSE_CONTROL_FLIGHT_SIM) && PlayerCfg.MouseFSIndicator) /* Old School Mouse */
+		if (PlayerCfg.CurrentCockpitMode != CM_LETTERBOX && Newdemo_state != ND_STATE_PLAYBACK && (PlayerCfg.MouseControlStyle == MOUSE_CONTROL_FLIGHT_SIM) && PlayerCfg.MouseFSIndicator) /* Old School Mouse */
 			show_mousefs_indicator(Controls.raw_mouse_axis[0], Controls.raw_mouse_axis[1], Controls.raw_mouse_axis[2], GWIDTH/2, GHEIGHT/2, GHEIGHT/4);
 		if (Game_mode & GM_MULTI && PlayerCfg.ObsShowObs[get_observer_game_mode()])
 		{
 			int startY = GHEIGHT;
 
-			if (PlayerCfg.CockpitMode[1] == CM_FULL_SCREEN || (is_observer() && (!is_observing_player() || Obs_at_distance || !PlayerCfg.ObsShowCockpit[get_observer_game_mode()]))) {
+			if (PlayerCfg.CurrentCockpitMode == CM_FULL_SCREEN || (is_observer() && !can_draw_observer_cockpit())) {
 				if ((Game_mode & GM_MULTI) || (Newdemo_state == ND_STATE_PLAYBACK && Newdemo_game_mode & GM_MULTI))
 					startY -= LINE_SPACING * 12;
 				else
 					startY -= LINE_SPACING * 6;
-			} else if (PlayerCfg.CockpitMode[1] == CM_STATUS_BAR) {
+			} else if (PlayerCfg.CurrentCockpitMode == CM_STATUS_BAR) {
 				if ((Game_mode & GM_MULTI) || (Newdemo_state == ND_STATE_PLAYBACK && Newdemo_game_mode & GM_MULTI))
 					startY -= LINE_SPACING * 8;
 				else
@@ -4323,7 +4323,7 @@ void draw_hud()
 		}
 	}
 
-	if (Rear_view && PlayerCfg.CockpitMode[1]!=CM_REAR_VIEW) {
+	if (Rear_view && PlayerCfg.CurrentCockpitMode!=CM_REAR_VIEW) {
 		HUD_render_message_frame();
 		gr_set_curfont( GAME_FONT );
 		gr_set_fontcolor(BM_XRGB(0,31,0),-1 );
@@ -4341,7 +4341,7 @@ void render_gauges()
 	int shields = f2ir(Players[pnum].shields);
 	int cloak = ((Players[pnum].flags&PLAYER_FLAGS_CLOAKED) != 0);
 
-	Assert(PlayerCfg.CockpitMode[1]==CM_FULL_COCKPIT || PlayerCfg.CockpitMode[1]==CM_STATUS_BAR);
+	Assert(PlayerCfg.CurrentCockpitMode==CM_FULL_COCKPIT || PlayerCfg.CurrentCockpitMode==CM_STATUS_BAR);
 
 	if (shields < 0 ) shields = 0;
 
@@ -4354,7 +4354,7 @@ void render_gauges()
 
 	draw_weapon_boxes();
 
-	if (PlayerCfg.CockpitMode[1] == CM_FULL_COCKPIT) {
+	if (PlayerCfg.CurrentCockpitMode == CM_FULL_COCKPIT) {
 
 		if (Newdemo_state == ND_STATE_RECORDING)
 			newdemo_record_player_energy(energy);
@@ -4379,7 +4379,7 @@ void render_gauges()
 		show_homing_warning();
 		draw_wbu_overlay();
 
-	} else if (PlayerCfg.CockpitMode[1] == CM_STATUS_BAR) {
+	} else if (PlayerCfg.CurrentCockpitMode == CM_STATUS_BAR) {
 
 		if (Newdemo_state == ND_STATE_RECORDING)
 			newdemo_record_player_energy(energy);

--- a/d1/main/newdemo.c
+++ b/d1/main/newdemo.c
@@ -2622,20 +2622,20 @@ int newdemo_read_frame_information(int rewrite)
 	if (nd_playback_v_dead)
 	{
 		Rear_view = 0;
-		if (PlayerCfg.CockpitMode[1] != CM_LETTERBOX)
+		if (PlayerCfg.CurrentCockpitMode != CM_LETTERBOX)
 			select_cockpit(CM_LETTERBOX);
 	}
 	else if (nd_playback_v_rear)
 	{
 		Rear_view = nd_playback_v_rear;
-		if (PlayerCfg.CockpitMode[0] == CM_FULL_COCKPIT)
+		if (PlayerCfg.PreferredCockpitMode == CM_FULL_COCKPIT)
 			select_cockpit(CM_REAR_VIEW);
 	}
 	else
 	{
 		Rear_view = 0;
-		if (PlayerCfg.CockpitMode[1] != PlayerCfg.CockpitMode[0])
-			select_cockpit(PlayerCfg.CockpitMode[0]);
+		if (PlayerCfg.CurrentCockpitMode != PlayerCfg.PreferredCockpitMode)
+			select_cockpit(PlayerCfg.PreferredCockpitMode);
 	}
 
 	if (nd_playback_v_bad_read) {

--- a/d1/main/object.c
+++ b/d1/main/object.c
@@ -1366,7 +1366,7 @@ void dead_player_end(void)
 	Player_exploded = 0;
 	obj_delete(Dead_player_camera-Objects);
 	//Dead_player_camera = NULL;
-	select_cockpit(PlayerCfg.CockpitMode[0]);
+	select_cockpit(PlayerCfg.PreferredCockpitMode);
 	Viewer = Viewer_save;
 	ConsoleObject->type = OBJ_PLAYER;
 	ConsoleObject->flags = Player_flags_save;

--- a/d1/main/player.c
+++ b/d1/main/player.c
@@ -9,6 +9,7 @@
 #include "multi.h"
 #include "hudmsg.h"
 #include "byteswap.h"
+#include "playsave.h"
 
 int RespawningConcussions[MAX_PLAYERS]; 
 vms_vector Last_pos; // Saved position of observer prior to following a player.
@@ -75,7 +76,8 @@ void reset_obs() {
 		return;
 	
 	Current_obs_player = Player_num;
-	init_cockpit();
+	// Force the cockpit mode back to full screen, since we don't have data for the gauges.
+	select_cockpit(CM_FULL_SCREEN);
 
 	Objects[Players[Current_obs_player].objnum].pos = Last_pos;
 	Objects[Players[Current_obs_player].objnum].orient = Last_orient;
@@ -100,7 +102,7 @@ void set_obs(int pnum) {
 			HUD_init_message(HM_DEFAULT, "Observing %s!", Players[pnum].callsign);
 		}
 		Current_obs_player = pnum;
-		init_cockpit();
+		select_cockpit(can_draw_observer_cockpit() ? PlayerCfg.PreferredCockpitMode : CM_FULL_SCREEN);
 	} else {
 		reset_obs();
 	}

--- a/d1/main/playsave.c
+++ b/d1/main/playsave.c
@@ -89,7 +89,7 @@ int new_player_config()
     PlayerCfg.MouseOverrun[0] = PlayerCfg.MouseOverrun[1] = PlayerCfg.MouseOverrun[2] = PlayerCfg.MouseOverrun[3] = PlayerCfg.MouseOverrun[4] = PlayerCfg.MouseOverrun[5] = 0;
 	PlayerCfg.MouseFSDead = 0;
 	PlayerCfg.MouseFSIndicator = 1;
-	PlayerCfg.CockpitMode[0] = PlayerCfg.CockpitMode[1] = CM_FULL_COCKPIT;
+	PlayerCfg.CurrentCockpitMode = PlayerCfg.PreferredCockpitMode = CM_FULL_COCKPIT;
 	PlayerCfg.ReticleType = RET_TYPE_CLASSIC;
 	PlayerCfg.ReticleRGBA[0] = RET_COLOR_DEFAULT_R; PlayerCfg.ReticleRGBA[1] = RET_COLOR_DEFAULT_G; PlayerCfg.ReticleRGBA[2] = RET_COLOR_DEFAULT_B; PlayerCfg.ReticleRGBA[3] = RET_COLOR_DEFAULT_A;
 	PlayerCfg.ReticleSize = 0;
@@ -380,7 +380,7 @@ int read_player_d1x(char *filename)
 			while(!strstr(word,"END") && !PHYSFS_eof(f))
 			{
 				if(!strcmp(word,"MODE"))
-					PlayerCfg.CockpitMode[0] = PlayerCfg.CockpitMode[1] = atoi(line);
+					PlayerCfg.CurrentCockpitMode = PlayerCfg.PreferredCockpitMode = atoi(line);
 				else if(!strcmp(word,"HUD"))
 					PlayerCfg.HudMode = atoi(line);
 				else if(!strcmp(word,"RETTYPE"))
@@ -874,7 +874,7 @@ int write_player_d1x(char *filename)
 		PHYSFSX_printf(fout,"0=0x%x,0x%x,0x%x\n",PlayerCfg.KeySettingsD1X[27],PlayerCfg.KeySettingsD1X[28],PlayerCfg.KeySettingsD1X[29]);
 		PHYSFSX_printf(fout,"[end]\n");
 		PHYSFSX_printf(fout,"[cockpit]\n");
-		PHYSFSX_printf(fout,"mode=%i\n",PlayerCfg.CockpitMode[0]);
+		PHYSFSX_printf(fout,"mode=%i\n",PlayerCfg.PreferredCockpitMode);
 		PHYSFSX_printf(fout,"hud=%i\n",PlayerCfg.HudMode);
 		PHYSFSX_printf(fout,"rettype=%i\n",PlayerCfg.ReticleType);
 		PHYSFSX_printf(fout,"retrgba=%i,%i,%i,%i\n",PlayerCfg.ReticleRGBA[0],PlayerCfg.ReticleRGBA[1],PlayerCfg.ReticleRGBA[2],PlayerCfg.ReticleRGBA[3]);

--- a/d1/main/playsave.h
+++ b/d1/main/playsave.h
@@ -73,7 +73,8 @@ typedef struct player_config
     int MouseOverrun[6];
 	int MouseFSDead;
 	int MouseFSIndicator;
-	int CockpitMode[2]; // 0 saves the "real" cockpit, 1 also saves letterbox and rear. Used to properly switch between modes and restore the real one.
+	int PreferredCockpitMode;
+	int CurrentCockpitMode; // Also includes letterbox/rear, which are not persisted in the player profile
 	char NetworkMessageMacro[4][MAX_MESSAGE_LEN];
 	int NetlifeKills;
 	int NetlifeKilled;

--- a/d1/main/render.c
+++ b/d1/main/render.c
@@ -1382,7 +1382,7 @@ void render_frame(fix eye_offset)
 
 	Viewer_eye = Viewer->pos;
 
-//	if (Viewer->type == OBJ_PLAYER && (PlayerCfg.CockpitMode[1]!=CM_REAR_VIEW))
+//	if (Viewer->type == OBJ_PLAYER && (PlayerCfg.CurrentCockpitMode!=CM_REAR_VIEW))
 //		vm_vec_scale_add2(&Viewer_eye,&Viewer->orient.fvec,(Viewer->size*3)/4);
 
 	if (eye_offset)	{

--- a/d2/main/endlevel.c
+++ b/d2/main/endlevel.c
@@ -517,7 +517,7 @@ void stop_endlevel_sequence()
 {
 	Interpolation_method = 0;
 
-	select_cockpit(PlayerCfg.CockpitMode[0]);
+	select_cockpit(PlayerCfg.PreferredCockpitMode);
 
 	Endlevel_sequence = EL_OFF;
 

--- a/d2/main/game.c
+++ b/d2/main/game.c
@@ -190,21 +190,21 @@ void init_cockpit()
 		return;
 
 	if ( Screen_mode == SCREEN_EDITOR )
-		PlayerCfg.CockpitMode[1] = CM_FULL_SCREEN;
+		PlayerCfg.CurrentCockpitMode = CM_FULL_SCREEN;
 
 #ifndef OGL
-	if ( Game_screen_mode != (GameArg.GfxHiresGFXAvailable? SM(640,480) : SM(320,200)) && PlayerCfg.CockpitMode[1] != CM_LETTERBOX) {
-		PlayerCfg.CockpitMode[1] = CM_FULL_SCREEN;
+	if ( Game_screen_mode != (GameArg.GfxHiresGFXAvailable? SM(640,480) : SM(320,200)) && PlayerCfg.CurrentCockpitMode != CM_LETTERBOX) {
+		PlayerCfg.CurrentCockpitMode = CM_FULL_SCREEN;
 	}
 #endif
 
 	gr_set_current_canvas(NULL);
 
-	if (is_observer() && (!is_observing_player() || Obs_at_distance || !PlayerCfg.ObsShowCockpit[get_observer_game_mode()])) {
+	if (is_observer() && !can_draw_observer_cockpit()) {
 		game_init_render_sub_buffers(0, 0, SWIDTH, SHEIGHT);
 	}
 	else {
-		switch (PlayerCfg.CockpitMode[1]) {
+		switch (PlayerCfg.CurrentCockpitMode) {
 			case CM_FULL_COCKPIT:
 				game_init_render_sub_buffers(0, 0, SWIDTH, (SHEIGHT * 2) / 3);
 				break;
@@ -214,8 +214,8 @@ void init_cockpit()
 				int x1 = 0, y1 = 0, x2 = SWIDTH, y2 = (SHEIGHT * 2) / 3;
 				grs_bitmap* bm;
 
-				PIGGY_PAGE_IN(cockpit_bitmap[PlayerCfg.CockpitMode[1]]);
-				bm = &GameBitmaps[cockpit_bitmap[PlayerCfg.CockpitMode[1]].index];
+				PIGGY_PAGE_IN(cockpit_bitmap[PlayerCfg.CurrentCockpitMode]);
+				bm = &GameBitmaps[cockpit_bitmap[PlayerCfg.CurrentCockpitMode].index];
 				gr_bitblt_find_transparent_area(bm, &x1, &y1, &x2, &y2);
 				game_init_render_sub_buffers(x1 * ((float)SWIDTH / bm->bm_w), y1 * ((float)SHEIGHT / bm->bm_h), (x2 - x1 + 1) * ((float)SWIDTH / bm->bm_w), (y2 - y1 + 2) * ((float)SHEIGHT / bm->bm_h));
 				break;
@@ -251,8 +251,8 @@ void init_cockpit()
 //selects a given cockpit (or lack of one).  See types in game.h
 void select_cockpit(int mode)
 {
-	if (mode != PlayerCfg.CockpitMode[1]) {		//new mode
-		PlayerCfg.CockpitMode[1]=mode;
+	if (mode != PlayerCfg.CurrentCockpitMode) {		//new mode
+		PlayerCfg.CurrentCockpitMode = mode;
 		init_cockpit();
 	}
 }
@@ -990,8 +990,8 @@ void check_rear_view()
 
 		if (Rear_view) {
 			Rear_view = 0;
-			if (PlayerCfg.CockpitMode[1]==CM_REAR_VIEW) {
-				select_cockpit(PlayerCfg.CockpitMode[0]);
+			if (PlayerCfg.CurrentCockpitMode==CM_REAR_VIEW) {
+				select_cockpit(PlayerCfg.PreferredCockpitMode);
 			}
 			if (Newdemo_state == ND_STATE_RECORDING)
 				newdemo_record_restore_rearview();
@@ -1000,7 +1000,7 @@ void check_rear_view()
 			Rear_view = 1;
 			leave_mode = 0;		//means wait for another key
 			entry_time = timer_query();
-			if (PlayerCfg.CockpitMode[1] == CM_FULL_COCKPIT) {
+			if (PlayerCfg.CurrentCockpitMode == CM_FULL_COCKPIT) {
 				select_cockpit(CM_REAR_VIEW);
 			}
 			if (Newdemo_state == ND_STATE_RECORDING)
@@ -1020,8 +1020,8 @@ void check_rear_view()
 		{
 			if (leave_mode==1 && Rear_view) {
 				Rear_view = 0;
-				if (PlayerCfg.CockpitMode[1]==CM_REAR_VIEW) {
-					select_cockpit(PlayerCfg.CockpitMode[0]);
+				if (PlayerCfg.CurrentCockpitMode==CM_REAR_VIEW) {
+					select_cockpit(PlayerCfg.PreferredCockpitMode);
 				}
 				if (Newdemo_state == ND_STATE_RECORDING)
 					newdemo_record_restore_rearview();
@@ -1037,7 +1037,7 @@ void reset_rear_view(void)
 	}
 
 	Rear_view = 0;
-	select_cockpit(PlayerCfg.CockpitMode[0]);
+	select_cockpit(PlayerCfg.PreferredCockpitMode);
 }
 
 int Config_menu_flag;
@@ -1061,7 +1061,7 @@ window *game_setup(void)
 {
 	window *game_wind;
 
-	PlayerCfg.CockpitMode[1] = PlayerCfg.CockpitMode[0];
+	PlayerCfg.CurrentCockpitMode = PlayerCfg.PreferredCockpitMode;
 	last_drawn_cockpit = -1;	// Force cockpit to redraw next time a frame renders.
 	Endlevel_sequence = 0;
 
@@ -1947,4 +1947,11 @@ object* get_player_view_object()
 		return &Objects[Players[Current_obs_player].objnum];
 	else
 		return ConsoleObject;
+}
+
+bool can_draw_observer_cockpit()
+{
+	// We can only draw a cockpit in observer mode if the relevant setting is enabled, and we're
+	// observing in first-person mode.
+	return PlayerCfg.ObsShowCockpit[get_observer_game_mode()] && is_observing_player() && !Obs_at_distance;
 }

--- a/d2/main/game.h
+++ b/d2/main/game.h
@@ -239,6 +239,7 @@ void game_leave_menus(void);
 
 bool is_observer();
 struct object* get_player_view_object();
+bool can_draw_observer_cockpit();
 
 //Cheats
 typedef struct game_cheats

--- a/d2/main/gamecntl.c
+++ b/d2/main/gamecntl.c
@@ -852,7 +852,9 @@ int HandleSystemKey(int key)
 		KEY_MAC(case KEY_COMMAND+KEY_3:)
 
 		case KEY_F3:
-			if (!Player_is_dead && Viewer->type==OBJ_PLAYER) //if (!(Guided_missile[Player_num] && Guided_missile[Player_num]->type==OBJ_WEAPON && Guided_missile[Player_num]->id==GUIDEDMISS_ID && Guided_missile[Player_num]->signature==Guided_missile_sig[Player_num] && PlayerCfg.GuidedInBigWindow))
+			if ((!Player_is_dead && Viewer->type==OBJ_PLAYER) ||
+				// Alternatively, we can also toggle the cockpit while observing in first-person mode.
+				(is_observer() && can_draw_observer_cockpit()))
 			{
 				toggle_cockpit();
 			}

--- a/d2/main/gauges.c
+++ b/d2/main/gauges.c
@@ -981,13 +981,13 @@ void hud_show_orbs (void)
 		grs_bitmap *bm;
 		int pnum = get_pnum_for_hud();
 
-		if (PlayerCfg.CockpitMode[1] == CM_FULL_COCKPIT) {
+		if (PlayerCfg.CurrentCockpitMode == CM_FULL_COCKPIT) {
 			x = (SWIDTH/18);
 		}
-		else if (PlayerCfg.CockpitMode[1] == CM_STATUS_BAR) {
+		else if (PlayerCfg.CurrentCockpitMode == CM_STATUS_BAR) {
 			x = FSPACX(2);
 		}
-		else if (PlayerCfg.CockpitMode[1] == CM_FULL_SCREEN) {
+		else if (PlayerCfg.CurrentCockpitMode == CM_FULL_SCREEN) {
 			y=HUD_SCALE_Y_AR(GameBitmaps[ GET_GAUGE_INDEX(GAUGE_LIVES) ].bm_h+GameBitmaps[ GET_GAUGE_INDEX(KEY_ICON_RED) ].bm_h+4)+FSPACY(1);
 			x = FSPACX(2);
 		}
@@ -1011,15 +1011,15 @@ void hud_show_flag(void)
 		int x=0,y=0,icon;
 		grs_bitmap *bm;
 
-		if (PlayerCfg.CockpitMode[1] == CM_FULL_COCKPIT) {
+		if (PlayerCfg.CurrentCockpitMode == CM_FULL_COCKPIT) {
 			y=HUD_SCALE_Y_AR(GameBitmaps[ GET_GAUGE_INDEX(GAUGE_LIVES) ].bm_h+2)+FSPACY(1);
 			x = (SWIDTH/10);
 		}
-		else if (PlayerCfg.CockpitMode[1] == CM_STATUS_BAR) {
+		else if (PlayerCfg.CurrentCockpitMode == CM_STATUS_BAR) {
 			y=HUD_SCALE_Y_AR(GameBitmaps[ GET_GAUGE_INDEX(GAUGE_LIVES) ].bm_h+2)+FSPACY(1);
 			x = FSPACX(2);
 		}
-		else if (PlayerCfg.CockpitMode[1] == CM_FULL_SCREEN) {
+		else if (PlayerCfg.CurrentCockpitMode == CM_FULL_SCREEN) {
 			y=HUD_SCALE_Y_AR(GameBitmaps[ GET_GAUGE_INDEX(GAUGE_LIVES) ].bm_h+GameBitmaps[ GET_GAUGE_INDEX(KEY_ICON_RED) ].bm_h+4)+FSPACY(1);
 			x = FSPACX(2);
 		}
@@ -1124,7 +1124,7 @@ void show_bomb_count(int x,int y,int bg_color,int always_show,int right_align)
 
 void draw_primary_ammo_info(int ammo_count)
 {
-	if (PlayerCfg.CockpitMode[1] == CM_STATUS_BAR)
+	if (PlayerCfg.CurrentCockpitMode == CM_STATUS_BAR)
 		draw_ammo_info(SB_PRIMARY_AMMO_X,SB_PRIMARY_AMMO_Y,ammo_count,1);
 	else
 		draw_ammo_info(PRIMARY_AMMO_X,PRIMARY_AMMO_Y,ammo_count,1);
@@ -1176,7 +1176,7 @@ void hud_show_weapons_mode(int type,int vertical,int x,int y){
 			}else
 				x-=w+FSPACX(3);
 			gr_string(x, y, weapon_str);
-			if (i == 1 && Players[pnum].primary_weapon == i && PlayerCfg.CockpitMode[1]==CM_FULL_SCREEN)
+			if (i == 1 && Players[pnum].primary_weapon == i && PlayerCfg.CurrentCockpitMode==CM_FULL_SCREEN)
 				gr_printf(x,y-(LINE_SPACING*1),"V:%i",f2i((unsigned int)Players[pnum].primary_ammo[1] * VULCAN_AMMO_SCALE));
 		}
 	} else {
@@ -1237,7 +1237,7 @@ void hud_show_weapons_mode(int type,int vertical,int x,int y){
 				case 8:
 					sprintf(weapon_str,"P");break;
 				case 9:
-					if (PlayerCfg.CockpitMode[1]==CM_FULL_SCREEN)
+					if (PlayerCfg.CurrentCockpitMode==CM_FULL_SCREEN)
 						sprintf(weapon_str, "O%03i", Omega_charge * 100/MAX_OMEGA_CHARGE);
 					else
 						sprintf(weapon_str,"O");
@@ -1252,7 +1252,7 @@ void hud_show_weapons_mode(int type,int vertical,int x,int y){
 
 			gr_string(x, y, weapon_str);
 
-			if (i == 6 && Players[pnum].primary_weapon == i && PlayerCfg.CockpitMode[1]==CM_FULL_SCREEN)
+			if (i == 6 && Players[pnum].primary_weapon == i && PlayerCfg.CurrentCockpitMode==CM_FULL_SCREEN)
 				gr_printf(x+FSPACX(9),y-(LINE_SPACING*2),"G:%i",f2i((unsigned int)Players[pnum].primary_ammo[1] * VULCAN_AMMO_SCALE));
 
 			// Deal with vulcan ammo uniformly here
@@ -1461,7 +1461,7 @@ void hud_show_lives()
 	if (HUD_toolong)
 		return;
 
-	if (PlayerCfg.CockpitMode[1] == CM_FULL_COCKPIT)
+	if (PlayerCfg.CurrentCockpitMode == CM_FULL_COCKPIT)
 		x = HUD_SCALE_X(7);
 	else
 		x = FSPACX(2);
@@ -1689,7 +1689,7 @@ void cockpit_decode_alpha(grs_bitmap *bm)
 
 void draw_wbu_overlay()
 {
-	unsigned cockpit_idx = PlayerCfg.CockpitMode[1]+(HIRESMODE?(Num_cockpits/2):0);
+	unsigned cockpit_idx = PlayerCfg.CurrentCockpitMode+(HIRESMODE?(Num_cockpits/2):0);
 	PIGGY_PAGE_IN(cockpit_bitmap[cockpit_idx]);
 	grs_bitmap *bm = &GameBitmaps[cockpit_bitmap[cockpit_idx].index];
 
@@ -1986,7 +1986,7 @@ void draw_weapon_info(int weapon_type,int weapon_num,int laser_level)
 		if (info_index == LASER_ID && laser_level > MAX_LASER_LEVEL)
 			info_index = SUPER_LASER_ID;
 
-		if (PlayerCfg.CockpitMode[1] == CM_STATUS_BAR)
+		if (PlayerCfg.CurrentCockpitMode == CM_STATUS_BAR)
 			draw_weapon_info_sub(info_index,
 				&gauge_boxes[SB_PRIMARY_BOX],
 				SB_PRIMARY_W_PIC_X,SB_PRIMARY_W_PIC_Y,
@@ -2003,7 +2003,7 @@ void draw_weapon_info(int weapon_type,int weapon_num,int laser_level)
 	else {
 		info_index = Secondary_weapon_to_weapon_info[weapon_num];
 
-		if (PlayerCfg.CockpitMode[1] == CM_STATUS_BAR)
+		if (PlayerCfg.CurrentCockpitMode == CM_STATUS_BAR)
 			draw_weapon_info_sub(info_index,
 				&gauge_boxes[SB_SECONDARY_BOX],
 				SB_SECONDARY_W_PIC_X,SB_SECONDARY_W_PIC_Y,
@@ -2019,10 +2019,10 @@ void draw_weapon_info(int weapon_type,int weapon_num,int laser_level)
 	if (PlayerCfg.HudMode!=0)
 	{
 		if (weapon_box_user[0] == WBU_WEAPON) {
-			hud_show_weapons_mode(0,1,(PlayerCfg.CockpitMode[1]==CM_STATUS_BAR?SB_PRIMARY_AMMO_X:PRIMARY_AMMO_X),(PlayerCfg.CockpitMode[1]==CM_STATUS_BAR?SB_SECONDARY_AMMO_Y:SECONDARY_AMMO_Y));
+			hud_show_weapons_mode(0,1,(PlayerCfg.CurrentCockpitMode==CM_STATUS_BAR?SB_PRIMARY_AMMO_X:PRIMARY_AMMO_X),(PlayerCfg.CurrentCockpitMode==CM_STATUS_BAR?SB_SECONDARY_AMMO_Y:SECONDARY_AMMO_Y));
 		}
 		if (weapon_box_user[1] == WBU_WEAPON) {
-			hud_show_weapons_mode(1,1,(PlayerCfg.CockpitMode[1]==CM_STATUS_BAR?SB_SECONDARY_AMMO_X:SECONDARY_AMMO_X),(PlayerCfg.CockpitMode[1]==CM_STATUS_BAR?SB_SECONDARY_AMMO_Y:SECONDARY_AMMO_Y));
+			hud_show_weapons_mode(1,1,(PlayerCfg.CurrentCockpitMode==CM_STATUS_BAR?SB_SECONDARY_AMMO_X:SECONDARY_AMMO_X),(PlayerCfg.CurrentCockpitMode==CM_STATUS_BAR?SB_SECONDARY_AMMO_Y:SECONDARY_AMMO_Y));
 		}
 	}
 }
@@ -2039,7 +2039,7 @@ void draw_ammo_info(int x,int y,int ammo_count,int primary)
 
 void draw_secondary_ammo_info(int ammo_count)
 {
-	if (PlayerCfg.CockpitMode[1] == CM_STATUS_BAR)
+	if (PlayerCfg.CurrentCockpitMode == CM_STATUS_BAR)
 		draw_ammo_info(SB_SECONDARY_AMMO_X,SB_SECONDARY_AMMO_Y,ammo_count,0);
 	else
 		draw_ammo_info(SECONDARY_AMMO_X,SECONDARY_AMMO_Y,ammo_count,0);
@@ -2101,7 +2101,7 @@ void draw_weapon_box(int weapon_type,int weapon_num)
 	if (weapon_box_states[weapon_type] != WS_SET)		//fade gauge
 	{
 		int fade_value = f2i(weapon_box_fade_values[weapon_type]);
-		int boxofs = (PlayerCfg.CockpitMode[1]==CM_STATUS_BAR)?SB_PRIMARY_BOX:COCKPIT_PRIMARY_BOX;
+		int boxofs = (PlayerCfg.CurrentCockpitMode==CM_STATUS_BAR)?SB_PRIMARY_BOX:COCKPIT_PRIMARY_BOX;
 
 		gr_settransblend(fade_value, GR_BLEND_NORMAL);
 		gr_rect(HUD_SCALE_X(gauge_boxes[boxofs+weapon_type].left),HUD_SCALE_Y(gauge_boxes[boxofs+weapon_type].top),HUD_SCALE_X(gauge_boxes[boxofs+weapon_type].right),HUD_SCALE_Y(gauge_boxes[boxofs+weapon_type].bot));
@@ -2119,7 +2119,7 @@ void draw_static(int win)
 	vclip *vc = &Vclip[VCLIP_MONITOR_STATIC];
 	grs_bitmap *bmp;
 	int framenum;
-	int boxofs = (PlayerCfg.CockpitMode[1]==CM_STATUS_BAR)?SB_PRIMARY_BOX:COCKPIT_PRIMARY_BOX;
+	int boxofs = (PlayerCfg.CurrentCockpitMode==CM_STATUS_BAR)?SB_PRIMARY_BOX:COCKPIT_PRIMARY_BOX;
 #ifndef OGL
 	int x,y;
 #endif
@@ -2290,7 +2290,7 @@ void draw_invulnerable_ship()
 	if (Players[pnum].invulnerable_time+INVULNERABLE_TIME_MAX-GameTime64 > 0 && (Players[pnum].invulnerable_time + INVULNERABLE_TIME_MAX - GameTime64 > F1_0*4 || GameTime64 & 0x8000))
 	{
 
-		if (PlayerCfg.CockpitMode[1] == CM_STATUS_BAR)	{
+		if (PlayerCfg.CurrentCockpitMode == CM_STATUS_BAR)	{
 			PAGE_IN_GAUGE( GAUGE_INVULNERABLE+invulnerable_frame );
 			hud_bitblt( HUD_SCALE_X(SB_SHIELD_GAUGE_X), HUD_SCALE_Y(SB_SHIELD_GAUGE_Y), &GameBitmaps[GET_GAUGE_INDEX(GAUGE_INVULNERABLE+invulnerable_frame) ]);
 		} else {
@@ -2305,7 +2305,7 @@ void draw_invulnerable_ship()
 			if (++invulnerable_frame == N_INVULNERABLE_FRAMES)
 				invulnerable_frame=0;
 		}
-	} else if (PlayerCfg.CockpitMode[1] == CM_STATUS_BAR)
+	} else if (PlayerCfg.CurrentCockpitMode == CM_STATUS_BAR)
 		sb_draw_shield_bar(f2ir(Players[pnum].shields));
 	else
 		draw_shield_bar(f2ir(Players[pnum].shields));
@@ -2572,7 +2572,7 @@ void hud_show_kill_list()
 
 	save_y = y = grd_curcanv->cv_bitmap.bm_h - n_left*(LINE_SPACING);
 
-	if (PlayerCfg.CockpitMode[1] == CM_FULL_COCKPIT) {
+	if (PlayerCfg.CurrentCockpitMode == CM_FULL_COCKPIT) {
 		save_y = y -= FSPACX(6);
 		if ((Game_mode & GM_MULTI_COOP) || (Game_mode & GM_MULTI_ROBOTS))
 			x1 = FSPACX(33);
@@ -2599,7 +2599,7 @@ void hud_show_kill_list()
 		int sw,sh,aw;
 
 		if (i>=n_left) {
-			if (PlayerCfg.CockpitMode[1] == CM_FULL_COCKPIT)
+			if (PlayerCfg.CurrentCockpitMode == CM_FULL_COCKPIT)
 				x0 = grd_curcanv->cv_bitmap.bm_w - FSPACX(53);
 			else
 				x0 = grd_curcanv->cv_bitmap.bm_w - FSPACX(60);
@@ -4533,11 +4533,11 @@ void draw_hud()
 		// Show bomb/mine countdown timers
 		observer_show_bomb_highlights();
 
-		if (is_observing_player() && PlayerCfg.ObsShowCockpit[get_observer_game_mode()] && !Obs_at_distance) {
-			if (PlayerCfg.CockpitMode[1] == CM_STATUS_BAR || PlayerCfg.CockpitMode[1] == CM_FULL_SCREEN)
+		if (can_draw_observer_cockpit()) {
+			if (PlayerCfg.CurrentCockpitMode == CM_STATUS_BAR || PlayerCfg.CurrentCockpitMode == CM_FULL_SCREEN)
 				hud_show_homing_warning();
 
-			if (PlayerCfg.CockpitMode[1] == CM_FULL_SCREEN) {
+			if (PlayerCfg.CurrentCockpitMode == CM_FULL_SCREEN) {
 				hud_show_energy();
 				hud_show_shield();
 				hud_show_afterburner();
@@ -4552,15 +4552,15 @@ void draw_hud()
 				}
 			}
 
-			if (PlayerCfg.CockpitMode[1] != CM_LETTERBOX && PlayerCfg.CockpitMode[1] != CM_REAR_VIEW)
+			if (PlayerCfg.CurrentCockpitMode != CM_LETTERBOX && PlayerCfg.CurrentCockpitMode != CM_REAR_VIEW)
 			{
 				hud_show_flag();
 				hud_show_orbs();
 			}
 
-			if (PlayerCfg.CockpitMode[1] != CM_LETTERBOX)
+			if (PlayerCfg.CurrentCockpitMode != CM_LETTERBOX)
 				show_reticle(PlayerCfg.ReticleType, 1);
-			if (PlayerCfg.CockpitMode[1] != CM_LETTERBOX && Newdemo_state != ND_STATE_PLAYBACK && (PlayerCfg.MouseControlStyle == MOUSE_CONTROL_FLIGHT_SIM) && PlayerCfg.MouseFSIndicator)
+			if (PlayerCfg.CurrentCockpitMode != CM_LETTERBOX && Newdemo_state != ND_STATE_PLAYBACK && (PlayerCfg.MouseControlStyle == MOUSE_CONTROL_FLIGHT_SIM) && PlayerCfg.MouseFSIndicator)
 				show_mousefs_indicator(Controls.raw_mouse_axis[0], Controls.raw_mouse_axis[1], Controls.raw_mouse_axis[2], GWIDTH / 2, GHEIGHT / 2, GHEIGHT / 4);
 		}
 
@@ -4571,19 +4571,19 @@ void draw_hud()
 		return;
 
 	// Cruise speed
-	if ( Player_num > -1 && Viewer->type==OBJ_PLAYER && Viewer->id==Player_num && PlayerCfg.CockpitMode[1] != CM_REAR_VIEW)	{
+	if ( Player_num > -1 && Viewer->type==OBJ_PLAYER && Viewer->id==Player_num && PlayerCfg.CurrentCockpitMode != CM_REAR_VIEW)	{
 		int	x = FSPACX(1);
 		int	y = grd_curcanv->cv_bitmap.bm_h;
 
 		gr_set_curfont( GAME_FONT );
 		gr_set_fontcolor( BM_XRGB(0, 31, 0), -1 );
 		if (Cruise_speed > 0) {
-			if (PlayerCfg.CockpitMode[1]==CM_FULL_SCREEN) {
+			if (PlayerCfg.CurrentCockpitMode==CM_FULL_SCREEN) {
 				if (Game_mode & GM_MULTI)
 					y -= LINE_SPACING * 10;
 				else
 					y -= LINE_SPACING * 6;
-			} else if (PlayerCfg.CockpitMode[1] == CM_STATUS_BAR) {
+			} else if (PlayerCfg.CurrentCockpitMode == CM_STATUS_BAR) {
 				if (Game_mode & GM_MULTI)
 					y -= LINE_SPACING * 6;
 				else
@@ -4600,24 +4600,24 @@ void draw_hud()
 	}
 
 	//	Show score so long as not in rearview
-	if ( !Rear_view && PlayerCfg.CockpitMode[1]!=CM_REAR_VIEW && PlayerCfg.CockpitMode[1]!=CM_STATUS_BAR) {
+	if ( !Rear_view && PlayerCfg.CurrentCockpitMode!=CM_REAR_VIEW && PlayerCfg.CurrentCockpitMode!=CM_STATUS_BAR) {
 		hud_show_score();
 		if (score_time)
 			hud_show_score_added();
 	}
 
-	if ( !Rear_view && PlayerCfg.CockpitMode[1]!=CM_REAR_VIEW)
+	if ( !Rear_view && PlayerCfg.CurrentCockpitMode!=CM_REAR_VIEW)
 		hud_show_timer_count();
 
 	//	Show other stuff if not in rearview or letterbox.
-	if (!Rear_view && PlayerCfg.CockpitMode[1]!=CM_REAR_VIEW)
+	if (!Rear_view && PlayerCfg.CurrentCockpitMode!=CM_REAR_VIEW)
 	{
 		show_HUD_names();
 
-		if (PlayerCfg.CockpitMode[1]==CM_STATUS_BAR || PlayerCfg.CockpitMode[1]==CM_FULL_SCREEN)
+		if (PlayerCfg.CurrentCockpitMode==CM_STATUS_BAR || PlayerCfg.CurrentCockpitMode==CM_FULL_SCREEN)
 			hud_show_homing_warning();
 
-		if (PlayerCfg.CockpitMode[1]==CM_FULL_SCREEN) {
+		if (PlayerCfg.CurrentCockpitMode==CM_FULL_SCREEN) {
 			hud_show_energy();
 			hud_show_shield();
 			hud_show_afterburner();
@@ -4637,7 +4637,7 @@ void draw_hud()
 			show_time();
 #endif
 
-		if (PlayerCfg.CockpitMode[1] != CM_LETTERBOX && PlayerCfg.CockpitMode[1] != CM_REAR_VIEW)
+		if (PlayerCfg.CurrentCockpitMode != CM_LETTERBOX && PlayerCfg.CurrentCockpitMode != CM_REAR_VIEW)
 		{
 			hud_show_flag();
 			hud_show_orbs();
@@ -4645,25 +4645,25 @@ void draw_hud()
 		
 		HUD_render_message_frame();
 
-		if (PlayerCfg.CockpitMode[1]!=CM_STATUS_BAR)
+		if (PlayerCfg.CurrentCockpitMode!=CM_STATUS_BAR)
 			hud_show_lives();
 		if (Game_mode&GM_MULTI && Show_kill_list)
 			hud_show_kill_list();
-		if (PlayerCfg.CockpitMode[1] != CM_LETTERBOX)
+		if (PlayerCfg.CurrentCockpitMode != CM_LETTERBOX)
 			show_reticle(PlayerCfg.ReticleType, 1);
-		if (PlayerCfg.CockpitMode[1] != CM_LETTERBOX && Newdemo_state != ND_STATE_PLAYBACK && (PlayerCfg.MouseControlStyle == MOUSE_CONTROL_FLIGHT_SIM) && PlayerCfg.MouseFSIndicator)
+		if (PlayerCfg.CurrentCockpitMode != CM_LETTERBOX && Newdemo_state != ND_STATE_PLAYBACK && (PlayerCfg.MouseControlStyle == MOUSE_CONTROL_FLIGHT_SIM) && PlayerCfg.MouseFSIndicator)
 			show_mousefs_indicator(Controls.raw_mouse_axis[0], Controls.raw_mouse_axis[1], Controls.raw_mouse_axis[2], GWIDTH/2, GHEIGHT/2, GHEIGHT/4);
 		if (Game_mode & GM_MULTI && PlayerCfg.ObsShowObs[get_observer_game_mode()])
 		{
 			int startY = GHEIGHT;
 
-			if (PlayerCfg.CockpitMode[1] == CM_FULL_SCREEN || (is_observer() && (!is_observing_player() || Obs_at_distance || !PlayerCfg.ObsShowCockpit[get_observer_game_mode()]))) {
+			if (PlayerCfg.CurrentCockpitMode == CM_FULL_SCREEN || (is_observer() && !can_draw_observer_cockpit())) {
 				if ((Game_mode & GM_MULTI) || (Newdemo_state == ND_STATE_PLAYBACK && Newdemo_game_mode & GM_MULTI))
 					startY -= LINE_SPACING * 12;
 				else
 					startY -= LINE_SPACING * 6;
 			}
-			else if (PlayerCfg.CockpitMode[1] == CM_STATUS_BAR) {
+			else if (PlayerCfg.CurrentCockpitMode == CM_STATUS_BAR) {
 				if ((Game_mode & GM_MULTI) || (Newdemo_state == ND_STATE_PLAYBACK && Newdemo_game_mode & GM_MULTI))
 					startY -= LINE_SPACING * 8;
 				else
@@ -4680,7 +4680,7 @@ void draw_hud()
 		}
 	}
 
-	if (Rear_view && PlayerCfg.CockpitMode[1]!=CM_REAR_VIEW) {
+	if (Rear_view && PlayerCfg.CurrentCockpitMode!=CM_REAR_VIEW) {
 		HUD_render_message_frame();
 		gr_set_curfont( GAME_FONT );
 		gr_set_fontcolor(BM_XRGB(0,31,0),-1 );
@@ -4697,7 +4697,7 @@ void render_gauges()
 	int shields = f2ir(Players[pnum].shields);
 	int cloak = ((Players[pnum].flags&PLAYER_FLAGS_CLOAKED) != 0);
 
-	Assert(PlayerCfg.CockpitMode[1]==CM_FULL_COCKPIT || PlayerCfg.CockpitMode[1]==CM_STATUS_BAR);
+	Assert(PlayerCfg.CurrentCockpitMode==CM_FULL_COCKPIT || PlayerCfg.CurrentCockpitMode==CM_STATUS_BAR);
 
 	if (shields < 0 ) shields = 0;
 
@@ -4710,7 +4710,7 @@ void render_gauges()
 
 	draw_weapon_boxes();
 
-	if (PlayerCfg.CockpitMode[1] == CM_FULL_COCKPIT) {
+	if (PlayerCfg.CurrentCockpitMode == CM_FULL_COCKPIT) {
 		if (Newdemo_state == ND_STATE_RECORDING)
 			newdemo_record_player_energy(energy);
 		draw_energy_bar(energy);
@@ -4739,7 +4739,7 @@ void render_gauges()
 		show_homing_warning();
 		draw_wbu_overlay();
 
-	} else if (PlayerCfg.CockpitMode[1] == CM_STATUS_BAR) {
+	} else if (PlayerCfg.CurrentCockpitMode == CM_STATUS_BAR) {
 
 		if (Newdemo_state == ND_STATE_RECORDING)
 			newdemo_record_player_energy(energy);
@@ -4837,7 +4837,7 @@ void do_cockpit_window_view(int win,object *viewer,int rear_view_flag,int user,c
 	Viewer = viewer;
 	Rear_view = rear_view_flag;
 
-	if (PlayerCfg.CockpitMode[1] == CM_FULL_SCREEN)
+	if (PlayerCfg.CurrentCockpitMode == CM_FULL_SCREEN)
 	{
 		w = HUD_SCALE_X_AR(HIRESMODE?106:44);
 		h = HUD_SCALE_Y_AR(HIRESMODE?106:44);
@@ -4850,9 +4850,9 @@ void do_cockpit_window_view(int win,object *viewer,int rear_view_flag,int user,c
 		gr_init_sub_canvas(&window_canv,&grd_curscreen->sc_canvas,window_x,window_y,w,h);
 	}
 	else {
-		if (PlayerCfg.CockpitMode[1] == CM_FULL_COCKPIT)
+		if (PlayerCfg.CurrentCockpitMode == CM_FULL_COCKPIT)
 			boxnum = (COCKPIT_PRIMARY_BOX)+win;
-		else if (PlayerCfg.CockpitMode[1] == CM_STATUS_BAR)
+		else if (PlayerCfg.CurrentCockpitMode == CM_STATUS_BAR)
 			boxnum = (SB_PRIMARY_BOX)+win;
 		else
 			goto abort;
@@ -4882,7 +4882,7 @@ void do_cockpit_window_view(int win,object *viewer,int rear_view_flag,int user,c
 	if (user == WBU_GUIDED)
 		show_reticle(RET_TYPE_CROSS_V1, 0);
 
-	if (PlayerCfg.CockpitMode[1] == CM_FULL_SCREEN) {
+	if (PlayerCfg.CurrentCockpitMode == CM_FULL_SCREEN) {
 		int small_window_bottom,big_window_bottom,extra_part_h;
 
 		{
@@ -4932,7 +4932,7 @@ void do_cockpit_window_view(int win,object *viewer,int rear_view_flag,int user,c
 	//force redraw when done
 	old_weapon[win] = -1;
 
-	if (PlayerCfg.CockpitMode[1] == CM_FULL_COCKPIT)
+	if (PlayerCfg.CurrentCockpitMode == CM_FULL_COCKPIT)
 		draw_wbu_overlay();
 
 abort:;

--- a/d2/main/newdemo.c
+++ b/d2/main/newdemo.c
@@ -2872,28 +2872,28 @@ int newdemo_read_frame_information(int rewrite)
 	if (nd_playback_v_dead)
 	{
 		Rear_view = 0;
-		if (PlayerCfg.CockpitMode[1] != CM_LETTERBOX)
+		if (PlayerCfg.CurrentCockpitMode != CM_LETTERBOX)
 			select_cockpit(CM_LETTERBOX);
 	}
 	else if (nd_playback_v_guided)
 	{
 		Rear_view = 0;
-		if (PlayerCfg.CockpitMode[1] != CM_FULL_SCREEN || PlayerCfg.CockpitMode[1] != CM_STATUS_BAR)
+		if (PlayerCfg.CurrentCockpitMode != CM_FULL_SCREEN || PlayerCfg.CurrentCockpitMode != CM_STATUS_BAR)
 		{
-			select_cockpit((PlayerCfg.CockpitMode[0] == CM_FULL_SCREEN)?CM_FULL_SCREEN:CM_STATUS_BAR);
+			select_cockpit((PlayerCfg.PreferredCockpitMode == CM_FULL_SCREEN)?CM_FULL_SCREEN:CM_STATUS_BAR);
 		}
 	}
 	else if (nd_playback_v_rear)
 	{
 		Rear_view = nd_playback_v_rear;
-		if (PlayerCfg.CockpitMode[0] == CM_FULL_COCKPIT)
+		if (PlayerCfg.PreferredCockpitMode == CM_FULL_COCKPIT)
 			select_cockpit(CM_REAR_VIEW);
 	}
 	else
 	{
 		Rear_view = 0;
-		if (PlayerCfg.CockpitMode[1] != PlayerCfg.CockpitMode[0])
-			select_cockpit(PlayerCfg.CockpitMode[0]);
+		if (PlayerCfg.CurrentCockpitMode != PlayerCfg.PreferredCockpitMode)
+			select_cockpit(PlayerCfg.PreferredCockpitMode);
 	}
 
 	if (nd_playback_v_bad_read) {

--- a/d2/main/object.c
+++ b/d2/main/object.c
@@ -1494,7 +1494,7 @@ void dead_player_end(void)
 	Player_exploded = 0;
 	obj_delete(Dead_player_camera-Objects);
 	//Dead_player_camera = NULL;
-	select_cockpit(PlayerCfg.CockpitMode[0]);
+	select_cockpit(PlayerCfg.PreferredCockpitMode);
 	Viewer = Viewer_save;
 	ConsoleObject->type = OBJ_PLAYER;
 	ConsoleObject->flags = Player_flags_save;

--- a/d2/main/player.c
+++ b/d2/main/player.c
@@ -9,6 +9,7 @@
 #include "multi.h"
 #include "hudmsg.h"
 #include "byteswap.h"
+#include "playsave.h"
 
 int RespawningConcussions[MAX_PLAYERS]; 
 int VulcanAmmoBoxesOnBoard[MAX_PLAYERS];
@@ -82,7 +83,8 @@ void reset_obs() {
 		return;
 	
 	Current_obs_player = Player_num;
-	init_cockpit();
+	// Force the cockpit mode back to full screen, since we don't have data for the gauges.
+	select_cockpit(CM_FULL_SCREEN);
 
 	Objects[Players[Current_obs_player].objnum].pos = Last_pos;
 	Objects[Players[Current_obs_player].objnum].orient = Last_orient;
@@ -107,7 +109,7 @@ void set_obs(int pnum) {
 			HUD_init_message(HM_DEFAULT, "Observing %s!", Players[pnum].callsign);
 		}
 		Current_obs_player = pnum;
-		init_cockpit();
+		select_cockpit(can_draw_observer_cockpit() ? PlayerCfg.PreferredCockpitMode : CM_FULL_SCREEN);
 	} else {
 		reset_obs();
 	}

--- a/d2/main/playsave.c
+++ b/d2/main/playsave.c
@@ -104,7 +104,7 @@ int new_player_config()
     PlayerCfg.MouseOverrun[0] = PlayerCfg.MouseOverrun[1] = PlayerCfg.MouseOverrun[2] = PlayerCfg.MouseOverrun[3] = PlayerCfg.MouseOverrun[4] = PlayerCfg.MouseOverrun[5] = 0;
 	PlayerCfg.MouseFSDead = 0;
 	PlayerCfg.MouseFSIndicator = 1;
-	PlayerCfg.CockpitMode[0] = PlayerCfg.CockpitMode[1] = CM_FULL_COCKPIT;
+	PlayerCfg.CurrentCockpitMode = PlayerCfg.PreferredCockpitMode = CM_FULL_COCKPIT;
 	PlayerCfg.Cockpit3DView[0]=CV_NONE;
 	PlayerCfg.Cockpit3DView[1]=CV_NONE;
 	PlayerCfg.ReticleType = RET_TYPE_CLASSIC;
@@ -824,7 +824,7 @@ int read_player_file()
 	PlayerCfg.DefaultDifficulty = PHYSFSX_readByte(file);
 	PlayerCfg.AutoLeveling       = PHYSFSX_readByte(file);
 	PHYSFS_seek(file,PHYSFS_tell(file)+sizeof(sbyte)); // skip ReticleOn
-	PlayerCfg.CockpitMode[0] = PlayerCfg.CockpitMode[1] = PHYSFSX_readByte(file);
+	PlayerCfg.CurrentCockpitMode = PlayerCfg.PreferredCockpitMode = PHYSFSX_readByte(file);
 	PHYSFS_seek(file,PHYSFS_tell(file)+sizeof(sbyte)); //skip Default_display_mode
 	PlayerCfg.MissileViewEnabled      = PHYSFSX_readByte(file);
 	PlayerCfg.HeadlightActiveDefault  = PHYSFSX_readByte(file);
@@ -1066,7 +1066,7 @@ int write_player_file()
 	PHYSFSX_writeU8(file, PlayerCfg.DefaultDifficulty);
 	PHYSFSX_writeU8(file, PlayerCfg.AutoLeveling);
 	PHYSFSX_writeU8(file, PlayerCfg.ReticleType==RET_TYPE_NONE?0:1);
-	PHYSFSX_writeU8(file, PlayerCfg.CockpitMode[0]);
+	PHYSFSX_writeU8(file, PlayerCfg.PreferredCockpitMode);
 	PHYSFS_seek(file,PHYSFS_tell(file)+sizeof(PHYSFS_uint8)); // skip Default_display_mode
 	PHYSFSX_writeU8(file, PlayerCfg.MissileViewEnabled);
 	PHYSFSX_writeU8(file, PlayerCfg.HeadlightActiveDefault);

--- a/d2/main/playsave.h
+++ b/d2/main/playsave.h
@@ -60,7 +60,8 @@ typedef struct player_config
     int MouseOverrun[6];
 	int MouseFSDead;
 	int MouseFSIndicator;
-	int CockpitMode[2]; // 0 saves the "real" cockpit, 1 also saves letterbox and rear. Used to properly switch between modes and restore the real one.
+	int PreferredCockpitMode;
+	int CurrentCockpitMode; // Also includes letterbox/rear, which are not persisted in the player profile
 	int Cockpit3DView[2];
 	char NetworkMessageMacro[4][MAX_MESSAGE_LEN];
 	int NetlifeKills;

--- a/d2/main/render.c
+++ b/d2/main/render.c
@@ -1626,7 +1626,7 @@ void render_frame(fix eye_offset, int window_num)
 
 	Viewer_eye = Viewer->pos;
 
-//	if (Viewer->type == OBJ_PLAYER && (PlayerCfg.CockpitMode[1]!=CM_REAR_VIEW))
+//	if (Viewer->type == OBJ_PLAYER && (PlayerCfg.CurrentCockpitMode!=CM_REAR_VIEW))
 //		vm_vec_scale_add2(&Viewer_eye,&Viewer->orient.fvec,(Viewer->size*3)/4);
 
 	if (eye_offset)	{


### PR DESCRIPTION
Chilly earlier reported that switching cockpit mode wasn't working in observer. It turns out that a change in D2 to block switching cockpit mode while flying a guided missile was responsible.
However, this code does make sense; changing cockpit modes while the cockpit isn't active seems like a problem. So, I added some logic to make sure that the game is at least in first-person mode before allowing cockpit mode switches. I also backported that to D1.
I split the CockpitMode array into "PreferredCockpitMode" and "CurrentCockpitMode" for readability (it was confusing me before :)). This wound up being most of the pull request though.