### PR TITLE
Fix Package - Windows32 GitHub Action

### DIFF
--- a/d2/main/net_udp.c
+++ b/d2/main/net_udp.c
@@ -73,6 +73,18 @@ typedef _ssize_t ssize_t;
 #endif
 #endif
 
+#if !defined(HAVE_STRUCT_TIMEVAL) || !HAVE_STRUCT_TIMEVAL
+struct timeval
+{
+	long tv_sec;
+	long tv_usec;
+};
+#endif
+
+#if defined(_WIN32) || defined(macintosh)
+int gettimeofday(struct timeval* tv, void* tz); // defined in mveplay for D2, but we still need the forward declaration
+#endif //  defined(_WIN32) || defined(macintosh)
+
 // Prototypes
 void net_udp_init();
 void net_udp_close();


### PR DESCRIPTION
The "Package - Windows32" action failed specifically while building D2 due to an implicit declaration error on gettimeofday. This symbol is defined in libmve for the D2 case, so I just added a forward declaration to net_udp.c to clear up the error for MSYS2. I also confirmed that MSVC is still able to build with this change.

Tested using https://github.com/dxx-redux/dxx-redux/actions/runs/12497663841