### PR TITLE
Replace Retro homing option by Remote Hit Spark

### DIFF
--- a/d1/main/collide.c
+++ b/d1/main/collide.c
@@ -1458,9 +1458,12 @@ void collide_player_and_weapon( object * player, object * weapon, vms_vector *co
 		}
 	}
 
-	if ((Game_mode & GM_MULTI) && player->id == Player_num)
+	// Send to other players that the local player got hit
+	if ((Game_mode & GM_MULTI) && Netgame.RemoteHitSpark && player->id == Player_num)
 		multi_send_create_explosion2(player->segnum, collision_point, i2f(10)/2, VCLIP_PLAYER_HIT);
-	if (player->id == Player_num)
+
+	// Show local hit if it won't be received from player
+	if (!(Game_mode & GM_MULTI) || !Netgame.RemoteHitSpark || player->id == Player_num)
 		object_create_explosion( player->segnum, collision_point, i2f(10)/2, VCLIP_PLAYER_HIT );
 
 	if ( Weapon_info[weapon->id].damage_radius ) {

--- a/d1/main/collide.c
+++ b/d1/main/collide.c
@@ -1458,7 +1458,11 @@ void collide_player_and_weapon( object * player, object * weapon, vms_vector *co
 		}
 	}
 
-	object_create_explosion( player->segnum, collision_point, i2f(10)/2, VCLIP_PLAYER_HIT );
+	if ((Game_mode & GM_MULTI) && player->id == Player_num)
+		multi_send_create_explosion2(player->segnum, collision_point, i2f(10)/2, VCLIP_PLAYER_HIT);
+	if (player->id == Player_num)
+		object_create_explosion( player->segnum, collision_point, i2f(10)/2, VCLIP_PLAYER_HIT );
+
 	if ( Weapon_info[weapon->id].damage_radius ) {
 		vms_vector player2weapon;
 		vm_vec_sub(&player2weapon, collision_point, &player->pos);

--- a/d1/main/gamerend.c
+++ b/d1/main/gamerend.c
@@ -215,7 +215,7 @@ void show_netplayerinfo()
 	char hom_string[16];
 	snprintf(hom_string, sizeof(hom_string), "Hom %d", Netgame.HomingUpdateRate);
 	draw_flag(hom_string, Netgame.HomingUpdateRate != 25,                          base_flags_left + word_spacing*0, y);
-	draw_flag("RetroHom", Netgame.ConstantHomingSpeed,                             base_flags_left + word_spacing*1, y);
+	draw_flag("RemSpark", Netgame.RemoteHitSpark,                                  base_flags_left + word_spacing*1, y);
 	draw_flag("CustMod",  Netgame.AllowCustomModelsTextures,                       base_flags_left + word_spacing*2, y);
 
 	set_font_newline();

--- a/d1/main/gameseq.c
+++ b/d1/main/gameseq.c
@@ -1245,7 +1245,6 @@ void StartNewLevelSub(int level_num, int page_in_textures, int secret_flag)
 	reset_respawnable_bots();
 
 	set_homing_update_rate(Game_mode & GM_MULTI ? Netgame.HomingUpdateRate : 25);
-	set_constant_homing_speed(Game_mode & GM_MULTI ? Netgame.ConstantHomingSpeed : 0);
 
 	//	Say player can use FLASH cheat to mark path to exit.
 	Last_level_path_created = -1;

--- a/d1/main/laser.c
+++ b/d1/main/laser.c
@@ -50,8 +50,6 @@ COPYRIGHT 1993-1998 PARALLAX SOFTWARE CORPORATION.  ALL RIGHTS RESERVED.
 
 #define NEWHOMER
 
-int Constant_homing_speed = 0;
-
 int Network_laser_track = -1;
 
 int find_homing_object_complete(vms_vector *curpos, object *tracker, int track_obj_type1, int track_obj_type2);
@@ -1003,7 +1001,7 @@ void Laser_do_weapon_sequence(object *obj, int doHomerFrame, fix idealHomerFrame
 
 				vm_vec_normalize_quick(&vector_to_object);
 				temp_vec = obj->mtype.phys_info.velocity;
-				speed = Constant_homing_speed ? vm_vec_normalize(&temp_vec) : vm_vec_normalize_quick(&temp_vec);
+				speed = vm_vec_normalize_quick(&temp_vec);
 				max_speed = Weapon_info[obj->id].speed[Difficulty_level];
 				if (speed+F1_0 < max_speed) {
 					speed += fixmul(max_speed, idealHomerFrameTime/2);  // CED 
@@ -1019,7 +1017,7 @@ void Laser_do_weapon_sequence(object *obj, int doHomerFrame, fix idealHomerFrame
 				//	The boss' smart children track better...
 				if (Weapon_info[obj->id].render_type != WEAPON_RENDER_POLYMODEL)
 					vm_vec_add2(&temp_vec, &vector_to_object);
-				Constant_homing_speed ? vm_vec_normalize(&temp_vec) : vm_vec_normalize_quick(&temp_vec);
+				vm_vec_normalize_quick(&temp_vec);
 				vm_vec_scale(&temp_vec, speed);
 				obj->mtype.phys_info.velocity = temp_vec;
 
@@ -1627,9 +1625,5 @@ void net_missile_firing(int player, int gun, int flags, vms_vector shot_orientat
 
 }
 #endif
-
-void set_constant_homing_speed(int value) {
-	Constant_homing_speed = value;
-}
 
 

--- a/d1/main/laser.h
+++ b/d1/main/laser.h
@@ -122,8 +122,6 @@ static inline int is_any_proximity_mine(enum weapon_type_t id)
 	return id == PROXIMITY_ID;
 }
 
-extern void set_constant_homing_speed(int value);
-
 #endif
 
  

--- a/d1/main/multi.c
+++ b/d1/main/multi.c
@@ -5291,6 +5291,8 @@ multi_process_data(const ubyte *buf, int len)
 			multi_do_repair(buf); break;
 		case MULTI_SHIP_STATUS:
 			multi_do_ship_status(buf); break;
+		case MULTI_CREATE_EXPLOSION2:
+			multi_do_create_explosion2(buf); break;
 		default:
 			Int3();
 	}
@@ -5608,4 +5610,65 @@ void multi_object_rw_to_object(object_rw *obj_rw, object *obj)
 			break;
 			
 	}
+}
+
+void
+multi_send_create_explosion2(int segnum, vms_vector *pos, fix size, int type)
+{
+	if(is_observer()) { return; }
+
+	// Create an explosion on a remote machine
+
+#ifdef WORDS_BIGENDIAN
+	vms_vector swapped_vec;
+#endif
+	int count = 0;
+
+	multibuf[count] = MULTI_CREATE_EXPLOSION2; count += 1;
+	multibuf[count] = Player_num;              count += 1;
+	PUT_INTEL_SHORT(multibuf+count, segnum );  count += 2;
+#ifndef WORDS_BIGENDIAN
+	memcpy(multibuf+count, pos, sizeof(vms_vector));  count += sizeof(vms_vector);
+#else
+	swapped_vec.x = (fix)INTEL_INT( (int)pos->x );
+	swapped_vec.y = (fix)INTEL_INT( (int)pos->y );
+	swapped_vec.z = (fix)INTEL_INT( (int)pos->z );
+	memcpy(multibuf+count, &swapped_vec, 12); count += 12;
+#endif
+	PUT_INTEL_INT(multibuf+count, size );     count += 4;
+	PUT_INTEL_INT(multibuf+count, type );     count += 4;
+
+	multi_send_data(multibuf, count, 2);
+}
+
+void
+multi_do_create_explosion2(const ubyte *buf)
+{
+	short segnum;
+	int pnum;
+	int count = 1;
+	vms_vector new_pos;
+	fix size;
+	int type;
+
+	pnum = buf[count++];
+	segnum = GET_INTEL_SHORT(buf + count); count += 2;
+
+	if ((segnum < 0) || (segnum > Highest_segment_index)) {
+		Int3();
+		return;
+	}
+
+	new_pos = *(vms_vector *)(buf+count); count+=sizeof(vms_vector);
+
+#ifdef WORDS_BIGENDIAN
+	new_pos.x = (fix)SWAPINT((int)new_pos.x);
+	new_pos.y = (fix)SWAPINT((int)new_pos.y);
+	new_pos.z = (fix)SWAPINT((int)new_pos.z);
+#endif
+
+	size = GET_INTEL_INT(buf + count); count += 4;
+	type = GET_INTEL_INT(buf + count); count += 4;
+
+	object_create_explosion(segnum, &new_pos, size, type);
 }

