### PR TITLE
More consistent homer tracking updates

### DIFF
--- a/d1/main/laser.c
+++ b/d1/main/laser.c
@@ -696,7 +696,7 @@ int track_track_goal(int track_goal, object *tracker, fix *dot, unsigned int hom
 #ifdef NEWHOMER
 	if (object_is_trackable(track_goal, tracker, dot)) {  // CED -- && (tracker - Objects) is useless
 		return track_goal;
-	} else if ((((tracker-Objects) ^ homerFrameCount) % 4) == 0) // CED -- Reverted to 1994 original release code, with homer frame count
+	} else if (((homerFrameCount - tracker->ctype.laser_info.creation_framecount) % 4) == 0) // CED -- Reverted to 1994 original release code, with homer frame count
 #else
 	//	Every 8 frames for each object, scan all objects.
 	if (object_is_trackable(track_goal, tracker, dot) && ((((tracker-Objects) ^ d_tick_count) % 8) != 0)) {

--- a/d1/main/multi.c
+++ b/d1/main/multi.c
@@ -5524,6 +5524,7 @@ void multi_object_rw_to_object(object_rw *obj_rw, object *obj)
 			obj->ctype.laser_info.last_hitobj      = obj_rw->ctype.laser_info.last_hitobj;
 			obj->ctype.laser_info.track_goal       = obj_rw->ctype.laser_info.track_goal;
 			obj->ctype.laser_info.multiplier       = obj_rw->ctype.laser_info.multiplier;
+			obj->ctype.laser_info.creation_framecount = 0;
 			break;
 			
 		case CT_EXPLOSION:

--- a/d1/main/object.c
+++ b/d1/main/object.c
@@ -1262,6 +1262,7 @@ int obj_create(enum object_type_t type, ubyte id,int segnum,vms_vector *pos,
 	if (obj->type == OBJ_WEAPON) {
 		obj->mtype.phys_info.flags |= (Weapon_info[obj->id].persistent*PF_PERSISTENT);
 		obj->ctype.laser_info.creation_time = GameTime64;
+		obj->ctype.laser_info.creation_framecount = homerFrameCount;
 		obj->ctype.laser_info.last_hitobj = -1;
 		memset(&obj->ctype.laser_info.hitobj_list, 0, sizeof(ubyte)*MAX_OBJECTS);
 		obj->ctype.laser_info.multiplier = F1_0;

--- a/d1/main/object.h
+++ b/d1/main/object.h
@@ -197,6 +197,7 @@ typedef struct laser_info {
 	ubyte   hitobj_list[MAX_OBJECTS]; // list of all objects persistent weapon has already damaged (useful in case it's in contact with two objects at the same time)
 	short   track_goal;         // Object this object is tracking.
 	fix     multiplier;         // Power if this is a fusion bolt (or other super weapon to be added).
+	int     creation_framecount;
 } __pack__ laser_info;
 
 // Same as above but structure Savegames/Multiplayer objects expect

--- a/d1/main/state.c
+++ b/d1/main/state.c
@@ -173,6 +173,7 @@ void state_object_to_object_rw(object *obj, object_rw *obj_rw)
 			obj_rw->ctype.laser_info.last_hitobj      = obj->ctype.laser_info.last_hitobj;
 			obj_rw->ctype.laser_info.track_goal       = obj->ctype.laser_info.track_goal;
 			obj_rw->ctype.laser_info.multiplier       = obj->ctype.laser_info.multiplier;
+			obj->ctype.laser_info.creation_framecount = 0;
 			break;
 			
 		case CT_EXPLOSION:

--- a/d2/main/laser.c
+++ b/d2/main/laser.c
@@ -1179,7 +1179,7 @@ int track_track_goal(int track_goal, object *tracker, fix *dot, unsigned int hom
 {
 	if (object_is_trackable(track_goal, tracker, dot)) {  // CED -- && (tracker - Objects) is useless
 		return track_goal;
-	} else if ((((tracker-Objects) ^ homerFrameCount) % 4) == 0) // CED -- Reverted to original release code, with homer frame count
+	} else if (((homerFrameCount - tracker->ctype.laser_info.creation_framecount) % 4) == 0) // CED -- Reverted to 1994 original release code, with homer frame count
 
 /*
 #ifdef NEWHOMER

--- a/d2/main/multi.c
+++ b/d2/main/multi.c
@@ -7313,6 +7313,7 @@ void multi_object_rw_to_object(object_rw *obj_rw, object *obj)
 			obj->ctype.laser_info.last_hitobj      = obj_rw->ctype.laser_info.last_hitobj;
 			obj->ctype.laser_info.track_goal       = obj_rw->ctype.laser_info.track_goal;
 			obj->ctype.laser_info.multiplier       = obj_rw->ctype.laser_info.multiplier;
+			obj->ctype.laser_info.creation_framecount = 0;
 			break;
 			
 		case CT_EXPLOSION:

--- a/d2/main/object.c
+++ b/d2/main/object.c
@@ -1371,6 +1371,7 @@ int obj_create(enum object_type_t type,ubyte id,int segnum,const vms_vector *pos
 		Assert(obj->control_type == CT_WEAPON);
 		obj->mtype.phys_info.flags |= (Weapon_info[obj->id].persistent*PF_PERSISTENT);
 		obj->ctype.laser_info.creation_time = GameTime64;
+		obj->ctype.laser_info.creation_framecount = homerFrameCount;
 		obj->ctype.laser_info.last_hitobj = -1;
 		memset(&obj->ctype.laser_info.hitobj_list, 0, sizeof(ubyte)*MAX_OBJECTS);
 		obj->ctype.laser_info.multiplier = F1_0;

--- a/d2/main/object.h
+++ b/d2/main/object.h
@@ -199,6 +199,7 @@ typedef struct laser_info {
 	ubyte   hitobj_list[MAX_OBJECTS]; // list of all objects persistent weapon has already damaged (useful in case it's in contact with two objects at the same time)
 	short   track_goal;         // Object this object is tracking.
 	fix     multiplier;         // Power if this is a fusion bolt (or other super weapon to be added).
+	int     creation_framecount;
 } __pack__ laser_info;
 
 // Same as above but structure Savegames/Multiplayer objects expect

--- a/d2/main/state.c
+++ b/d2/main/state.c
@@ -193,6 +193,7 @@ void state_object_to_object_rw(object *obj, object_rw *obj_rw)
 			obj_rw->ctype.laser_info.last_hitobj      = obj->ctype.laser_info.last_hitobj;
 			obj_rw->ctype.laser_info.track_goal       = obj->ctype.laser_info.track_goal;
 			obj_rw->ctype.laser_info.multiplier       = obj->ctype.laser_info.multiplier;
+			obj->ctype.laser_info.creation_framecount = 0;
 			break;
 			
 		case CT_EXPLOSION:


### PR DESCRIPTION
Use homer-frames since homer creation instead of an object number based offset to determine in which frame to do a tracking update. This makes homing behavior more consistent between players.