### PR TITLE
Allow automatic demo recording in single-player; add silent mode

### DIFF
--- a/d1/main/game.c
+++ b/d1/main/game.c
@@ -1027,7 +1027,7 @@ int game_handler(window *wind, d_event *event, void *data)
 			digi_stop_digi_sounds();
 
 			if ( (Newdemo_state == ND_STATE_RECORDING) || (Newdemo_state == ND_STATE_PAUSED) )
-				newdemo_stop_recording();
+				newdemo_stop_recording(0);
 
 #ifdef NETWORK
 			multi_leave_game();

--- a/d1/main/gamecntl.c
+++ b/d1/main/gamecntl.c
@@ -580,9 +580,9 @@ int HandleSystemKey(int key)
 		KEY_MAC(case KEY_COMMAND+KEY_5:)
 		case KEY_F5:
 			if ( Newdemo_state == ND_STATE_RECORDING )
-				newdemo_stop_recording();
+				newdemo_stop_recording(1);
 			else if ( Newdemo_state == ND_STATE_NORMAL )
-				newdemo_start_recording();
+				newdemo_start_recording(0);
 			break;
 #ifdef NETWORK
 		KEY_MAC(case KEY_COMMAND+KEY_ALTED+KEY_4:)

--- a/d1/main/gamerend.c
+++ b/d1/main/gamerend.c
@@ -429,7 +429,8 @@ void game_draw_hud_stuff()
 		if (is_observer() && can_draw_observer_cockpit() && PlayerCfg.CurrentCockpitMode == CM_FULL_COCKPIT)
 			y = grd_curcanv->cv_bitmap.bm_h / 1.2 ;
 