--- a/d1/main/multi.h
+++ b/d1/main/multi.h
@@ -64,7 +64,7 @@ extern int multi_protocol; // set and determinate used protocol
 #define MULTI_PROTO_UDP 1 // UDP protocol
 
 // What version of the multiplayer protocol is this? Increment each time something drastic changes in Multiplayer without the version number changes. Can be reset to 0 each time the version of the game changes
-#define MULTI_PROTO_VERSION 30003 // Redux 0.5
+#define MULTI_PROTO_VERSION 29003 // Redux 1.0 remspark
 
 // PROTOCOL VARIABLES AND DEFINES - END
 
@@ -124,6 +124,7 @@ extern int multi_protocol; // set and determinate used protocol
 	VALUE(MULTI_DAMAGE               , 14)  \
 	VALUE(MULTI_REPAIR               , 11)  \
 	VALUE(MULTI_SHIP_STATUS          , 29)  \
+	VALUE(MULTI_CREATE_EXPLOSION2    , 24)  \
 	AFTER
 for_each_multiplayer_command(enum {, define_multiplayer_command, });
 
@@ -257,6 +258,8 @@ void multi_do_repair( const ubyte *buf );
 void multi_send_ship_status();
 void multi_do_ship_status( const ubyte *buf );
 
+void multi_send_create_explosion2(int segnum, vms_vector *pos, fix size, int type);
+void multi_do_create_explosion2( const ubyte *buf );
 
 void multi_send_bounty( void );
 void multi_endlevel_score(void);

