### PR TITLE
Add -gamelog_split option

### DIFF
--- a/d1/d1x-default.ini
+++ b/d1/d1x-default.ini
@@ -15,6 +15,7 @@
 ;-window                       Run the game in a window
 ;-noborders                    Do not show borders in window mode
 ;-gamelog_timestamp            Create gamelog-20010203-040506.txt files
+;-gamelog_split                Create separate gamelog files for each game played
 
  Controls:
 

--- a/d1/include/args.h
+++ b/d1/include/args.h
@@ -94,6 +94,7 @@ typedef struct Arg
 #endif
 	int LogNetTraffic; 
 	int GameLogTimeStamp;
+	int GameLogSplit;
 } __pack__ Arg;
 
 extern struct Arg GameArg;

--- a/d1/include/console.h
+++ b/d1/include/console.h
@@ -32,6 +32,7 @@ typedef struct console_buffer
 void con_init(void);
 void con_printf(int level, const char *fmt, ...);
 void con_showup(void);
+void con_switch_log(const char* filename);
 
 #endif /* _CONSOLE_H_ */
 

--- a/d1/main/console.c
+++ b/d1/main/console.c
@@ -269,23 +269,35 @@ static void con_close(void)
 
 void con_init(void)
 {
-	char filename[PATH_MAX];
-
 	memset(con_buffer,0,sizeof(con_buffer));
 
-	if (GameArg.GameLogTimeStamp) {
-		time_t now = time(NULL);
-		struct tm *t = localtime(&now);
-		snprintf(filename, sizeof(filename), "gamelog-%04d%02d%02d-%02d%02d%02d.txt",
-			t->tm_year + 1900, t->tm_mon, t->tm_mday, t->tm_hour, t->tm_min, t->tm_sec);
-	} else {
-		strcpy(filename, "gamelog.txt");
-	}
+	con_switch_log(NULL);
 
-	if (GameArg.DbgSafelog)
-		gamelog_fp = PHYSFS_openWrite(filename);
-	else
-		gamelog_fp = PHYSFSX_openWriteBuffered(filename);
 	atexit(con_close);
 }
 
+void con_switch_log(const char* filename)
+{
+	char filenameBuffer[PATH_MAX];
+	const char* filenameToUse = filename;
+
+	con_close();
+
+	if (filename == NULL) {
+		// Switch to default log filename
+		if (GameArg.GameLogTimeStamp) {
+			time_t now = time(NULL);
+			struct tm *t = localtime(&now);
+			snprintf(filenameBuffer, SDL_arraysize(filenameBuffer), "gamelog-%04d%02d%02d-%02d%02d%02d.txt",
+				t->tm_year + 1900, t->tm_mon, t->tm_mday, t->tm_hour, t->tm_min, t->tm_sec);
+		} else {
+			strcpy(filenameBuffer, "gamelog.txt");
+		}
+		filenameToUse = filenameBuffer;
+	}
+
+	if (GameArg.DbgSafelog)
+		gamelog_fp = PHYSFS_openWrite(filenameToUse);
+	else
+		gamelog_fp = PHYSFSX_openWriteBuffered(filenameToUse);
+}

--- a/d1/main/game.c
+++ b/d1/main/game.c
@@ -1040,6 +1040,8 @@ int game_handler(window *wind, d_event *event, void *data)
 
 			game_disable_cheats();
 			Game_mode = GM_GAME_OVER;
+			if (GameArg.GameLogSplit)
+				con_switch_log(NULL); // switch back to default log
 #ifdef EDITOR
 			if (!EditorWindow)		// have to do it this way because of the necessary longjmp. Yuck.
 #endif

--- a/d1/main/gameseq.c
+++ b/d1/main/gameseq.c
@@ -1129,6 +1129,17 @@ void StartNewLevelSub(int level_num, int page_in_textures, int secret_flag)
 		last_drawn_cockpit = -1;
 	}
 
+	if (GameArg.GameLogSplit) {
+		// Include the mission name, level number and timestamp in the log filename
+		char log_filename[PATH_MAX];
+		time_t now = time(NULL);
+		struct tm *t = localtime(&now);
+		snprintf(log_filename, SDL_arraysize(log_filename), "gamelog-%s-%d-%04d%02d%02d-%02d%02d%02d.txt",
+			Current_mission_filename, level_num, t->tm_year + 1900, t->tm_mon, t->tm_mday, t->tm_hour, t->tm_min, t->tm_sec);
+
+		con_switch_log(log_filename);
+	}
+
 	if (Newdemo_state == ND_STATE_PAUSED)
 		Newdemo_state = ND_STATE_RECORDING;
 

--- a/d1/misc/args.c
+++ b/d1/misc/args.c
@@ -224,6 +224,7 @@ void ReadCmdArgs(void)
 	GameArg.LogNetTraffic 		= FindArg("-netlog");
 
 	GameArg.GameLogTimeStamp	= FindArg("-gamelog_timestamp");
+	GameArg.GameLogSplit		= FindArg("-gamelog_split");
 }
 
 void args_exit(void)