-		if (PlayerCfg.CurrentCockpitMode != CM_REAR_VIEW) {
+		if (PlayerCfg.CurrentCockpitMode != CM_REAR_VIEW &&
+			(!PlayerCfg.AutoDemoHideUi || !Newdemo_is_autorecord)) {
 			if (PlayerCfg.DemoRecordingIndicator == 0) {
 				gr_string(0x8000, y, message );
 			} else if (PlayerCfg.DemoRecordingIndicator == 1) {

--- a/d1/main/gameseq.c
+++ b/d1/main/gameseq.c
@@ -969,7 +969,7 @@ int AdvanceLevel(int secret_flag)
 	if (Current_level_num == Last_level) {		//player has finished the game!
 
 		if ((Newdemo_state == ND_STATE_RECORDING) || (Newdemo_state == ND_STATE_PAUSED))
-			newdemo_stop_recording();
+			newdemo_stop_recording(0);
 
 		do_end_briefing_screens(Ending_text_filename);
 
@@ -1243,8 +1243,11 @@ void StartNewLevelSub(int level_num, int page_in_textures, int secret_flag)
 	if (!((Game_mode & GM_MULTI) && (Newdemo_state != ND_STATE_PLAYBACK)))
 		palette_save();
 
-	if(Game_mode & GM_MULTI && PlayerCfg.AutoDemo && Newdemo_state != ND_STATE_RECORDING) {
-		newdemo_start_recording();
+	int autodemo_enabled_for_game_mode =
+		(!(Game_mode & GM_MULTI) && PlayerCfg.AutoDemoSp) ||
+		((Game_mode & GM_MULTI) && PlayerCfg.AutoDemoMp);
+	if (autodemo_enabled_for_game_mode && Newdemo_state != ND_STATE_RECORDING) {
+		newdemo_start_recording(1);
 	}
 
 	if (!Game_wind)

--- a/d1/main/menu.c
+++ b/d1/main/menu.c
@@ -2012,7 +2012,7 @@ struct misc_menu_data {
 
 void do_misc_menu()
 {
-	newmenu_item m[31];
+	newmenu_item m[35];
 	int i = 0;
 	struct misc_menu_data misc_menu_data;
 
@@ -2045,74 +2045,83 @@ void do_misc_menu()
 		m[8].type = NM_TYPE_TEXT;
 		m[8].text = "";
 
-		ADD_CHECK(9, "No redundant pickup messages",PlayerCfg.NoRedundancy);
-		ADD_CHECK(10, "Show Player chat only (Multi)",PlayerCfg.MultiMessages);
-		ADD_CHECK(11, "No Rankings (Multi)",PlayerCfg.NoRankings);
-		ADD_CHECK(12, "Show D2-style Prox. Bomb Gauge",PlayerCfg.BombGauge);
-		ADD_CHECK(13, "Free Flight controls in Automap",PlayerCfg.AutomapFreeFlight);
-		ADD_CHECK(14, "No Weapon Autoselect when firing",PlayerCfg.NoFireAutoselect);		
-		ADD_CHECK(15, "Autoselect after firing",PlayerCfg.SelectAfterFire);
-		ADD_CHECK(16, "Only Cycle Autoselect Weapons",PlayerCfg.CycleAutoselectOnly);		
-		ADD_CHECK(17, "Ammo Warnings",PlayerCfg.VulcanAmmoWarnings);
-		ADD_CHECK(18, "Shield Warnings",PlayerCfg.ShieldWarnings);
-		ADD_CHECK(19, "Automatically Start Demos",PlayerCfg.AutoDemo);
-		ADD_CHECK(20, "No Player Chat Sound",PlayerCfg.NoChatSound);
+		m[9].type = NM_TYPE_TEXT;
+		m[9].text = "Automatically Start Demos:";
 
-		m[21].type = NM_TYPE_TEXT;
-		m[21].text = "";
+		ADD_CHECK(10, "Single-Player", PlayerCfg.AutoDemoSp);
+		ADD_CHECK(11, "Multiplayer", PlayerCfg.AutoDemoMp);
+		ADD_CHECK(12, "Silent (Don't Show Prompts)", PlayerCfg.AutoDemoHideUi);
 
-		m[22].type = NM_TYPE_TEXT;
-		m[22].text = "My Ship Colors:";
+		m[13].type = NM_TYPE_TEXT;
+		m[13].text = "";
+
+		ADD_CHECK(14, "No redundant pickup messages",PlayerCfg.NoRedundancy);
+		ADD_CHECK(15, "Show Player chat only (Multi)",PlayerCfg.MultiMessages);
+		ADD_CHECK(16, "No Rankings (Multi)",PlayerCfg.NoRankings);
+		ADD_CHECK(17, "Show D2-style Prox. Bomb Gauge",PlayerCfg.BombGauge);
+		ADD_CHECK(18, "Free Flight controls in Automap",PlayerCfg.AutomapFreeFlight);
+		ADD_CHECK(19, "No Weapon Autoselect when firing",PlayerCfg.NoFireAutoselect);		
+		ADD_CHECK(20, "Autoselect after firing",PlayerCfg.SelectAfterFire);
+		ADD_CHECK(21, "Only Cycle Autoselect Weapons",PlayerCfg.CycleAutoselectOnly);		
+		ADD_CHECK(22, "Ammo Warnings",PlayerCfg.VulcanAmmoWarnings);
+		ADD_CHECK(23, "Shield Warnings",PlayerCfg.ShieldWarnings);
+		ADD_CHECK(24, "No Player Chat Sound",PlayerCfg.NoChatSound);
+
+		m[25].type = NM_TYPE_TEXT;
+		m[25].text = "";
+
+		m[26].type = NM_TYPE_TEXT;
+		m[26].text = "My Ship Colors:";
 
 		print_ship_color(misc_menu_data.preferred_color, SDL_arraysize(misc_menu_data.preferred_color),
 			PlayerCfg.ShipColor);
-		m[23].type = NM_TYPE_SLIDER;
-		m[23].value = PlayerCfg.ShipColor;
-		m[23].text = misc_menu_data.preferred_color;
-		m[23].min_value = 0;
-		m[23].max_value = 8;
+		m[27].type = NM_TYPE_SLIDER;
+		m[27].value = PlayerCfg.ShipColor;
+		m[27].text = misc_menu_data.preferred_color;
+		m[27].min_value = 0;
+		m[27].max_value = 8;
 
 		print_missile_color(misc_menu_data.missile_color, SDL_arraysize(misc_menu_data.missile_color),
 			PlayerCfg.MissileColor);
-		m[24].type = NM_TYPE_SLIDER;
-		m[24].value = PlayerCfg.MissileColor;
-		m[24].text = misc_menu_data.missile_color;
-		m[24].min_value = 0;
-		m[24].max_value = 8;
-
-		ADD_CHECK(25, "Show Custom Ship Colors", PlayerCfg.ShowCustomColors);
-
-		m[26].type = NM_TYPE_TEXT;
-		m[26].text = "";
-
-		m[27].type = NM_TYPE_TEXT;
-		m[27].text = "Team Colors:";
-
-		print_my_team_color(misc_menu_data.my_team_color, SDL_arraysize(misc_menu_data.my_team_color),
-			PlayerCfg.MyTeamColor);
 		m[28].type = NM_TYPE_SLIDER;
-		m[28].value = PlayerCfg.MyTeamColor;
-		m[28].text = misc_menu_data.my_team_color;
+		m[28].value = PlayerCfg.MissileColor;
+		m[28].text = misc_menu_data.missile_color;
 		m[28].min_value = 0;
 		m[28].max_value = 8;
 
+		ADD_CHECK(29, "Show Custom Ship Colors", PlayerCfg.ShowCustomColors);
+
+		m[30].type = NM_TYPE_TEXT;
+		m[30].text = "";
+
+		m[31].type = NM_TYPE_TEXT;
+		m[31].text = "Team Colors:";
+
+		print_my_team_color(misc_menu_data.my_team_color, SDL_arraysize(misc_menu_data.my_team_color),
+			PlayerCfg.MyTeamColor);
+		m[32].type = NM_TYPE_SLIDER;
+		m[32].value = PlayerCfg.MyTeamColor;
+		m[32].text = misc_menu_data.my_team_color;
+		m[32].min_value = 0;
+		m[32].max_value = 8;
+
 		print_other_team_color(misc_menu_data.other_team_color, SDL_arraysize(misc_menu_data.other_team_color),
 			PlayerCfg.OtherTeamColor);
-		m[29].type = NM_TYPE_SLIDER;
-		m[29].value = PlayerCfg.OtherTeamColor;
-		m[29].text = misc_menu_data.other_team_color;
-		m[29].min_value = 0;
-		m[29].max_value = 8;
+		m[33].type = NM_TYPE_SLIDER;
+		m[33].value = PlayerCfg.OtherTeamColor;
+		m[33].text = misc_menu_data.other_team_color;
+		m[33].min_value = 0;
+		m[33].max_value = 8;
 
 		if (PlayerCfg.MyTeamColor == 8 && PlayerCfg.OtherTeamColor == 8) {
 			// If we're not setting explicit team colors, we don't override what the game host picked
-			m[30].type = NM_TYPE_TEXT;
-			m[30].text = "Ignore Per-Game Team Colors (N/A)";
+			m[34].type = NM_TYPE_TEXT;
+			m[34].text = "Ignore Per-Game Team Colors (N/A)";
 		} else {
-			m[30].type = NM_TYPE_CHECK;
-			m[30].text = "Ignore Per-Game Team Colors";
+			m[34].type = NM_TYPE_CHECK;
+			m[34].text = "Ignore Per-Game Team Colors";
 		}
-		m[30].value = PlayerCfg.PreferMyTeamColors;
+		m[34].value = PlayerCfg.PreferMyTeamColors;
 
 		i = newmenu_do1(NULL, "Misc Options", SDL_arraysize(m), m, menu_misc_options_handler, &misc_menu_data, i);
 
@@ -2126,20 +2135,22 @@ void do_misc_menu()
 		} else if (m[7].value) {
 			PlayerCfg.DemoRecordingIndicator = 2;
 		}
-		PlayerCfg.NoRedundancy 			= m[9].value;
-		PlayerCfg.MultiMessages 		= m[10].value;
-		PlayerCfg.NoRankings 			= m[11].value;
-		PlayerCfg.BombGauge 			= m[12].value;
-		PlayerCfg.AutomapFreeFlight		= m[13].value;
-		PlayerCfg.NoFireAutoselect		= m[14].value;
-		PlayerCfg.SelectAfterFire       = m[15].value;  if(PlayerCfg.SelectAfterFire) { PlayerCfg.NoFireAutoselect = 1; }
-		PlayerCfg.CycleAutoselectOnly		= m[16].value;
-		PlayerCfg.VulcanAmmoWarnings = m[17].value; 
-		PlayerCfg.ShieldWarnings = m[18].value; 
-		PlayerCfg.AutoDemo = m[19].value;
-		PlayerCfg.NoChatSound = m[20].value;
-		PlayerCfg.ShowCustomColors = m[25].value;
-		PlayerCfg.PreferMyTeamColors = (PlayerCfg.MyTeamColor == 8 && PlayerCfg.OtherTeamColor == 8) ? 0 : m[30].value;
+		PlayerCfg.AutoDemoSp			= m[10].value;
+		PlayerCfg.AutoDemoMp			= m[11].value;
+		PlayerCfg.AutoDemoHideUi		= m[12].value;
+		PlayerCfg.NoRedundancy 			= m[14].value;
+		PlayerCfg.MultiMessages 		= m[15].value;
+		PlayerCfg.NoRankings 			= m[16].value;
+		PlayerCfg.BombGauge 			= m[17].value;
+		PlayerCfg.AutomapFreeFlight		= m[18].value;
+		PlayerCfg.NoFireAutoselect		= m[19].value;
+		PlayerCfg.SelectAfterFire		= m[20].value;  if(PlayerCfg.SelectAfterFire) { PlayerCfg.NoFireAutoselect = 1; }
+		PlayerCfg.CycleAutoselectOnly		= m[21].value;
+		PlayerCfg.VulcanAmmoWarnings = m[22].value; 
+		PlayerCfg.ShieldWarnings = m[23].value; 
+		PlayerCfg.NoChatSound = m[24].value;
+		PlayerCfg.ShowCustomColors = m[29].value;
+		PlayerCfg.PreferMyTeamColors = (PlayerCfg.MyTeamColor == 8 && PlayerCfg.OtherTeamColor == 8) ? 0 : m[34].value;
 
 	} while( i>-1 );
 
@@ -2158,30 +2169,30 @@ int menu_misc_options_handler(newmenu* menu, d_event* event, void* userdata)
 	struct misc_menu_data* menu_data = (struct misc_menu_data*)userdata;
 	
 	if (event->type == EVENT_NEWMENU_CHANGED) {
-		if (citem == 23) {
-			PlayerCfg.ShipColor = menus[23].value;
+		if (citem == 27) {
+			PlayerCfg.ShipColor = menus[27].value;
 			print_ship_color(menu_data->preferred_color, SDL_arraysize(menu_data->preferred_color),
 				PlayerCfg.ShipColor);
-		} else if (citem == 24) {
-			PlayerCfg.MissileColor = menus[24].value;
+		} else if (citem == 28) {
+			PlayerCfg.MissileColor = menus[28].value;
 			print_missile_color(menu_data->missile_color, SDL_arraysize(menu_data->missile_color),
 				PlayerCfg.MissileColor);
-		} else if (citem == 28) {
-			PlayerCfg.MyTeamColor = menus[28].value;
+		} else if (citem == 32) {
+			PlayerCfg.MyTeamColor = menus[32].value;
 			print_my_team_color(menu_data->my_team_color, SDL_arraysize(menu_data->my_team_color),
 				PlayerCfg.MyTeamColor);
-		} else if (citem == 29) {
-			PlayerCfg.OtherTeamColor = menus[29].value;
+		} else if (citem == 33) {
+			PlayerCfg.OtherTeamColor = menus[33].value;
 			print_other_team_color(menu_data->other_team_color, SDL_arraysize(menu_data->other_team_color),
 				PlayerCfg.OtherTeamColor);
 		}
 
 		if (PlayerCfg.MyTeamColor == 8 && PlayerCfg.OtherTeamColor == 8) {
-			menus[30].type = NM_TYPE_TEXT;
-			menus[30].text = "Ignore Per-Game Team Colors (N/A)";
+			menus[34].type = NM_TYPE_TEXT;
+			menus[34].text = "Ignore Per-Game Team Colors (N/A)";
 		} else {
-			menus[30].type = NM_TYPE_CHECK;
-			menus[30].text = "Ignore Per-Game Team Colors";
+			menus[34].type = NM_TYPE_CHECK;
+			menus[34].text = "Ignore Per-Game Team Colors";
 		}
 	}
 

--- a/d1/main/newdemo.c
+++ b/d1/main/newdemo.c
@@ -2612,6 +2612,7 @@ int newdemo_read_frame_information(int rewrite)
 			palette_save();						// initialise for palette_restore()
 
 			start_time();
+			reset_time(); // stop FrameTime spikes that mess up interpolation
 			break;
 		}
 

--- a/d1/main/newdemo.h
+++ b/d1/main/newdemo.h
@@ -40,6 +40,7 @@ COPYRIGHT 1993-1998 PARALLAX SOFTWARE CORPORATION.  ALL RIGHTS RESERVED.
 
 // Gives state of recorder
 extern int Newdemo_state;
+extern int Newdemo_is_autorecord;
 extern int NewdemoFrameCount;
 
 extern int Newdemo_vcr_state;
@@ -101,8 +102,8 @@ extern void newdemo_goto_beginning();
 // Interactive functions to control playback/record;
 extern void newdemo_start_playback( char * filename );
 extern void newdemo_stop_playback();
-extern void newdemo_start_recording();
-extern void newdemo_stop_recording();
+extern void newdemo_start_recording(int is_autorecord);
+extern void newdemo_stop_recording(int is_manual);
 
 extern int newdemo_swap_endian(char *filename);
 

--- a/d1/main/playsave.c
+++ b/d1/main/playsave.c
@@ -111,7 +111,9 @@ int new_player_config()
 	PlayerCfg.SelectAfterFire = 1;  /* SelectAfterFire */
 	PlayerCfg.VulcanAmmoWarnings = 1; 
 	PlayerCfg.ShieldWarnings = 0; 
-	PlayerCfg.AutoDemo = 1; 
+	PlayerCfg.AutoDemoSp = 0;
+	PlayerCfg.AutoDemoMp = 0;
+	PlayerCfg.AutoDemoHideUi = 0;
 	PlayerCfg.ShowCustomColors = 1; 
 	PlayerCfg.PreferMyTeamColors = 0;
 	PlayerCfg.QuietPlasma = 1; 
@@ -435,7 +437,13 @@ int read_player_d1x(char *filename)
 				if(!strcmp(word,"SHIELDWARNINGS"))
 					PlayerCfg.ShieldWarnings = atoi(line);	
 				if(!strcmp(word,"AUTODEMO"))
-					PlayerCfg.AutoDemo = atoi(line);	
+					PlayerCfg.AutoDemoMp = atoi(line);
+				if(!strcmp(word,"AUTODEMOSP"))
+					PlayerCfg.AutoDemoSp = atoi(line);
+				if(!strcmp(word,"AUTODEMOMP"))
+					PlayerCfg.AutoDemoMp = atoi(line);
+				if(!strcmp(word,"AUTODEMOHIDEUI"))
+					PlayerCfg.AutoDemoHideUi = atoi(line);
 				if(!strcmp(word,"SHOWCUSTOMCOLORS"))
 					PlayerCfg.ShowCustomColors = atoi(line);	
 				if(!strcmp(word,"SHIPCOLOR"))
@@ -896,7 +904,9 @@ int write_player_d1x(char *filename)
 		PHYSFSX_printf(fout,"cycleautoselectonly=%i\n",PlayerCfg.CycleAutoselectOnly);
 		PHYSFSX_printf(fout,"vulcanammowarnings=%i\n",PlayerCfg.VulcanAmmoWarnings);		
 		PHYSFSX_printf(fout,"shieldwarnings=%i\n",PlayerCfg.ShieldWarnings);				
-		PHYSFSX_printf(fout,"autodemo=%i\n",PlayerCfg.AutoDemo);					
+		PHYSFSX_printf(fout,"autodemosp=%i\n",PlayerCfg.AutoDemoSp);
+		PHYSFSX_printf(fout,"autodemomp=%i\n",PlayerCfg.AutoDemoMp);
+		PHYSFSX_printf(fout,"autodemohideui=%i\n",PlayerCfg.AutoDemoHideUi);
 		PHYSFSX_printf(fout,"showcustomcolors=%i\n",PlayerCfg.ShowCustomColors);	
 		PHYSFSX_printf(fout,"shipcolor=%i\n",PlayerCfg.ShipColor);	
 		PHYSFSX_printf(fout,"missilecolor=%i\n",PlayerCfg.MissileColor);

--- a/d1/main/playsave.h
+++ b/d1/main/playsave.h
@@ -94,7 +94,9 @@ typedef struct player_config
 	ubyte CycleAutoselectOnly;
 	ubyte VulcanAmmoWarnings;
 	ubyte ShieldWarnings; 
-	ubyte AutoDemo; 
+	ubyte AutoDemoSp;
+	ubyte AutoDemoMp;
+	ubyte AutoDemoHideUi;
 	ubyte ShowCustomColors; 
 	ubyte PreferMyTeamColors;
 	ubyte QuietPlasma; 

--- a/d1/main/state.c
+++ b/d1/main/state.c
@@ -1078,7 +1078,7 @@ int state_restore_all(int in_game)
 	char filename[PATH_MAX];
 
 	if ( Newdemo_state == ND_STATE_RECORDING )
-		newdemo_stop_recording();
+		newdemo_stop_recording(0);
 
 	if ( Newdemo_state != ND_STATE_NORMAL )
 		return 0;

--- a/d2/main/game.c
+++ b/d2/main/game.c
@@ -1184,7 +1184,7 @@ int game_handler(window *wind, d_event *event, void *data)
 			digi_stop_digi_sounds();
 
 			if ( (Newdemo_state == ND_STATE_RECORDING) || (Newdemo_state == ND_STATE_PAUSED) )
-				newdemo_stop_recording();
+				newdemo_stop_recording(0);
 
 #ifdef NETWORK
 			multi_leave_game();

--- a/d2/main/gamecntl.c
+++ b/d2/main/gamecntl.c
@@ -863,9 +863,9 @@ int HandleSystemKey(int key)
 		KEY_MAC(case KEY_COMMAND+KEY_5:)
 		case KEY_F5:
 			if ( Newdemo_state == ND_STATE_RECORDING )
-				newdemo_stop_recording();
+				newdemo_stop_recording(1);
 			else if ( Newdemo_state == ND_STATE_NORMAL )
-				newdemo_start_recording();
+				newdemo_start_recording(0);
 			break;
 #ifdef NETWORK
 		KEY_MAC(case KEY_COMMAND+KEY_ALTED+KEY_4:)

--- a/d2/main/gamerend.c
+++ b/d2/main/gamerend.c
@@ -508,7 +508,8 @@ void game_draw_hud_stuff()
 		if (is_observer() && can_draw_observer_cockpit() && PlayerCfg.CurrentCockpitMode == CM_FULL_COCKPIT)
 			y = grd_curcanv->cv_bitmap.bm_h / 1.2 ;
 
-		if (PlayerCfg.CurrentCockpitMode != CM_REAR_VIEW) {
+		if (PlayerCfg.CurrentCockpitMode != CM_REAR_VIEW &&
+			(!PlayerCfg.AutoDemoHideUi || !Newdemo_is_autorecord)) {
 			if (PlayerCfg.DemoRecordingIndicator == 0) {
 				gr_string(0x8000, y, message);
 			}

--- a/d2/main/gameseq.c
+++ b/d2/main/gameseq.c
@@ -1281,7 +1281,7 @@ void show_order_form();
 void DoEndGame(void)
 {
 	if ((Newdemo_state == ND_STATE_RECORDING) || (Newdemo_state == ND_STATE_PAUSED))
-		newdemo_stop_recording();
+		newdemo_stop_recording(0);
 
 	set_screen_mode( SCREEN_MENU );
 
@@ -1650,8 +1650,11 @@ void StartNewLevelSub(int level_num, int page_in_textures, int secret_flag)
 	if (!((Game_mode & GM_MULTI) && (Newdemo_state != ND_STATE_PLAYBACK)))
 		full_palette_save();
 
-	if(Game_mode & GM_MULTI && PlayerCfg.AutoDemo && Newdemo_state != ND_STATE_RECORDING) {
-		newdemo_start_recording();
+	int autodemo_enabled_for_game_mode =
+		(!(Game_mode & GM_MULTI) && PlayerCfg.AutoDemoSp) ||
+		((Game_mode & GM_MULTI) && PlayerCfg.AutoDemoMp);
+	if (autodemo_enabled_for_game_mode && Newdemo_state != ND_STATE_RECORDING) {
+		newdemo_start_recording(1);
 	}
 
 	if (!Game_wind)

--- a/d2/main/menu.c
+++ b/d2/main/menu.c
@@ -2039,7 +2039,7 @@ struct misc_menu_data {
 
 void do_misc_menu()
 {
-	newmenu_item m[35];
+	newmenu_item m[39];
 	int i = 0;
 	struct misc_menu_data misc_menu_data;
 
@@ -2076,74 +2076,83 @@ void do_misc_menu()
 		m[12].type = NM_TYPE_TEXT;
 		m[12].text = "";
 
-		ADD_CHECK(13, "Movie Subtitles",GameCfg.MovieSubtitles);
-		ADD_CHECK(14, "No redundant pickup messages",PlayerCfg.NoRedundancy);
-		ADD_CHECK(15, "Show Player chat only (Multi)",PlayerCfg.MultiMessages);
-		ADD_CHECK(16, "No Rankings (Multi)",PlayerCfg.NoRankings);
-		ADD_CHECK(17, "Free Flight controls in Automap",PlayerCfg.AutomapFreeFlight);
-		ADD_CHECK(18, "No Weapon Autoselect when firing",PlayerCfg.NoFireAutoselect);
-		ADD_CHECK(19, "Autoselect after firing",PlayerCfg.SelectAfterFire);
-		ADD_CHECK(20, "Only Cycle Autoselect Weapons",PlayerCfg.CycleAutoselectOnly);
-		ADD_CHECK(21, "Ammo Warnings",PlayerCfg.VulcanAmmoWarnings);
-		ADD_CHECK(22, "Shield Warnings",PlayerCfg.ShieldWarnings);
-		ADD_CHECK(23, "Automatically Start Demos", PlayerCfg.AutoDemo);
-		ADD_CHECK(24, "No Player Chat Sound",PlayerCfg.NoChatSound);
+		m[13].type = NM_TYPE_TEXT;
+		m[13].text = "Automatically Start Demos:";
 
-		m[25].type = NM_TYPE_TEXT;
-		m[25].text = "";
+		ADD_CHECK(14, "Single-Player", PlayerCfg.AutoDemoSp);
+		ADD_CHECK(15, "Multiplayer", PlayerCfg.AutoDemoMp);
+		ADD_CHECK(16, "Silent (Don't Show Prompts)", PlayerCfg.AutoDemoHideUi);
 
-		m[26].type = NM_TYPE_TEXT;
-		m[26].text = "My Ship Colors:";
+		m[17].type = NM_TYPE_TEXT;
+		m[17].text = "";
+
+		ADD_CHECK(18, "Movie Subtitles",GameCfg.MovieSubtitles);
+		ADD_CHECK(19, "No redundant pickup messages",PlayerCfg.NoRedundancy);
+		ADD_CHECK(20, "Show Player chat only (Multi)",PlayerCfg.MultiMessages);
+		ADD_CHECK(21, "No Rankings (Multi)",PlayerCfg.NoRankings);
+		ADD_CHECK(22, "Free Flight controls in Automap",PlayerCfg.AutomapFreeFlight);
+		ADD_CHECK(23, "No Weapon Autoselect when firing",PlayerCfg.NoFireAutoselect);
+		ADD_CHECK(24, "Autoselect after firing",PlayerCfg.SelectAfterFire);
+		ADD_CHECK(25, "Only Cycle Autoselect Weapons",PlayerCfg.CycleAutoselectOnly);
+		ADD_CHECK(26, "Ammo Warnings",PlayerCfg.VulcanAmmoWarnings);
+		ADD_CHECK(27, "Shield Warnings",PlayerCfg.ShieldWarnings);
+		ADD_CHECK(28, "No Player Chat Sound",PlayerCfg.NoChatSound);
+
+		m[29].type = NM_TYPE_TEXT;
+		m[29].text = "";
+
+		m[30].type = NM_TYPE_TEXT;
+		m[30].text = "My Ship Colors:";
 
 		print_ship_color(misc_menu_data.preferred_color, SDL_arraysize(misc_menu_data.preferred_color),
 			PlayerCfg.ShipColor);
-		m[27].type = NM_TYPE_SLIDER;
-		m[27].value = PlayerCfg.ShipColor;
-		m[27].text = misc_menu_data.preferred_color;
-		m[27].min_value = 0;
-		m[27].max_value = 8;
+		m[31].type = NM_TYPE_SLIDER;
+		m[31].value = PlayerCfg.ShipColor;
+		m[31].text = misc_menu_data.preferred_color;
+		m[31].min_value = 0;
+		m[31].max_value = 8;
 
 		print_missile_color(misc_menu_data.missile_color, SDL_arraysize(misc_menu_data.missile_color),
 			PlayerCfg.MissileColor);
-		m[28].type = NM_TYPE_SLIDER;
-		m[28].value = PlayerCfg.MissileColor;
-		m[28].text = misc_menu_data.missile_color;
-		m[28].min_value = 0;
-		m[28].max_value = 8;
-
-		ADD_CHECK(29, "Show Custom Ship Colors", PlayerCfg.ShowCustomColors);
-
-		m[30].type = NM_TYPE_TEXT;
-		m[30].text = "";
-
-		m[31].type = NM_TYPE_TEXT;
-		m[31].text = "Team Colors:";
-
-		print_my_team_color(misc_menu_data.my_team_color, SDL_arraysize(misc_menu_data.my_team_color),
-			PlayerCfg.MyTeamColor);
 		m[32].type = NM_TYPE_SLIDER;
-		m[32].value = PlayerCfg.MyTeamColor;
-		m[32].text = misc_menu_data.my_team_color;
+		m[32].value = PlayerCfg.MissileColor;
+		m[32].text = misc_menu_data.missile_color;
 		m[32].min_value = 0;
 		m[32].max_value = 8;
 
+		ADD_CHECK(33, "Show Custom Ship Colors", PlayerCfg.ShowCustomColors);
+
+		m[34].type = NM_TYPE_TEXT;
+		m[34].text = "";
+
+		m[35].type = NM_TYPE_TEXT;
+		m[35].text = "Team Colors:";
+
+		print_my_team_color(misc_menu_data.my_team_color, SDL_arraysize(misc_menu_data.my_team_color),
+			PlayerCfg.MyTeamColor);
+		m[36].type = NM_TYPE_SLIDER;
+		m[36].value = PlayerCfg.MyTeamColor;
+		m[36].text = misc_menu_data.my_team_color;
+		m[36].min_value = 0;
+		m[36].max_value = 8;
+
 		print_other_team_color(misc_menu_data.other_team_color, SDL_arraysize(misc_menu_data.other_team_color),
 			PlayerCfg.OtherTeamColor);
-		m[33].type = NM_TYPE_SLIDER;
-		m[33].value = PlayerCfg.OtherTeamColor;
-		m[33].text = misc_menu_data.other_team_color;
-		m[33].min_value = 0;
-		m[33].max_value = 8;
+		m[37].type = NM_TYPE_SLIDER;
+		m[37].value = PlayerCfg.OtherTeamColor;
+		m[37].text = misc_menu_data.other_team_color;
+		m[37].min_value = 0;
+		m[37].max_value = 8;
 
 		if (PlayerCfg.MyTeamColor == 8 && PlayerCfg.OtherTeamColor == 8) {
 			// If we're not setting explicit team colors, we don't override what the game host picked
-			m[34].type = NM_TYPE_TEXT;
-			m[34].text = "Ignore Per-Game Team Colors (N/A)";
+			m[38].type = NM_TYPE_TEXT;
+			m[38].text = "Ignore Per-Game Team Colors (N/A)";
 		} else {
-			m[34].type = NM_TYPE_CHECK;
-			m[34].text = "Ignore Per-Game Team Colors";
+			m[38].type = NM_TYPE_CHECK;
+			m[38].text = "Ignore Per-Game Team Colors";
 		}
-		m[34].value = PlayerCfg.PreferMyTeamColors;
+		m[38].value = PlayerCfg.PreferMyTeamColors;
 
 		i = newmenu_do1(NULL, "Misc Options", SDL_arraysize(m), m, menu_misc_options_handler, &misc_menu_data, i);
 
@@ -2163,20 +2172,22 @@ void do_misc_menu()
 		else if (m[11].value) {
 			PlayerCfg.DemoRecordingIndicator = 2;
 		}
-		GameCfg.MovieSubtitles 			= m[13].value;
-		PlayerCfg.NoRedundancy 			= m[14].value;
-		PlayerCfg.MultiMessages 		= m[15].value;
-		PlayerCfg.NoRankings 			= m[16].value;
-		PlayerCfg.AutomapFreeFlight		= m[17].value;
-		PlayerCfg.NoFireAutoselect		= m[18].value;
-		PlayerCfg.SelectAfterFire		= m[19].value; if(PlayerCfg.SelectAfterFire) { PlayerCfg.NoFireAutoselect = 1; }
-		PlayerCfg.CycleAutoselectOnly		= m[20].value;
-		PlayerCfg.VulcanAmmoWarnings = m[21].value; 
-		PlayerCfg.ShieldWarnings = m[22].value;
-		PlayerCfg.AutoDemo = m[23].value;
-		PlayerCfg.NoChatSound = m[24].value;
-		PlayerCfg.ShowCustomColors = m[29].value;
-		PlayerCfg.PreferMyTeamColors = (PlayerCfg.MyTeamColor == 8 && PlayerCfg.OtherTeamColor == 8) ? 0 : m[34].value;
+		PlayerCfg.AutoDemoSp			= m[14].value;
+		PlayerCfg.AutoDemoMp			= m[15].value;
+		PlayerCfg.AutoDemoHideUi		= m[16].value;
+		GameCfg.MovieSubtitles 			= m[18].value;
+		PlayerCfg.NoRedundancy 			= m[19].value;
+		PlayerCfg.MultiMessages 		= m[20].value;
+		PlayerCfg.NoRankings 			= m[21].value;
+		PlayerCfg.AutomapFreeFlight		= m[22].value;
+		PlayerCfg.NoFireAutoselect		= m[23].value;
+		PlayerCfg.SelectAfterFire		= m[24].value; if(PlayerCfg.SelectAfterFire) { PlayerCfg.NoFireAutoselect = 1; }
+		PlayerCfg.CycleAutoselectOnly		= m[25].value;
+		PlayerCfg.VulcanAmmoWarnings = m[26].value; 
+		PlayerCfg.ShieldWarnings = m[27].value;
+		PlayerCfg.NoChatSound = m[28].value;
+		PlayerCfg.ShowCustomColors = m[33].value;
+		PlayerCfg.PreferMyTeamColors = (PlayerCfg.MyTeamColor == 8 && PlayerCfg.OtherTeamColor == 8) ? 0 : m[38].value;
 
 	} while( i>-1 );
 
@@ -2195,30 +2206,30 @@ int menu_misc_options_handler(newmenu* menu, d_event* event, void* userdata)
 	struct misc_menu_data* menu_data = (struct misc_menu_data*)userdata;
 	
 	if (event->type == EVENT_NEWMENU_CHANGED) {
-		if (citem == 27) {
-			PlayerCfg.ShipColor = menus[27].value;
+		if (citem == 31) {
+			PlayerCfg.ShipColor = menus[31].value;
 			print_ship_color(menu_data->preferred_color, SDL_arraysize(menu_data->preferred_color),
 				PlayerCfg.ShipColor);
-		} else if (citem == 28) {
-			PlayerCfg.MissileColor = menus[28].value;
+		} else if (citem == 32) {
+			PlayerCfg.MissileColor = menus[32].value;
 			print_missile_color(menu_data->missile_color, SDL_arraysize(menu_data->missile_color),
 				PlayerCfg.MissileColor);
-		} else if (citem == 32) {
-			PlayerCfg.MyTeamColor = menus[32].value;
+		} else if (citem == 36) {
+			PlayerCfg.MyTeamColor = menus[36].value;
 			print_my_team_color(menu_data->my_team_color, SDL_arraysize(menu_data->my_team_color),
 				PlayerCfg.MyTeamColor);
-		} else if (citem == 33) {
-			PlayerCfg.OtherTeamColor = menus[33].value;
+		} else if (citem == 37) {
+			PlayerCfg.OtherTeamColor = menus[37].value;
 			print_other_team_color(menu_data->other_team_color, SDL_arraysize(menu_data->other_team_color),
 				PlayerCfg.OtherTeamColor);
 		}
 
 		if (PlayerCfg.MyTeamColor == 8 && PlayerCfg.OtherTeamColor == 8) {
-			menus[34].type = NM_TYPE_TEXT;
-			menus[34].text = "Ignore Per-Game Team Colors (N/A)";
+			menus[38].type = NM_TYPE_TEXT;
+			menus[38].text = "Ignore Per-Game Team Colors (N/A)";
 		} else {
-			menus[34].type = NM_TYPE_CHECK;
-			menus[34].text = "Ignore Per-Game Team Colors";
+			menus[38].type = NM_TYPE_CHECK;
+			menus[38].text = "Ignore Per-Game Team Colors";
 		}
 	}
 

--- a/d2/main/newdemo.c
+++ b/d2/main/newdemo.c
@@ -2862,6 +2862,7 @@ int newdemo_read_frame_information(int rewrite)
 			full_palette_save();				// initialise for palette_restore()
 
 			start_time();
+			reset_time(); // stop FrameTime spikes that mess up interpolation
 			break;
 		}
 

--- a/d2/main/newdemo.c
+++ b/d2/main/newdemo.c
@@ -22,6 +22,7 @@ COPYRIGHT 1993-1999 PARALLAX SOFTWARE CORPORATION.  ALL RIGHTS RESERVED.
 #include <stdio.h>
 #include <stdarg.h>
 #include <string.h> // for memset
+#include <time.h>
 #include <errno.h>
 #include <ctype.h>
 
@@ -160,6 +161,7 @@ PHYSFS_file *outfile = NULL;
 
 // Some globals
 int Newdemo_state = 0;
+int Newdemo_is_autorecord = 0;
 int Newdemo_game_mode = 0;
 int Newdemo_vcr_state = 0;
 int Newdemo_show_percentage=1;
@@ -287,7 +289,7 @@ int newdemo_write(const void *buffer, int elsize, int nelem )
 		return num_written;
 
 	nd_record_v_no_space=2;
-	newdemo_stop_recording();
+	newdemo_stop_recording(0);
 	return -1;
 }
 
@@ -3351,11 +3353,12 @@ void newdemo_playback_one_frame()
 	}
 }
 
-void newdemo_start_recording()
+void newdemo_start_recording(int is_autorecord)
 {
 	Newdemo_num_written = 0;
 	nd_record_v_no_space=0;
 	Newdemo_state = ND_STATE_RECORDING;
+	Newdemo_is_autorecord = is_autorecord;
 
 	PHYSFS_mkdir(DEMO_DIR); //always try making directory - could only exist in read-only path
 
@@ -3440,16 +3443,135 @@ void newdemo_write_end()
 	nd_write_byte(ND_EVENT_EOF);
 }
 
-char demoname_allowed_chars[] = "azAZ09__--";
-void newdemo_stop_recording()
+// Removes invalid characters from a filename.
+void newdemo_clean_filename(char* filename_buffer, unsigned int filename_buffer_length)
 {
-	newmenu_item m[6];
-	int exit;
-	static char filename[PATH_MAX] = "", *s;
-	static sbyte tmpcnt = 0;
-	char fullname[PATH_MAX] = DEMO_DIR;
+	size_t len = strnlen(filename_buffer, filename_buffer_length);
+	for (char* fc = filename_buffer; *fc;) {
+		if (!isalnum(*fc) && *fc != '_') {
+			size_t bytes_to_move = len + filename_buffer - fc - 1;
+			memmove(fc, fc + 1, bytes_to_move);
+			fc[bytes_to_move] = 0;
+		} else {
+			fc++;
+		}
+	}
+}
 
-	exit = 0;
+// Checks whether a demo filename is valid, notifying the player if not.
+int newdemo_validate_filename(const char* filename_buffer, unsigned int filename_buffer_length)
+{
+	if (filename_buffer[0] == 0) // empty string
+		return 0;
+
+	//check to make sure name is ok
+	for (const char* s = filename_buffer; *s; s++)
+		if (!isalnum(*s) && *s != '_') {
+			nm_messagebox(NULL, 1, TXT_CONTINUE, TXT_DEMO_USE_LETTERS);
+			return 0;
+		}
+
+	return 1;
+}
+
+#define MAX_DEMO_NAME_ATTEMPTS 255
+void newdemo_get_default_filename(char* filename_buffer, unsigned int filename_buffer_length)
+{
+	char basename[PATH_MAX] = "";
+
+	if (Game_mode & GM_MULTI) {
+		// Multiplayer game; use the game type, who we're playing against, etc.
+		if (is_observer()) {
+			sprintf_s(basename, SDL_arraysize(basename), "%s_OBS_%s", Players[Player_num].callsign, Netgame.mission_name);
+		} else if(Game_mode & GM_MULTI_COOP) {
+			sprintf_s(basename, SDL_arraysize(basename), "%s_COOP_%s", Players[Player_num].callsign, Netgame.mission_name);
+		}
+		// Was this a 1v1? Checking callsigns instead of player count to handle the case where players leave.
+		else if (strlen(Players[0].callsign) && strlen(Players[1].callsign) && !strlen(Players[2].callsign)) {
+			int me = Player_num;
+			int you = Player_num ? 0 : 1;
+			sprintf_s(basename, SDL_arraysize(basename), "%s_%s_%d_%d_%s",
+				Players[Player_num].callsign, Players[you].callsign, Players[me].net_kills_total, Players[you].net_kills_total, Netgame.mission_name);
+		} else {
+			sprintf_s(basename, SDL_arraysize(basename), "%s_ANARCHY_%s", Players[Player_num].callsign, Netgame.mission_name);
+		}
+	} else {
+		// Single-player game; use our name, the name of the mission, and the date.
+		time_t now = time(NULL);
+		struct tm* t = localtime(&now);
+		sprintf_s(basename, SDL_arraysize(basename), "%s_%s_%04d%02d%02d",
+			Players[Player_num].callsign, Current_mission_filename, t->tm_year + 1900, t->tm_mon, t->tm_mday);
+	}
+
+	// Remove invalid characters, because map names can include invalid characters.
+	newdemo_clean_filename(basename, SDL_arraysize(basename));
+
+	// Try to make sure the filename is unique; try appending numbers if there's a collision.
+	for (int attemptnum = 1; attemptnum <= MAX_DEMO_NAME_ATTEMPTS; attemptnum++)
+	{
+		char testpath[PATH_MAX] = "";
+		if (attemptnum > 1)
+			sprintf_s(testpath, SDL_arraysize(testpath), DEMO_DIR "%s_%d" DEMO_EXT, basename, attemptnum);
+		else
+			sprintf_s(testpath, SDL_arraysize(testpath), DEMO_DIR "%s" DEMO_EXT, basename);
+
+		if (!PHYSFSX_exists(testpath, 0)) {
+			if (attemptnum > 1)
+				sprintf_s(filename_buffer, filename_buffer_length, "%s_%d", basename, attemptnum);
+			else
+				strcpy_s(filename_buffer, filename_buffer_length, basename);
+			break;
+		}
+	}
+
+	if (filename_buffer[0] == '\0')
+		// Ran out of attempts. Just overwrite the old file
+		sprintf_s(filename_buffer, filename_buffer_length, "%s_%d", basename, MAX_DEMO_NAME_ATTEMPTS);
+
+	con_printf(CON_NORMAL, "Got default demo file name: %s\n", filename_buffer);
+}
+
+int newdemo_prompt_filename(char* filename_buffer, unsigned int filename_buffer_length)
+{
+	char filename_from_prompt[PATH_MAX] = "";
+	strncpy_s(filename_from_prompt, SDL_arraysize(filename_from_prompt), filename_buffer, filename_buffer_length);
+
+	do {
+		newmenu_item m[2];
+		int exit = 0;
+		Newmenu_allowed_chars = "azAZ09__";
+		if (!nd_record_v_no_space) {
+			m[0].type = NM_TYPE_INPUT;
+			m[0].text_len = SDL_arraysize(filename_from_prompt) - 1;
+			m[0].text = filename_from_prompt;
+			exit = newmenu_do(NULL, TXT_SAVE_DEMO_AS, 1, m, NULL, NULL);
+		} else if (nd_record_v_no_space == 2) {
+			m[0].type = NM_TYPE_TEXT;
+			m[0].text = TXT_DEMO_SAVE_NOSPACE;
+			m[1].type = NM_TYPE_INPUT;
+			m[1].text_len = SDL_arraysize(filename_from_prompt) - 1;
+			m[1].text = filename_from_prompt;
+			exit = newmenu_do(NULL, NULL, 2, m, NULL, NULL);
+		}
+		Newmenu_allowed_chars = NULL;
+
+		if (exit == -2) { // got bumped out from network menu
+			return 1; // Just use the default filename
+		}
+		if (exit == -1) { // pressed ESC
+			HUD_init_message_literal(HM_DEFAULT | HM_MULTI, "Demo saved as tmpdemo.dem");
+			return 0; // tell caller not to move the demo
+		}
+	} while (!newdemo_validate_filename(filename_from_prompt, SDL_arraysize(filename_from_prompt)));
+
+	strcpy_s(filename_buffer, filename_buffer_length, filename_from_prompt);
+	return 1;
+}
+
+void newdemo_stop_recording(int is_manual)
+{
+	char demo_name[PATH_MAX] = "";
+	int was_autorecord = Newdemo_is_autorecord;
 
 	if (!nd_record_v_no_space)
 	{
@@ -3460,149 +3582,22 @@ void newdemo_stop_recording()
 	PHYSFS_close(outfile);
 	outfile = NULL;
 	Newdemo_state = ND_STATE_NORMAL;
+	Newdemo_is_autorecord = 0;
 	gr_palette_load( gr_palette );
 
-	if(Game_mode & GM_MULTI) {
-		char p1[CALLSIGN_LEN + 1];
-		strcpy(p1, Players[Player_num].callsign);
+	newdemo_get_default_filename(demo_name, SDL_arraysize(demo_name));
+	// If we're suppressing auto-record UI, don't ask for the name, just use the default.
+	// If the player presses F5 while auto-recording, we do prompt for a name though.
+	if (is_manual || !was_autorecord || !PlayerCfg.AutoDemoHideUi)
+		if (!newdemo_prompt_filename(demo_name, SDL_arraysize(demo_name)))
+			return;
 
-		char p2[16];
+	// Add path and extension to the file name
+	char filename[PATH_MAX] = "";
+	sprintf_s(filename, SDL_arraysize(filename), DEMO_DIR "%s" DEMO_EXT, demo_name);
 
-		if(is_observer()) {
-			sprintf(p2, "OBS");
-		} else if(Game_mode & GM_MULTI_COOP) {
-			sprintf(p2, "COOP");
-		} else if (strlen(Players[0].callsign) && strlen(Players[1].callsign) && ! strlen(Players[2].callsign)) {
-			int me = Player_num;
-			int you = Player_num ? 0 : 1;
-
-			snprintf(p2, sizeof(p2), "%s_%d_%d", Players[you].callsign, Players[me].net_kills_total, Players[you].net_kills_total);
-		} else {
-			sprintf(p2, "ANARCHY");
-		}
-
-		char basename[PATH_MAX] = "";
-		char testpath[PATH_MAX] = "";
-		int attemptnum = 2;
-
-		sprintf(basename, "%s_%s_%s", p1, p2, Netgame.mission_name);
-
-		sprintf(testpath, "%s%s%s", DEMO_DIR, basename, DEMO_EXT);
-		while(PHYSFSX_exists(testpath, 0) && attemptnum < 20) {
-			sprintf(testpath, "%s%s_%d%s", DEMO_DIR, basename, attemptnum++, DEMO_EXT);
-		}
-
-		con_printf(CON_NORMAL, "%s does not exist!\n", testpath);
-
-		if(attemptnum > 2) {
-			sprintf(filename, "%s_%d", basename, attemptnum - 1);
-		} else {
-			strncpy(filename, basename, PATH_MAX);
-		}
-
-	} else {
-
-		if (filename[0] != '\0') {
-			int num, i = strlen(filename) - 1;
-			char newfile[PATH_MAX];
-
-			while (isdigit(filename[i])) {
-				i--;
-				if (i == -1)
-					break;
-			}
-			i++;
-			num = atoi(&(filename[i]));
-			num++;
-			filename[i] = '\0';
-			sprintf (newfile, "%s%d", filename, num);
-			strncpy(filename, newfile, PATH_MAX);
-			filename[PATH_MAX - 1] = '\0';
-		}
-	}
-
-	// Remove invalid characters, because map names can include invalid characters.
-	char* fc = filename;
-
-	while (*fc) {
-		const char* p = demoname_allowed_chars;
-
-		bool good = 0;
-		while (*p) {
-			Assert(p[1]);
-
-			if (fc[0] >= p[0] && fc[0] <= p[1]) {
-				good = 1;
-				break;
-			}
-
-			p += 2;
-		}
-
-		if (!good) {
-			char* fc2 = fc;
-
-			while (*fc2) {
-				fc2[0] = fc2[1];
-
-				fc2++;
-			}
-		}
-
-		fc++;
-	}
-
-try_again:
-	;
-
-	Newmenu_allowed_chars = demoname_allowed_chars;
-	if (!nd_record_v_no_space) {
-		m[0].type=NM_TYPE_INPUT; m[0].text_len = PATH_MAX - 1; m[0].text = filename;
-		exit = newmenu_do( NULL, TXT_SAVE_DEMO_AS, 1, &(m[0]), NULL, NULL );
-	} else if (nd_record_v_no_space == 2) {
-		m[ 0].type = NM_TYPE_TEXT; m[ 0].text = TXT_DEMO_SAVE_NOSPACE;
-		m[ 1].type = NM_TYPE_INPUT;m[ 1].text_len = PATH_MAX - 1; m[1].text = filename;
-		exit = newmenu_do( NULL, NULL, 2, m, NULL, NULL );
-	}
-	Newmenu_allowed_chars = NULL;
-
-	if (exit == -2) {                   // got bumped out from network menu
-		char save_file[PATH_MAX];
-
-		if (filename[0] != '\0') {
-			strcpy(save_file, DEMO_DIR);
-			strcat(save_file, filename);
-			strcat(save_file, DEMO_EXT);
-		} else
-			sprintf (save_file, "%stmp%d.dem", DEMO_DIR, tmpcnt++);
-		remove(save_file);
-		PHYSFSX_rename(DEMO_FILENAME, save_file);
-		return;
-	}
-	// Nooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
-	if (exit == -1) {               // pressed ESC
-		HUD_init_message_literal( HM_DEFAULT|HM_MULTI, "Demo saved as tmpdemo.dem" );
-	//	PHYSFS_delete(DEMO_FILENAME);   // might as well remove the file
-		return;                     // return without doing anything
-	}
-
-	if (filename[0]==0) //null string
-		goto try_again;
-
-	//check to make sure name is ok
-	for (s=filename;*s;s++)
-		if (!isalnum(*s) && *s!='_') {
-			nm_messagebox(NULL, 1,TXT_CONTINUE, TXT_DEMO_USE_LETTERS);
-			goto try_again;
-		}
-
-	if (nd_record_v_no_space)
-		strcat(fullname, m[1].text);
-	else
-		strcat(fullname, m[0].text);
-	strcat(fullname, DEMO_EXT);
-	PHYSFS_delete(fullname);
-	PHYSFSX_rename(DEMO_FILENAME, fullname);
+	PHYSFS_delete(filename);
+	PHYSFSX_rename(DEMO_FILENAME, filename);
 }
 
 //returns the number of demo files on the disk

--- a/d2/main/newdemo.h
+++ b/d2/main/newdemo.h
@@ -40,6 +40,7 @@ COPYRIGHT 1993-1999 PARALLAX SOFTWARE CORPORATION.  ALL RIGHTS RESERVED.
 
 // Gives state of recorder
 extern int Newdemo_state;
+extern int Newdemo_is_autorecord;
 extern int NewdemoFrameCount;
 
 extern int Newdemo_vcr_state;
@@ -111,8 +112,8 @@ extern void newdemo_goto_beginning();
 // Interactive functions to control playback/record;
 extern void newdemo_start_playback( char * filename );
 extern void newdemo_stop_playback();
-extern void newdemo_start_recording();
-extern void newdemo_stop_recording();
+extern void newdemo_start_recording(int is_autorecord);
+extern void newdemo_stop_recording(int is_manual);
 
 extern int newdemo_swap_endian(char *filename);
 

--- a/d2/main/playsave.c
+++ b/d2/main/playsave.c
@@ -133,7 +133,9 @@ int new_player_config()
 	PlayerCfg.SelectAfterFire = 1;  /* SelectAfterFire */
 	PlayerCfg.VulcanAmmoWarnings = 1; 
 	PlayerCfg.ShieldWarnings = 0; 
-	PlayerCfg.AutoDemo = 1;
+	PlayerCfg.AutoDemoSp = 0;
+	PlayerCfg.AutoDemoMp = 0;
+	PlayerCfg.AutoDemoHideUi = 0;
 	PlayerCfg.ShowCustomColors = 1;
 	PlayerCfg.PreferMyTeamColors = 0;
 	PlayerCfg.QuietPlasma = 1; 
@@ -406,7 +408,13 @@ int read_player_d2x(char *filename)
 				if(!strcmp(word,"SHIELDWARNINGS"))
 					PlayerCfg.ShieldWarnings = atoi(line);	
 				if(!strcmp(word,"AUTODEMO"))
-					PlayerCfg.AutoDemo = atoi(line);
+					PlayerCfg.AutoDemoMp = atoi(line);
+				if(!strcmp(word,"AUTODEMOSP"))
+					PlayerCfg.AutoDemoSp = atoi(line);
+				if(!strcmp(word,"AUTODEMOMP"))
+					PlayerCfg.AutoDemoMp = atoi(line);
+				if(!strcmp(word,"AUTODEMOHIDEUI"))
+					PlayerCfg.AutoDemoHideUi = atoi(line);
 				if(!strcmp(word,"SHOWCUSTOMCOLORS"))
 					PlayerCfg.ShowCustomColors = atoi(line);
 				if(!strcmp(word,"SHIPCOLOR"))
@@ -682,7 +690,9 @@ int write_player_d2x(char *filename)
 		PHYSFSX_printf(fout,"cycleautoselectonly=%i\n",PlayerCfg.CycleAutoselectOnly);
 		PHYSFSX_printf(fout,"vulcanammowarnings=%i\n",PlayerCfg.VulcanAmmoWarnings);		
 		PHYSFSX_printf(fout,"shieldwarnings=%i\n",PlayerCfg.ShieldWarnings);
-		PHYSFSX_printf(fout,"autodemo=%i\n",PlayerCfg.AutoDemo);
+		PHYSFSX_printf(fout,"autodemosp=%i\n",PlayerCfg.AutoDemoSp);
+		PHYSFSX_printf(fout,"autodemomp=%i\n",PlayerCfg.AutoDemoMp);
+		PHYSFSX_printf(fout,"autodemohideui=%i\n",PlayerCfg.AutoDemoHideUi);
 		PHYSFSX_printf(fout,"showcustomcolors=%i\n",PlayerCfg.ShowCustomColors);
 		PHYSFSX_printf(fout,"shipcolor=%i\n",PlayerCfg.ShipColor);	
 		PHYSFSX_printf(fout,"missilecolor=%i\n",PlayerCfg.MissileColor);

--- a/d2/main/playsave.h
+++ b/d2/main/playsave.h
@@ -87,7 +87,9 @@ typedef struct player_config
 	ubyte CycleAutoselectOnly;
 	ubyte VulcanAmmoWarnings;
 	ubyte ShieldWarnings;
-	ubyte AutoDemo;
+	ubyte AutoDemoSp;
+	ubyte AutoDemoMp;
+	ubyte AutoDemoHideUi;
 	ubyte ShowCustomColors;
 	ubyte PreferMyTeamColors;
 	ubyte QuietPlasma;

--- a/d2/main/state.c
+++ b/d2/main/state.c
@@ -1155,7 +1155,7 @@ int state_restore_all(int in_game, int secret_restore, char *filename_override)
 	}
 
 	if ( Newdemo_state == ND_STATE_RECORDING )
-		newdemo_stop_recording();
+		newdemo_stop_recording(0);
 
 	if ( Newdemo_state != ND_STATE_NORMAL )
 		return 0;


### PR DESCRIPTION
This adds a few upgrades/changes to Redux's automatic demo recording feature.

1. Automatic demo recording is now supported in single-player as well.
2. Demo name suggestions have been added to single-player demos (with or without automatic recording).
3. Silent automatic demo recording; in this case the recording indicator will not be shown, and the demo will be automatically saved to the default suggested name without showing a prompt. (The player can still cancel recording by pressing F5, and will be prompted in this case.)
4. Automatic demo recording is no longer enabled by default in multiplayer for new player files; most people don't need demos. (I think the default setting from Retro was a result of the DCL era; it doesn't make that much sense anymore.) It will continue to be enabled for existing player files that use it today.