### PR TITLE
Fix sound from right playing from left

### DIFF
--- a/d1/arch/sdl/digi_mixer.c
+++ b/d1/arch/sdl/digi_mixer.c
@@ -44,7 +44,7 @@
 
 static int digi_initialised = 0;
 static int digi_max_channels = MAX_SOUND_SLOTS;
-static inline int fix2byte(fix f) { return (f / 256) % 256; }
+static inline int fix2byte(fix f) { return f < 0 ? 0 : f >= 65536 ? 255 : f / 256; }
 Mix_Chunk SoundChunks[MAX_SOUNDS];
 ubyte channels[MAX_SOUND_SLOTS];
 

--- a/d2/arch/sdl/digi_mixer.c
+++ b/d2/arch/sdl/digi_mixer.c
@@ -44,7 +44,7 @@
 
 static int digi_initialised = 0;
 static int digi_max_channels = MAX_SOUND_SLOTS;
-static inline int fix2byte(fix f) { return (f / 256) % 256; }
+static inline int fix2byte(fix f) { return f < 0 ? 0 : f >= 65536 ? 255 : f / 256; }
 Mix_Chunk SoundChunks[MAX_SOUNDS];
 ubyte channels[MAX_SOUND_SLOTS];
 


### PR DESCRIPTION
The pan value for a 3d sound can be F1_0 if the sound comes exactly from the right. This would get truncated to 0 (=left) in the digi_mixer code.
Add a check to prevent overflow of the mixer pan byte.