### PR TITLE
Fix demo playback playing homer sound too often

### DIFF
--- a/d1/main/gauges.c
+++ b/d1/main/gauges.c
@@ -903,7 +903,7 @@ void play_homing_warning(void)
 
 	int pnum = get_pnum_for_hud();
 
-	if (Endlevel_sequence || Player_is_dead)
+	if (Endlevel_sequence || Player_is_dead || Newdemo_state == ND_STATE_PLAYBACK)
 		return;
 
 	if (Players[pnum].homing_object_dist >= 0) {

--- a/d2/main/gauges.c
+++ b/d2/main/gauges.c
@@ -881,7 +881,7 @@ void play_homing_warning(void)
 
 	int pnum = get_pnum_for_hud();
 
-	if (Endlevel_sequence || Player_is_dead)
+	if (Endlevel_sequence || Player_is_dead || Newdemo_state == ND_STATE_PLAYBACK)
 		return;
 
 	if (Players[pnum].homing_object_dist >= 0) {


### PR DESCRIPTION
The demo system both records playing the sound and plays the sound again on playback. Remove playing the homer sound on playback.