### PR TITLE
Add automatic crash dump saving

### DIFF
--- a/d1/arch/win32/CMakeLists.txt
+++ b/d1/arch/win32/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_library(arch_win32 STATIC
+    crashdump.c
     messagebox.c
     )
 

--- a/d1/arch/win32/crashdump.c
+++ b/d1/arch/win32/crashdump.c
@@ -1,0 +1,38 @@
+// Contains handlers for automatically generating crash dumps on Windows.
+
+#include <windows.h>
+#include <DbgHelp.h>
+#include "dxxerror.h"
+
+void win32_create_dump(EXCEPTION_POINTERS* exceptionPointers)
+{
+    // Append the current date and time to the dump file name.
+    char dumpFileName[MAX_PATH];
+    SYSTEMTIME stLocalTime;
+    GetLocalTime(&stLocalTime);
+    wsprintf(dumpFileName, "d1x-redux_%04d%02d%02d_%02d%02d%02d.dmp",
+             stLocalTime.wYear, stLocalTime.wMonth, stLocalTime.wDay,
+             stLocalTime.wHour, stLocalTime.wMinute, stLocalTime.wSecond);
+
+    HANDLE hDumpFile = CreateFile(dumpFileName, GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
+    if (hDumpFile != INVALID_HANDLE_VALUE) {
+        MINIDUMP_EXCEPTION_INFORMATION exceptionInfo;
+        exceptionInfo.ThreadId = GetCurrentThreadId();
+        exceptionInfo.ExceptionPointers = exceptionPointers;
+        exceptionInfo.ClientPointers = FALSE;
+        
+        MiniDumpWriteDump(GetCurrentProcess(), GetCurrentProcessId(), hDumpFile, MiniDumpNormal, &exceptionInfo, NULL, NULL);
+        CloseHandle(hDumpFile);
+    }
+}
+
+LONG WINAPI win32_exception_handler(EXCEPTION_POINTERS* exceptionPointers)
+{
+    win32_create_dump(exceptionPointers);
+    return EXCEPTION_CONTINUE_SEARCH;
+}
+
+void init_crash_dump_handler()
+{
+	SetUnhandledExceptionFilter(win32_exception_handler);
+}

--- a/d1/d1x-default.ini
+++ b/d1/d1x-default.ini
@@ -39,7 +39,7 @@
 ;-udp_hostaddr <s>             Use IP address/Hostname <s> for manual game joining (default: localhost)
 ;-udp_hostport <n>             Use UDP port <n> for manual game joining (default: 42424)
 ;-udp_myport <n>               Set my own UDP port to <n> (default: 42424)
-;-tracker_hostaddr <n>         Address of Tracker server to register/query games to/from (default: dxxtracker.reenigne.net)
+;-tracker_hostaddr <n>         Address of Tracker server to register/query games to/from (default: retro-tracker.game-server.cc)
 ;-tracker_hostport <n>         Port of Tracker server to register/query games to/from (default: 42420)
 ;-netlog                       Write network traffic log (netlog.txt)
 
@@ -48,6 +48,7 @@
 ;-debug                        Enable debugging output.
 ;-verbose                      Enable verbose output.
 ;-safelog                      Write gamelog.txt unbuffered. Use to keep helpful output to trace program crashes.
+;-autodump                     Automatically save core dumps if the program crashes.
 ;-norun                        Bail out after initialization
 ;-renderstats                  Enable renderstats info by default
 ;-text <s>                     Specify alternate .tex file

--- a/d1/include/args.h
+++ b/d1/include/args.h
@@ -81,6 +81,7 @@ typedef struct Arg
 	int DbgUseDoubleBuffer;
 	int DbgBigPig;
 	int DbgBpp;
+	int DbgAutoDump;
 #ifdef OGL
 	int DbgAltTexMerge;
 	int DbgGlIntensity4Ok;

--- a/d1/include/dxxerror.h
+++ b/d1/include/dxxerror.h
@@ -37,6 +37,7 @@ void Warning(char *fmt,...);				//print out warning message to user
 void set_warn_func(void (*f)(char *s));//specifies the function to call with warning messages
 void clear_warn_func(void (*f)(char *s));//say this function no longer valid
 void Error(const char *fmt,...) __noreturn __attribute_gcc_format((printf, 1, 2));				//exit with error code=1, print message
+void init_crash_dump_handler();
 #define Assert assert
 #ifndef NDEBUG		//macros for debugging
 

--- a/d1/main/CMakeLists.txt
+++ b/d1/main/CMakeLists.txt
@@ -100,7 +100,7 @@ if(UDP)
 endif()
 
 if(WIN32)
-    target_link_libraries(d1x-redux PUBLIC glu32 winmm ws2_32)
+    target_link_libraries(d1x-redux PUBLIC dbghelp glu32 winmm ws2_32)
     target_link_libraries(d1x-redux PRIVATE arch_win32)
     target_sources(d1x-redux PRIVATE
         ${CMAKE_SOURCE_DIR}/arch/win32/d1x-rebirth.ico

--- a/d1/main/inferno.c
+++ b/d1/main/inferno.c
@@ -296,6 +296,9 @@ int main(int argc, char *argv[])
 #ifdef _WIN32
 	freopen( "CON", "w", stdout );
 	freopen( "CON", "w", stderr );
+	// Automatic crash dump saving is currently only implemented in Win32
+	if (GameArg.DbgAutoDump)
+		init_crash_dump_handler();
 #endif
 
 	if (GameArg.SysShowCmdHelp) {

--- a/d1/misc/args.c
+++ b/d1/misc/args.c
@@ -207,6 +207,7 @@ void ReadCmdArgs(void)
 	GameArg.DbgUseDoubleBuffer 	= !FindArg("-nodoublebuffer");
 	GameArg.DbgBigPig 		= !FindArg("-bigpig");
 	GameArg.DbgBpp 			= (FindArg("-16bpp") ? 16 : 32);
+	GameArg.DbgAutoDump		= FindArg("-autodump");
 
 #ifdef OGL
 	GameArg.DbgAltTexMerge 		= !FindArg("-gl_oldtexmerge");

--- a/d2/arch/win32/CMakeLists.txt
+++ b/d2/arch/win32/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_library(arch_win32 STATIC
+    crashdump.c
     messagebox.c
     )
 

--- a/d2/arch/win32/crashdump.c
+++ b/d2/arch/win32/crashdump.c
@@ -1,0 +1,38 @@
+// Contains handlers for automatically generating crash dumps on Windows.
+
+#include <windows.h>
+#include <DbgHelp.h>
+#include "dxxerror.h"
+
+void win32_create_dump(EXCEPTION_POINTERS* exceptionPointers)
+{
+    // Append the current date and time to the dump file name.
+    char dumpFileName[MAX_PATH];
+    SYSTEMTIME stLocalTime;
+    GetLocalTime(&stLocalTime);
+    wsprintf(dumpFileName, "d2x-redux_%04d%02d%02d_%02d%02d%02d.dmp",
+             stLocalTime.wYear, stLocalTime.wMonth, stLocalTime.wDay,
+             stLocalTime.wHour, stLocalTime.wMinute, stLocalTime.wSecond);
+
+    HANDLE hDumpFile = CreateFile(dumpFileName, GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
+    if (hDumpFile != INVALID_HANDLE_VALUE) {
+        MINIDUMP_EXCEPTION_INFORMATION exceptionInfo;
+        exceptionInfo.ThreadId = GetCurrentThreadId();
+        exceptionInfo.ExceptionPointers = exceptionPointers;
+        exceptionInfo.ClientPointers = FALSE;
+        
+        MiniDumpWriteDump(GetCurrentProcess(), GetCurrentProcessId(), hDumpFile, MiniDumpNormal, &exceptionInfo, NULL, NULL);
+        CloseHandle(hDumpFile);
+    }
+}
+
+LONG WINAPI win32_exception_handler(EXCEPTION_POINTERS* exceptionPointers)
+{
+    win32_create_dump(exceptionPointers);
+    return EXCEPTION_CONTINUE_SEARCH;
+}
+
+void init_crash_dump_handler()
+{
+	SetUnhandledExceptionFilter(win32_exception_handler);
+}

--- a/d2/d2x-default.ini
+++ b/d2/d2x-default.ini
@@ -42,7 +42,7 @@
 ;-udp_hostaddr <s>             Use IP address/Hostname <s> for manual game joining (default: localhost)
 ;-udp_hostport <n>             Use UDP port <n> for manual game joining (default: 42424)
 ;-udp_myport <n>               Set my own UDP port to <n> (default: 42424)
-;-tracker_hostaddr <n>         Address of Tracker server to register/query games to/from (default: dxxtracker.reenigne.net)
+;-tracker_hostaddr <n>         Address of Tracker server to register/query games to/from (default: retro-tracker.game-server.cc)
 ;-tracker_hostport <n>         Port of Tracker server to register/query games to/from (default: 42420)
 ;-netlog                       Write network traffic log (netlog.txt)
 
@@ -51,6 +51,7 @@
 ;-debug                        Enable debugging output.
 ;-verbose                      Enable verbose output.
 ;-safelog                      Write gamelog.txt unbuffered. Use to keep helpful output to trace program crashes.
+;-autodump                     Automatically save core dumps if the program crashes.
 ;-norun                        Bail out after initialization
 ;-renderstats                  Enable renderstats info by default
 ;-text <s>                     Specify alternate .tex file

--- a/d2/include/args.h
+++ b/d2/include/args.h
@@ -84,6 +84,7 @@ typedef struct Arg
 	int DbgUseDoubleBuffer;
 	int DbgBigPig;
 	int DbgBpp;
+	int DbgAutoDump;
 #ifdef OGL
 	int DbgAltTexMerge;
 	int DbgGlIntensity4Ok;

--- a/d2/include/dxxerror.h
+++ b/d2/include/dxxerror.h
@@ -37,6 +37,7 @@ void Warning(char *fmt,...);				//print out warning message to user
 void set_warn_func(void (*f)(char *s));//specifies the function to call with warning messages
 void clear_warn_func(void (*f)(char *s));//say this function no longer valid
 void Error(const char *fmt,...) __noreturn __attribute_gcc_format((printf, 1, 2));				//exit with error code=1, print message
+void init_crash_dump_handler();
 #define Assert assert
 #ifndef NDEBUG		//macros for debugging
 

--- a/d2/main/CMakeLists.txt
+++ b/d2/main/CMakeLists.txt
@@ -102,7 +102,7 @@ if(UDP)
 endif()
 
 if(WIN32)
-    target_link_libraries(d2x-redux PUBLIC glu32 winmm ws2_32)
+    target_link_libraries(d2x-redux PUBLIC dbghelp glu32 winmm ws2_32)
     target_link_libraries(d2x-redux PRIVATE arch_win32)
     target_sources(d2x-redux PRIVATE
         ${CMAKE_SOURCE_DIR}/arch/win32/d2x-rebirth.ico

--- a/d2/main/inferno.c
+++ b/d2/main/inferno.c
@@ -307,6 +307,9 @@ int main(int argc, char *argv[])
 #ifdef _WIN32
 	freopen( "CON", "w", stdout );
 	freopen( "CON", "w", stderr );
+	// Automatic crash dump saving is currently only implemented in Win32
+	if (GameArg.DbgAutoDump)
+		init_crash_dump_handler();
 #endif
 
 	if (GameArg.SysShowCmdHelp) {

--- a/d2/misc/args.c
+++ b/d2/misc/args.c
@@ -216,6 +216,7 @@ void ReadCmdArgs(void)
 	GameArg.DbgUseDoubleBuffer 	= !FindArg("-nodoublebuffer");
 	GameArg.DbgBigPig 		= !FindArg("-bigpig");
 	GameArg.DbgBpp 			= (FindArg("-16bpp") ? 16 : 32);
+	GameArg.DbgAutoDump		= FindArg("-autodump");
 
 #ifdef OGL
 	GameArg.DbgAltTexMerge 		= !FindArg("-gl_oldtexmerge");


### PR DESCRIPTION
This is an attempt to track down crashes that have been hard to reproduce. I have to note that I'm not really sure this is the right thing to do; but a PR is a good place to review it.
My main concerns:
1. It is already possible to configure Windows to save crash dumps for a program without resorting to programmatic techniques; but it's considerably harder to walk users through it...
2. I don't have a Linux/OS X implementation - mostly because I'm not sure what the best approach would be there, or even whether it's really necessary (a bunch of StackOverflow discussions talk about ulimit etc). Maybe printing a backtrace would be enough...

Happy to make further changes if you have recommendations here.