### PR TITLE
Fix overlapping observer kill graph and MFD (picture-in-picture) views in D2

### DIFF
--- a/d1/main/game.c
+++ b/d1/main/game.c
@@ -1460,6 +1460,9 @@ bool is_observer() {
 
 bool can_draw_observer_cockpit()
 {
+	// The result of this function is meaningful only in observer mode.
+	Assert(is_observer());
+
 	// We can only draw a cockpit in observer mode if the relevant setting is enabled, and we're
 	// observing in first-person mode.
 	return PlayerCfg.ObsShowCockpit[get_observer_game_mode()] && is_observing_player() && !Obs_at_distance;

--- a/d1/main/gamerend.c
+++ b/d1/main/gamerend.c
@@ -426,7 +426,7 @@ void game_draw_hud_stuff()
 
 		y = GHEIGHT-(LINE_SPACING*2);
 
-		if (can_draw_observer_cockpit() && PlayerCfg.CurrentCockpitMode == CM_FULL_COCKPIT)
+		if (is_observer() && can_draw_observer_cockpit() && PlayerCfg.CurrentCockpitMode == CM_FULL_COCKPIT)
 			y = grd_curcanv->cv_bitmap.bm_h / 1.2 ;
 
 		if (PlayerCfg.CurrentCockpitMode != CM_REAR_VIEW) {

--- a/d2/main/game.c
+++ b/d2/main/game.c
@@ -1951,6 +1951,9 @@ object* get_player_view_object()
 
 bool can_draw_observer_cockpit()
 {
+	// The result of this function is meaningful only in observer mode.
+	Assert(is_observer());
+
 	// We can only draw a cockpit in observer mode if the relevant setting is enabled, and we're
 	// observing in first-person mode.
 	return PlayerCfg.ObsShowCockpit[get_observer_game_mode()] && is_observing_player() && !Obs_at_distance;

--- a/d2/main/gamerend.c
+++ b/d2/main/gamerend.c
@@ -505,7 +505,7 @@ void game_draw_hud_stuff()
 
 		y = GHEIGHT-(LINE_SPACING*2);
 
-		if (can_draw_observer_cockpit() && PlayerCfg.CurrentCockpitMode == CM_FULL_COCKPIT)
+		if (is_observer() && can_draw_observer_cockpit() && PlayerCfg.CurrentCockpitMode == CM_FULL_COCKPIT)
 			y = grd_curcanv->cv_bitmap.bm_h / 1.2 ;
 
 		if (PlayerCfg.CurrentCockpitMode != CM_REAR_VIEW) {

--- a/d2/main/gauges.c
+++ b/d2/main/gauges.c
@@ -4839,6 +4839,10 @@ void do_cockpit_window_view(int win,object *viewer,int rear_view_flag,int user,c
 
 	if (PlayerCfg.CurrentCockpitMode == CM_FULL_SCREEN)
 	{
+		// If we're drawing the kill graph in observer mode, we don't have space for the extra views
+		if (is_observer() && PlayerCfg.ObsShowKillGraph[get_observer_game_mode()] && GameTime64 < Show_graph_until)
+			goto abort;
+
 		w = HUD_SCALE_X_AR(HIRESMODE?106:44);
 		h = HUD_SCALE_Y_AR(HIRESMODE?106:44);
 


### PR DESCRIPTION
Since the observer mode kill graph is drawn in the same place as D2's MFD views (missile, rear view, etc), we need to suppress one or the other to display both. The kill graph is temporary, so it made more sense to prioritize that one while it's up. (In theory it might be possible to display both by moving the graph, but then we start running out of screen space.)

I added a fix for the assert seen in demo playback where game_draw_hud_stuff wasn't checking for observer mode before calling can_draw_observer_cockpit.

I'm still trying to find time to test this out properly - hopefully soon!