--- a/d2/d2x-default.ini
+++ b/d2/d2x-default.ini
@@ -15,6 +15,7 @@
 ;-noborders                    Do not show borders in window mode
 ;-nomovies                     Don't play movies
 ;-gamelog_timestamp            Create gamelog-20010203-040506.txt files
+;-gamelog_split                Create separate gamelog files for each game played
 
  Controls:
 

--- a/d2/include/args.h
+++ b/d2/include/args.h
@@ -97,6 +97,7 @@ typedef struct Arg
 #endif
 	int LogNetTraffic; 	
 	int GameLogTimeStamp;
+	int GameLogSplit;
 } Arg;
 
 extern struct Arg GameArg;

--- a/d2/include/console.h
+++ b/d2/include/console.h
@@ -32,6 +32,7 @@ typedef struct console_buffer
 void con_init(void);
 void con_printf(int level, const char *fmt, ...);
 void con_showup(void);
+void con_switch_log(const char* filename);
 
 #endif /* _CONSOLE_H_ */
 

--- a/d2/main/console.c
+++ b/d2/main/console.c
@@ -270,23 +270,35 @@ static void con_close(void)
 
 void con_init(void)
 {
-	char filename[PATH_MAX];
-
 	memset(con_buffer,0,sizeof(con_buffer));
 
-	if (GameArg.GameLogTimeStamp) {
-		time_t now = time(NULL);
-		struct tm *t = localtime(&now);
-		snprintf(filename, sizeof(filename), "gamelog-%04d%02d%02d-%02d%02d%02d.txt",
-			t->tm_year + 1900, t->tm_mon, t->tm_mday, t->tm_hour, t->tm_min, t->tm_sec);
-	} else {
-		strcpy(filename, "gamelog.txt");
-	}
+	con_switch_log(NULL);
 
-	if (GameArg.DbgSafelog)
-		gamelog_fp = PHYSFS_openWrite(filename);
-	else
-		gamelog_fp = PHYSFSX_openWriteBuffered(filename);
 	atexit(con_close);
 }
 
+void con_switch_log(const char* filename)
+{
+	char filenameBuffer[PATH_MAX];
+	const char* filenameToUse = filename;
+
+	con_close();
+
+	if (filename == NULL) {
+		// Switch to default log filename
+		if (GameArg.GameLogTimeStamp) {
+			time_t now = time(NULL);
+			struct tm *t = localtime(&now);
+			snprintf(filenameBuffer, SDL_arraysize(filenameBuffer), "gamelog-%04d%02d%02d-%02d%02d%02d.txt",
+				t->tm_year + 1900, t->tm_mon, t->tm_mday, t->tm_hour, t->tm_min, t->tm_sec);
+		} else {
+			strcpy(filenameBuffer, "gamelog.txt");
+		}
+		filenameToUse = filenameBuffer;
+	}
+
+	if (GameArg.DbgSafelog)
+		gamelog_fp = PHYSFS_openWrite(filenameToUse);
+	else
+		gamelog_fp = PHYSFSX_openWriteBuffered(filenameToUse);
+}

--- a/d2/main/game.c
+++ b/d2/main/game.c
@@ -1197,6 +1197,8 @@ int game_handler(window *wind, d_event *event, void *data)
 
 			game_disable_cheats();
 			Game_mode = GM_GAME_OVER;
+			if (GameArg.GameLogSplit)
+				con_switch_log(NULL); // switch back to default log
 #ifdef EDITOR
 			if (!EditorWindow)		// have to do it this way because of the necessary longjmp. Yuck.
 #endif

--- a/d2/main/gameseq.c
+++ b/d2/main/gameseq.c
@@ -1524,6 +1524,16 @@ void StartNewLevelSub(int level_num, int page_in_textures, int secret_flag)
 	}
    BigWindowSwitch=0;
 
+	if (GameArg.GameLogSplit) {
+		// Include the mission name, level number and timestamp in the log filename
+		char log_filename[PATH_MAX];
+		time_t now = time(NULL);
+		struct tm *t = localtime(&now);
+		snprintf(log_filename, SDL_arraysize(log_filename), "gamelog-%s-%d-%04d%02d%02d-%02d%02d%02d.txt",
+			Current_mission_filename, level_num, t->tm_year + 1900, t->tm_mon, t->tm_mday, t->tm_hour, t->tm_min, t->tm_sec);
+
+		con_switch_log(log_filename);
+	}
 
 	if (Newdemo_state == ND_STATE_PAUSED)
 		Newdemo_state = ND_STATE_RECORDING;

--- a/d2/misc/args.c
+++ b/d2/misc/args.c
@@ -232,6 +232,7 @@ void ReadCmdArgs(void)
 	GameArg.LogNetTraffic 		= FindArg("-netlog");
 
 	GameArg.GameLogTimeStamp	= FindArg("-gamelog_timestamp");
+	GameArg.GameLogSplit		= FindArg("-gamelog_split");
 }
 
 void args_exit(void)


### PR DESCRIPTION
This change adds a d1x.ini/d2x.ini option to split gamelog.txt up into separate files for each level played. On returning to the main menu, it will revert to the default gamelog.txt (note that this does cause gamelog.txt to get replaced unless -gamelog_timestamp is used).

Resolves issue #79.