--- a/d1/main/multi.h
+++ b/d1/main/multi.h
@@ -64,7 +64,7 @@ extern int multi_protocol; // set and determinate used protocol
 #define MULTI_PROTO_UDP 1 // UDP protocol
 
 // What version of the multiplayer protocol is this? Increment each time something drastic changes in Multiplayer without the version number changes. Can be reset to 0 each time the version of the game changes
-#define MULTI_PROTO_VERSION 29003 // Redux 1.0 remspark
+#define MULTI_PROTO_VERSION 30005 // Redux 1.1
 
 // PROTOCOL VARIABLES AND DEFINES - END
 
@@ -511,7 +511,7 @@ typedef struct netgame_info
 	ubyte						LowVulcan;
 	ubyte						AllowPreferredColors;
 	ubyte						HomingUpdateRate;
-	ubyte						ConstantHomingSpeed;
+	ubyte						RemoteHitSpark;
 	ubyte						AllowCustomModelsTextures;
 	ubyte						ReducedFlash;
 	ubyte						GaussAmmoStyle;

--- a/d1/main/net_udp.c
+++ b/d1/main/net_udp.c
@@ -3039,7 +3039,7 @@ void net_udp_send_game_info(struct _sockaddr sender_addr, ubyte info_upid, ubyte
 		buf[len] = Netgame.obs_min; len++;
 		buf[len] = Netgame.host_is_obs; len++;
 		buf[len] = Netgame.HomingUpdateRate; len++;
-		buf[len] = Netgame.ConstantHomingSpeed; len++;
+		buf[len] = Netgame.RemoteHitSpark; len++;
 		buf[len] = Netgame.AllowCustomModelsTextures; len++;
 		buf[len] = Netgame.ReducedFlash; len++;
 		buf[len] = Netgame.GaussAmmoStyle; len++;
@@ -3271,7 +3271,7 @@ int net_udp_process_game_info(ubyte *data, int data_len, struct _sockaddr game_a
 		Netgame.obs_min = data[len]; len++;
 		Netgame.host_is_obs = data[len]; len++;
 		Netgame.HomingUpdateRate = data[len]; len++;
-		Netgame.ConstantHomingSpeed = data[len]; len++;
+		Netgame.RemoteHitSpark = data[len]; len++;
 		Netgame.AllowCustomModelsTextures = data[len]; len++;
 		Netgame.ReducedFlash = data[len]; len++;
 		Netgame.GaussAmmoStyle = data[len]; len++;
@@ -3783,7 +3783,7 @@ static int opt_spawn_no_invul, opt_spawn_short_invul, opt_spawn_long_invul, opt_
 static int opt_allowprefcolor; 
 static int opt_low_vulcan;
 static int opt_homing_update_rate;
-static int opt_constant_homing_speed;
+static int opt_remote_hit_spark;
 static int opt_allow_custom_models_textures;
 static int opt_reduced_flash;
 static int opt_gauss_duplicating, opt_gauss_depleting, opt_gauss_steady_recharge, opt_gauss_steady_respawn;
@@ -3953,8 +3953,8 @@ void net_udp_more_game_options ()
 	sprintf( HomingUpdateRateText, "Homing Update Rate: %d", Netgame.HomingUpdateRate);
 	m[opt].type = NM_TYPE_SLIDER; m[opt].value=max(0, Netgame.HomingUpdateRate - 20); m[opt].text= HomingUpdateRateText; m[opt].min_value=0; m[opt].max_value=10; opt++;
 
-	opt_constant_homing_speed=opt;
-	m[opt].type = NM_TYPE_CHECK; m[opt].text = "DXX-Retro Homing Speed"; m[opt].value = Netgame.ConstantHomingSpeed; opt++;
+	opt_remote_hit_spark=opt;
+	m[opt].type = NM_TYPE_CHECK; m[opt].text = "Remote Hit Spark"; m[opt].value = Netgame.RemoteHitSpark; opt++;
 
 	opt_allow_custom_models_textures=opt;
 	m[opt].type = NM_TYPE_CHECK; m[opt].text = "Allow custom models and textures"; m[opt].value = Netgame.AllowCustomModelsTextures; opt++;
@@ -4017,7 +4017,7 @@ menu:
 	Netgame.LowVulcan = m[opt_low_vulcan].value;
 	Netgame.AllowPreferredColors = m[opt_allowprefcolor].value;
 	Netgame.HomingUpdateRate = m[opt_homing_update_rate].value + 20;
-	Netgame.ConstantHomingSpeed = m[opt_constant_homing_speed].value;
+	Netgame.RemoteHitSpark = m[opt_remote_hit_spark].value;
 	Netgame.AllowCustomModelsTextures = m[opt_allow_custom_models_textures].value;
 	Netgame.ReducedFlash = m[opt_reduced_flash].value;
 
@@ -4334,7 +4334,7 @@ void netgame_set_defaults(void)
 	Netgame.LowVulcan = 0;
 	Netgame.AllowPreferredColors = 1; 
 	Netgame.HomingUpdateRate = 25;
-	Netgame.ConstantHomingSpeed = 0;
+	Netgame.RemoteHitSpark = 0;
 	Netgame.AllowCustomModelsTextures = 0;
 	Netgame.ReducedFlash = 0;
 	Netgame.GaussAmmoStyle = GAUSS_STYLE_DEPLETING;
@@ -7522,13 +7522,13 @@ static int show_game_rules_handler(window *wind, d_event *event, netgame_info *n
 			y = 85;
 
 			gr_set_fontcolor(label_color,-1);
-			gr_printf( FSPACX( 25),FSPACY(y+ 0), "DXX-Retro Homing:");
+			gr_printf( FSPACX( 25),FSPACY(y+ 0), "Remote Hit Spark:");
 			gr_printf( FSPACX( 25),FSPACY(y+ 6), "Custom Mods:");
 			gr_printf( FSPACX(155),FSPACY(y+ 0), "Reduced Flash:");
 			gr_printf( FSPACX(155),FSPACY(y+ 6), "Vulcan Ammo Style:");
 
 			gr_set_fontcolor(value_color,-1);
-			gr_printf( FSPACX(115),FSPACY(y+ 0), netgame->ConstantHomingSpeed?"ON":"OFF");
+			gr_printf( FSPACX(115),FSPACY(y+ 0), netgame->RemoteHitSpark?"ON":"OFF");
 			gr_printf( FSPACX(115),FSPACY(y+ 6), netgame->AllowCustomModelsTextures?"ON":"OFF");
 			gr_printf( FSPACX(275),FSPACY(y+ 0), netgame->ReducedFlash?"ON":"OFF");
 			gr_printf( FSPACX(275),FSPACY(y+ 6), ammo_style[netgame->GaussAmmoStyle]);

--- a/d1/main/playsave.c
+++ b/d1/main/playsave.c
@@ -1456,8 +1456,8 @@ int read_netgame_settings_file(const char *filename, netgame_info *ng, int no_na
 				ng->obs_min = strtol(value, NULL, 10);
 			else if (!strcmp(token, "HomingUpdateRate"))
 				ng->HomingUpdateRate = strtol(value, NULL, 10);
-			else if (!strcmp(token, "ConstantHomingSpeed"))
-				ng->ConstantHomingSpeed = strtol(value, NULL, 10);
+			else if (!strcmp(token, "RemoteHitSpark"))
+				ng->RemoteHitSpark = strtol(value, NULL, 10);
 			else if (!strcmp(token, "AllowCustomModelsTextures"))
 				ng->AllowCustomModelsTextures = strtol(value, NULL, 10);
 			else if (!strcmp(token, "ReducedFlash"))
@@ -1528,7 +1528,7 @@ int write_netgame_settings_file(const char *filename, netgame_info *ng, int no_n
 	PHYSFSX_printf(file, "obs_delay=%i\n", ng->obs_delay);
 	PHYSFSX_printf(file, "obs_min=%i\n", ng->obs_min);
 	PHYSFSX_printf(file, "HomingUpdateRate=%i\n", ng->HomingUpdateRate);
-	PHYSFSX_printf(file, "ConstantHomingSpeed=%i\n", ng->ConstantHomingSpeed);
+	PHYSFSX_printf(file, "RemoteHitSpark=%i\n", ng->RemoteHitSpark);
 	PHYSFSX_printf(file, "AllowCustomModelsTextures=%i\n", ng->AllowCustomModelsTextures);
 	PHYSFSX_printf(file, "ReducedFlash=%i\n", ng->ReducedFlash);
 #ifdef USE_TRACKER

--- a/d2/main/collide.c
+++ b/d2/main/collide.c
@@ -2378,7 +2378,11 @@ void collide_player_and_weapon( object * playerobj, object * weapon, vms_vector 
 		}
 	}
 
-	object_create_explosion( playerobj->segnum, collision_point, i2f(10)/2, VCLIP_PLAYER_HIT );
+	if ((Game_mode & GM_MULTI) && playerobj->id == Player_num)
+		multi_send_create_explosion2(playerobj->segnum, collision_point, i2f(10)/2, VCLIP_PLAYER_HIT);
+	if (playerobj->id == Player_num)
+		object_create_explosion( playerobj->segnum, collision_point, i2f(10)/2, VCLIP_PLAYER_HIT );
+
 	if ( Weapon_info[weapon->id].damage_radius ) {
 		vms_vector player2weapon;
 		vm_vec_sub(&player2weapon, collision_point, &playerobj->pos);

--- a/d2/main/collide.c
+++ b/d2/main/collide.c
@@ -2378,9 +2378,12 @@ void collide_player_and_weapon( object * playerobj, object * weapon, vms_vector 
 		}
 	}
 
-	if ((Game_mode & GM_MULTI) && playerobj->id == Player_num)
+	// Send to other players that the local player got hit
+	if ((Game_mode & GM_MULTI) && Netgame.RemoteHitSpark && playerobj->id == Player_num)
 		multi_send_create_explosion2(playerobj->segnum, collision_point, i2f(10)/2, VCLIP_PLAYER_HIT);
-	if (playerobj->id == Player_num)
+
+	// Show local hit if it won't be received from player
+	if (!(Game_mode & GM_MULTI) || !Netgame.RemoteHitSpark || playerobj->id == Player_num)
 		object_create_explosion( playerobj->segnum, collision_point, i2f(10)/2, VCLIP_PLAYER_HIT );
 
 	if ( Weapon_info[weapon->id].damage_radius ) {

--- a/d2/main/gamerend.c
+++ b/d2/main/gamerend.c
@@ -236,7 +236,7 @@ void show_netplayerinfo()
 	char hom_string[16];
 	snprintf(hom_string, sizeof(hom_string), "Hom %d", Netgame.HomingUpdateRate);
 	draw_flag(hom_string, Netgame.HomingUpdateRate != 25,                          base_flags_left + word_spacing*0, y);
-	draw_flag("RetroHom", Netgame.ConstantHomingSpeed,                             base_flags_left + word_spacing*1, y);
+	draw_flag("RemSpark", Netgame.RemoteHitSpark,                                  base_flags_left + word_spacing*1, y);
 	draw_flag("CustMod",  Netgame.AllowCustomModelsTextures,                       base_flags_left + word_spacing*2, y);
 
 	set_font_newline();

--- a/d2/main/gameseq.c
+++ b/d2/main/gameseq.c
@@ -1650,7 +1650,6 @@ void StartNewLevelSub(int level_num, int page_in_textures, int secret_flag)
 	reset_respawnable_bots();
 
 	set_homing_update_rate(Game_mode & GM_MULTI ? Netgame.HomingUpdateRate : 25);
-	set_constant_homing_speed(Game_mode & GM_MULTI ? Netgame.ConstantHomingSpeed : 0);
 
 	//	Say player can use FLASH cheat to mark path to exit.
 	Last_level_path_created = -1;

--- a/d2/main/laser.c
+++ b/d2/main/laser.c
@@ -57,8 +57,6 @@ COPYRIGHT 1993-1999 PARALLAX SOFTWARE CORPORATION.  ALL RIGHTS RESERVED.
 object *Guided_missile[MAX_PLAYERS]={NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL};
 int Guided_missile_sig[MAX_PLAYERS]={-1,-1,-1,-1,-1,-1,-1,-1};
 
-int Constant_homing_speed = 0;
-
 int Network_laser_track = -1;
 
 int find_homing_object_complete(vms_vector *curpos, object *tracker, int track_obj_type1, int track_obj_type2);
@@ -1532,7 +1530,7 @@ void Laser_do_weapon_sequence(object *obj, int doHomerFrame, fix idealHomerFrame
 
 				vm_vec_normalize_quick(&vector_to_object);
 				temp_vec = obj->mtype.phys_info.velocity;
-				speed = Constant_homing_speed ? vm_vec_normalize(&temp_vec) : vm_vec_normalize_quick(&temp_vec);
+				speed = vm_vec_normalize_quick(&temp_vec);
 				max_speed = Weapon_info[obj->id].speed[Difficulty_level];
 				if( (Game_mode & GM_MULTI) && Netgame.OriginalD1Weapons) {
 					if(obj->id == 12) { // Spread
@@ -1553,7 +1551,7 @@ void Laser_do_weapon_sequence(object *obj, int doHomerFrame, fix idealHomerFrame
 				//	The boss' smart children track better...
 				if (Weapon_info[obj->id].render_type != WEAPON_RENDER_POLYMODEL)
 					vm_vec_add2(&temp_vec, &vector_to_object);
-				Constant_homing_speed ? vm_vec_normalize(&temp_vec) : vm_vec_normalize_quick(&temp_vec);
+				vm_vec_normalize_quick(&temp_vec);
 				vm_vec_scale(&temp_vec, speed);
 				obj->mtype.phys_info.velocity = temp_vec;
 
@@ -2227,8 +2225,4 @@ void do_missile_firing(int drop_bomb)
 		if (Game_mode & GM_MULTI)
 			multi_send_ship_status();
 	}
-}
-
-void set_constant_homing_speed(int value) {
-	Constant_homing_speed = value;
 }

--- a/d2/main/laser.h
+++ b/d2/main/laser.h
@@ -171,6 +171,4 @@ static inline int is_proximity_bomb_or_smart_mine_or_placed_mine(enum weapon_typ
 	return id == PROXIMITY_ID;
 }
 
-extern void set_constant_homing_speed(int value);
-
 #endif /* _LASER_H */

--- a/d2/main/multi.c
+++ b/d2/main/multi.c
@@ -7072,6 +7072,8 @@ multi_process_data(const ubyte *buf, int len)
 			multi_do_repair(buf); break;
 		case MULTI_SHIP_STATUS:
 			multi_do_ship_status(buf); break;
+		case MULTI_CREATE_EXPLOSION2:
+			multi_do_create_explosion2(buf); break;
 		default:
 			Int3();
 	}
@@ -7415,4 +7417,65 @@ int multi_change_weapon_info(void)
 		changed = 1;
 	}
 	return changed;
+}
+
+void
+multi_send_create_explosion2(int segnum, vms_vector *pos, fix size, int type)
+{
+	if(is_observer()) { return; }
+
+	// Create an explosion on a remote machine
+
+#ifdef WORDS_BIGENDIAN
+	vms_vector swapped_vec;
+#endif
+	int count = 0;
+
+	multibuf[count] = MULTI_CREATE_EXPLOSION2; count += 1;
+	multibuf[count] = Player_num;              count += 1;
+	PUT_INTEL_SHORT(multibuf+count, segnum );  count += 2;
+#ifndef WORDS_BIGENDIAN
+	memcpy(multibuf+count, pos, sizeof(vms_vector));  count += sizeof(vms_vector);
+#else
+	swapped_vec.x = (fix)INTEL_INT( (int)pos->x );
+	swapped_vec.y = (fix)INTEL_INT( (int)pos->y );
+	swapped_vec.z = (fix)INTEL_INT( (int)pos->z );
+	memcpy(multibuf+count, &swapped_vec, 12); count += 12;
+#endif
+	PUT_INTEL_INT(multibuf+count, size );     count += 4;
+	PUT_INTEL_INT(multibuf+count, type );     count += 4;
+
+	multi_send_data(multibuf, count, 2);
+}
+
+void
+multi_do_create_explosion2(const ubyte *buf)
+{
+	short segnum;
+	int pnum;
+	int count = 1;
+	vms_vector new_pos;
+	fix size;
+	int type;
+
+	pnum = buf[count++];
+	segnum = GET_INTEL_SHORT(buf + count); count += 2;
+
+	if ((segnum < 0) || (segnum > Highest_segment_index)) {
+		Int3();
+		return;
+	}
+
+	new_pos = *(vms_vector *)(buf+count); count+=sizeof(vms_vector);
+
+#ifdef WORDS_BIGENDIAN
+	new_pos.x = (fix)SWAPINT((int)new_pos.x);
+	new_pos.y = (fix)SWAPINT((int)new_pos.y);
+	new_pos.z = (fix)SWAPINT((int)new_pos.z);
+#endif
+
+	size = GET_INTEL_INT(buf + count); count += 4;
+	type = GET_INTEL_INT(buf + count); count += 4;
+
+	object_create_explosion(segnum, &new_pos, size, type);
 }

--- a/d2/main/multi.h
+++ b/d2/main/multi.h
@@ -145,6 +145,7 @@ extern int multi_protocol; // set and determinate used protocol
 	VALUE(MULTI_DAMAGE               , 14)  \
 	VALUE(MULTI_REPAIR               , 11)  \
 	VALUE(MULTI_SHIP_STATUS          , 43)  \
+	VALUE(MULTI_CREATE_EXPLOSION2    , 24)  \
 	AFTER
 for_each_multiplayer_command(enum {, define_multiplayer_command, });
 
@@ -298,6 +299,9 @@ void multi_send_repair(fix repair, fix shields, ubyte sourcetype);
 void multi_do_repair(const ubyte *buf);
 void multi_send_ship_status();
 void multi_do_ship_status( const ubyte *buf );
+void multi_send_create_explosion2(int segnum, vms_vector *pos, fix size, int type);
+void multi_do_create_explosion2( const ubyte *buf );
+
 void multi_send_bounty( void );
 
 void multi_endlevel_score(void);

--- a/d2/main/multi.h
+++ b/d2/main/multi.h
@@ -60,7 +60,7 @@ extern int multi_protocol; // set and determinate used protocol
 #define MULTI_PROTO_UDP 1 // UDP protocol
 
 // What version of the multiplayer protocol is this? Increment each time something drastic changes in Multiplayer without the version number changes. Can be reset to 0 each time the version of the game changes
-#define MULTI_PROTO_VERSION 30004 // Redux 1.1
+#define MULTI_PROTO_VERSION 30005 // Redux 1.1
 
 // PROTOCOL VARIABLES AND DEFINES - END
 
@@ -575,7 +575,7 @@ typedef struct netgame_info
 	ubyte						Tracker;
 #endif
 	ubyte						HomingUpdateRate;
-	ubyte						ConstantHomingSpeed;
+	ubyte						RemoteHitSpark;
 	ubyte						AllowCustomModelsTextures;
 	ubyte						ReducedFlash;
 	ubyte						DisableGaussSplash;

--- a/d2/main/net_udp.c
+++ b/d2/main/net_udp.c
@@ -3069,7 +3069,7 @@ void net_udp_send_game_info(struct _sockaddr sender_addr, ubyte info_upid, ubyte
 		buf[len] = Netgame.obs_min; len++;
 		buf[len] = Netgame.host_is_obs; len++;
 		buf[len] = Netgame.HomingUpdateRate; len++;
-		buf[len] = Netgame.ConstantHomingSpeed; len++;
+		buf[len] = Netgame.RemoteHitSpark; len++;
 		buf[len] = Netgame.AllowCustomModelsTextures; len++;
 		buf[len] = Netgame.ReducedFlash; len++;
 		buf[len] = Netgame.DisableGaussSplash; len++;
@@ -3320,7 +3320,7 @@ int net_udp_process_game_info(ubyte *data, int data_len, struct _sockaddr game_a
 		Netgame.obs_min = data[len]; len++;
 		Netgame.host_is_obs = data[len]; len++;
 		Netgame.HomingUpdateRate = data[len]; len++;
-		Netgame.ConstantHomingSpeed = data[len]; len++;
+		Netgame.RemoteHitSpark = data[len]; len++;
 		Netgame.AllowCustomModelsTextures = data[len]; len++;
 		Netgame.ReducedFlash = data[len]; len++;
 		Netgame.DisableGaussSplash = data[len]; len++;
@@ -3832,7 +3832,7 @@ static int opt_allowprefcolor, opt_ow;
 static int opt_low_vulcan;
 static int opt_gauss_duplicating, opt_gauss_depleting, opt_gauss_steady_recharge, opt_gauss_steady_respawn; 
 static int opt_homing_update_rate;
-static int opt_constant_homing_speed;
+static int opt_remote_hit_spark;
 static int opt_allow_custom_models_textures;
 static int opt_reduced_flash;
 static int opt_disable_gauss_splash;
@@ -4017,8 +4017,8 @@ void net_udp_more_game_options ()
 	sprintf( HomingUpdateRateText, "Homing Update Rate: %d", Netgame.HomingUpdateRate);
 	m[opt].type = NM_TYPE_SLIDER; m[opt].value=max(0, Netgame.HomingUpdateRate - 20); m[opt].text= HomingUpdateRateText; m[opt].min_value=0; m[opt].max_value=10; opt++;
 
-	opt_constant_homing_speed=opt;
-	m[opt].type = NM_TYPE_CHECK; m[opt].text = "DXX-Retro Homing Speed"; m[opt].value = Netgame.ConstantHomingSpeed; opt++;
+	opt_remote_hit_spark=opt;
+	m[opt].type = NM_TYPE_CHECK; m[opt].text = "Remote Hit Spark"; m[opt].value = Netgame.RemoteHitSpark; opt++;
 
 	opt_allow_custom_models_textures=opt;
 	m[opt].type = NM_TYPE_CHECK; m[opt].text = "Allow custom models and textures"; m[opt].value = Netgame.AllowCustomModelsTextures; opt++;
@@ -4089,7 +4089,7 @@ menu:
 	Netgame.AllowPreferredColors = m[opt_allowprefcolor].value;
 	Netgame.OriginalD1Weapons = m[opt_ow].value;
 	Netgame.HomingUpdateRate = m[opt_homing_update_rate].value + 20;
-	Netgame.ConstantHomingSpeed = m[opt_constant_homing_speed].value;
+	Netgame.RemoteHitSpark = m[opt_remote_hit_spark].value;
 	Netgame.AllowCustomModelsTextures = m[opt_allow_custom_models_textures].value;
 	Netgame.ReducedFlash = m[opt_reduced_flash].value;
 	Netgame.DisableGaussSplash = m[opt_disable_gauss_splash].value;
@@ -4404,7 +4404,7 @@ void netgame_set_defaults()
 	Netgame.AllowPreferredColors = 0;
 	Netgame.OriginalD1Weapons = 0;
 	Netgame.HomingUpdateRate = 25;
-	Netgame.ConstantHomingSpeed = 0;
+	Netgame.RemoteHitSpark = 0;
 	Netgame.AllowCustomModelsTextures = 0;
 	Netgame.ReducedFlash = 0;
 	Netgame.DisableGaussSplash = 0;
@@ -7664,14 +7664,14 @@ static int show_game_rules_handler(window *wind, d_event *event, netgame_info *n
 			y = 77;
 
 			gr_set_fontcolor(label_color,-1);
-			gr_printf( FSPACX( 25),FSPACY(y+ 0), "DXX-Retro Homing:");
+			gr_printf( FSPACX( 25),FSPACY(y+ 0), "Remote Hit Spark:");
 			gr_printf( FSPACX( 25),FSPACY(y+ 6), "Custom Mods:");
 			gr_printf( FSPACX( 25),FSPACY(y+12), "No Gauss Splash:");
 			gr_printf( FSPACX(155),FSPACY(y+ 0), "Reduced Flash:");
 			gr_printf( FSPACX(155),FSPACY(y+ 6), "Gauss Ammo Style:");
 
 			gr_set_fontcolor(value_color,-1);
-			gr_printf( FSPACX(115),FSPACY(y+ 0), netgame->ConstantHomingSpeed?"ON":"OFF");
+			gr_printf( FSPACX(115),FSPACY(y+ 0), netgame->RemoteHitSpark?"ON":"OFF");
 			gr_printf( FSPACX(115),FSPACY(y+ 6), netgame->AllowCustomModelsTextures?"ON":"OFF");
 			gr_printf( FSPACX(115),FSPACY(y+12), netgame->DisableGaussSplash?"ON":"OFF");
 			gr_printf( FSPACX(275),FSPACY(y+ 0), netgame->ReducedFlash?"ON":"OFF");

--- a/d2/main/playsave.c
+++ b/d2/main/playsave.c
@@ -1297,8 +1297,8 @@ int read_netgame_settings_file(const char *filename, netgame_info *ng, int no_na
 				ng->obs_min = strtol(value, NULL, 10);
 			else if (!strcmp(token, "HomingUpdateRate"))
 				ng->HomingUpdateRate = strtol(value, NULL, 10);
-			else if (!strcmp(token, "ConstantHomingSpeed"))
-				ng->ConstantHomingSpeed = strtol(value, NULL, 10);
+			else if (!strcmp(token, "RemoteHitSpark"))
+				ng->RemoteHitSpark = strtol(value, NULL, 10);
 			else if (!strcmp(token, "AllowCustomModelsTextures"))
 				ng->AllowCustomModelsTextures = strtol(value, NULL, 10);
 			else if (!strcmp(token, "ReducedFlash"))
@@ -1375,7 +1375,7 @@ int write_netgame_settings_file(const char *filename, netgame_info *ng, int no_n
 	PHYSFSX_printf(file, "obs_delay=%i\n", ng->obs_delay);
 	PHYSFSX_printf(file, "obs_min=%i\n", ng->obs_min);
 	PHYSFSX_printf(file, "HomingUpdateRate=%i\n", ng->HomingUpdateRate);
-	PHYSFSX_printf(file, "ConstantHomingSpeed=%i\n", ng->ConstantHomingSpeed);
+	PHYSFSX_printf(file, "RemoteHitSpark=%i\n", ng->RemoteHitSpark);
 	PHYSFSX_printf(file, "AllowCustomModelsTextures=%i\n", ng->AllowCustomModelsTextures);
 	PHYSFSX_printf(file, "ReducedFlash=%i\n", ng->ReducedFlash);
 	PHYSFSX_printf(file, "DisableGaussSplash=%i\n", ng->DisableGaussSplash);


### PR DESCRIPTION
To ease implementation this patch does two things:
- Remove the 'DXX-Retro Homing Speed' option. It helped the transition to the quick-normalize algorithm but is no longer used.
- Add a Remote Hit Spark option. When enabled, the hit spark is shown only when the weapon actually hit a player on their end (as with the clang sound).