### PR TITLE
Fix recording observer demo

### DIFF
--- a/d1/main/newdemo.c
+++ b/d1/main/newdemo.c
@@ -945,7 +945,13 @@ void newdemo_record_viewer_object(object * obj)
 		return;
 	stop_time();
 	nd_write_byte(ND_EVENT_VIEWER_OBJECT);
+
+	// workaround for observer player with RT_NONE
+	ubyte render_type = obj->render_type;
+	obj->render_type = RT_POLYOBJ;
 	nd_write_object(obj);
+	obj->render_type = render_type;
+
 	start_time();
 }
 
@@ -1683,6 +1689,8 @@ int newdemo_read_frame_information(int rewrite)
 				nd_write_object(Viewer);
 				break;
 			}
+			if (is_observer())
+				Viewer->render_type = RT_NONE;
 			if (Newdemo_vcr_state != ND_STATE_PAUSED) {
 				segnum = Viewer->segnum;
 				Viewer->next = Viewer->prev = Viewer->segnum = -1;

--- a/d2/main/newdemo.c
+++ b/d2/main/newdemo.c
@@ -1000,7 +1000,13 @@ void newdemo_record_viewer_object(object * obj)
 	nd_record_v_rendering[RenderingType]=1;
 	nd_write_byte(ND_EVENT_VIEWER_OBJECT);
 	nd_write_byte(RenderingType);
+
+	// workaround for observer player with RT_NONE
+	ubyte render_type = obj->render_type;
+	obj->render_type = RT_POLYOBJ;
 	nd_write_object(obj);
+	obj->render_type = render_type;
+
 	start_time();
 }
 
@@ -1802,6 +1808,8 @@ int newdemo_read_frame_information(int rewrite)
 					nd_write_object(Viewer);
 					break;
 				}
+				if (is_observer())
+					Viewer->render_type = RT_NONE;
 
 				if (Newdemo_vcr_state != ND_STATE_PAUSED) {
 					segnum = Viewer->segnum;


### PR DESCRIPTION
The rear view MFDs fix sets the viewer render type to RT_NONE, but this breaks the demo system (it needs the viewer orientation but doesn't write the orientation with render type RT_NONE).

Work around it by temporarily setting the render type to RT_POLYOBJ, and setting it back to RT_NONE on read.

Fixes: 819190b