### PR TITLE
Write dump files on crash on Windows

### DIFF
--- a/.github/workflows/package-windows.yml
+++ b/.github/workflows/package-windows.yml
@@ -27,8 +27,6 @@ jobs:
           install: >-
             git
             zip
-            base-devel 
-            mingw-w64-x86_64-toolchain
             mingw-w64-x86_64-pkgconf
             mingw-w64-x86_64-cmake
             mingw-w64-x86_64-physfs
@@ -37,18 +35,20 @@ jobs:
             mingw-w64-x86_64-libpng
             mingw-w64-x86_64-glew
             mingw-w64-x86_64-ntldd-git
+            mingw-w64-x86_64-clang
+            mingw-w64-x86_64-lld
 
       - name: Clone repository
         uses: actions/checkout@v3
 
       - name: Configure D1
-        run: cmake -S d1 -B buildd1 -DCMAKE_BUILD_TYPE=RelWithDebInfo
+        run: CC=clang CXX=clang++ cmake -S d1 -B buildd1 -DCMAKE_BUILD_TYPE=RelWithDebInfo
 
       - name: Build D1
         run: cmake --build buildd1 
 
       - name: Configure D2
-        run: cmake -S d2 -B buildd2 -DCMAKE_BUILD_TYPE=RelWithDebInfo
+        run: CC=clang CXX=clang++ cmake -S d2 -B buildd2 -DCMAKE_BUILD_TYPE=RelWithDebInfo
 
       - name: Build D2
         run: cmake --build buildd2

--- a/.github/workflows/package-windows32.yml
+++ b/.github/workflows/package-windows32.yml
@@ -30,8 +30,6 @@ jobs:
           install: >-
             git
             zip
-            base-devel
-            mingw-w64-i686-toolchain
             mingw-w64-i686-pkgconf
             mingw-w64-i686-cmake
             mingw-w64-i686-physfs
@@ -40,18 +38,20 @@ jobs:
             mingw-w64-i686-libpng
             mingw-w64-i686-glew
             mingw-w64-i686-ntldd-git
+            mingw-w64-i686-clang
+            mingw-w64-i686-lld
 
       - name: Clone repository
         uses: actions/checkout@v3
 
       - name: Configure D1
-        run: cmake -S d1 -B buildd1 -DCMAKE_BUILD_TYPE=RelWithDebInfo
+        run: CC=clang CXX=clang++ cmake -S d1 -B buildd1 -DCMAKE_BUILD_TYPE=RelWithDebInfo
 
       - name: Build D1
         run: cmake --build buildd1
 
       - name: Configure D2
-        run: cmake -S d2 -B buildd2 -DCMAKE_BUILD_TYPE=RelWithDebInfo
+        run: CC=clang CXX=clang++ cmake -S d2 -B buildd2 -DCMAKE_BUILD_TYPE=RelWithDebInfo
 
       - name: Build D2
         run: cmake --build buildd2

--- a/d1/CMakeLists.txt
+++ b/d1/CMakeLists.txt
@@ -75,6 +75,10 @@ if(WIN32)
     # memory corruption when Windows headers are compiled with non-default packing (set in
     # include/pstypes.h). This may actually be a problem that warrants fixing; keep an eye on that.
     add_definitions(/DWINDOWS /DHAVE_STRUCT_TIMEVAL /DWINDOWS_IGNORE_PACKING_MISMATCH)
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+        add_compile_options(-gcodeview -fms-extensions -fseh-exceptions)
+        add_link_options(-fuse-ld=lld -Wl,--pdb=)
+    endif()
 elseif(APPLE)
     add_definitions(/DHAVE_STRUCT_TIMESPEC /DHAVE_STRUCT_TIMEVAL /D__unix__)
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")

--- a/d1/arch/win32/CMakeLists.txt
+++ b/d1/arch/win32/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_library(arch_win32 STATIC
+    crashdump.c
     messagebox.c
     )
 

--- a/d1/arch/win32/crashdump.c
+++ b/d1/arch/win32/crashdump.c
@@ -1,0 +1,33 @@
+// Contains handlers for automatically generating crash dumps on Windows.
+
+#include <windows.h>
+#include <DbgHelp.h>
+#include "dxxerror.h"
+
+void win32_create_dump(EXCEPTION_POINTERS* exceptionPointers)
+{
+	// Append the current date and time to the dump file name.
+	char dumpFileName[MAX_PATH];
+	SYSTEMTIME stLocalTime;
+	GetLocalTime(&stLocalTime);
+	wsprintf(dumpFileName, "d1x-redux_%04d%02d%02d_%02d%02d%02d.dmp",
+			 stLocalTime.wYear, stLocalTime.wMonth, stLocalTime.wDay,
+			 stLocalTime.wHour, stLocalTime.wMinute, stLocalTime.wSecond);
+
+	HANDLE hDumpFile = CreateFile(dumpFileName, GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
+	if (hDumpFile != INVALID_HANDLE_VALUE) {
+		MINIDUMP_EXCEPTION_INFORMATION exceptionInfo;
+		exceptionInfo.ThreadId = GetCurrentThreadId();
+		exceptionInfo.ExceptionPointers = exceptionPointers;
+		exceptionInfo.ClientPointers = FALSE;
+
+		MiniDumpWriteDump(GetCurrentProcess(), GetCurrentProcessId(), hDumpFile, MiniDumpNormal, &exceptionInfo, NULL, NULL);
+		CloseHandle(hDumpFile);
+	}
+}
+
+LONG WINAPI win32_exception_handler(EXCEPTION_POINTERS* exceptionPointers)
+{
+	win32_create_dump(exceptionPointers);
+	return EXCEPTION_CONTINUE_SEARCH;
+}

--- a/d1/main/CMakeLists.txt
+++ b/d1/main/CMakeLists.txt
@@ -99,7 +99,7 @@ if(UDP)
 endif()
 
 if(WIN32)
-    target_link_libraries(d1x-redux PUBLIC glu32 winmm ws2_32)
+    target_link_libraries(d1x-redux PUBLIC glu32 winmm ws2_32 dbghelp)
     target_link_libraries(d1x-redux PRIVATE arch_win32)
     target_sources(d1x-redux PRIVATE
         ${CMAKE_SOURCE_DIR}/arch/win32/d1x-rebirth.ico

--- a/d2/CMakeLists.txt
+++ b/d2/CMakeLists.txt
@@ -79,6 +79,10 @@ if(WIN32)
     # memory corruption when Windows headers are compiled with non-default packing (set in
     # include/pstypes.h). This may actually be a problem that warrants fixing; keep an eye on that.
     add_definitions(/DWINDOWS /DHAVE_STRUCT_TIMEVAL /DWINDOWS_IGNORE_PACKING_MISMATCH)
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+        add_compile_options(-gcodeview -fms-extensions -fseh-exceptions)
+        add_link_options(-fuse-ld=lld -Wl,--pdb=)
+    endif()
 elseif(APPLE)
     add_definitions(/DHAVE_STRUCT_TIMESPEC /DHAVE_STRUCT_TIMEVAL /D__unix__)
 elseif(__LINUX__)

--- a/d2/arch/win32/CMakeLists.txt
+++ b/d2/arch/win32/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_library(arch_win32 STATIC
+    crashdump.c
     messagebox.c
     )
 

--- a/d2/arch/win32/crashdump.c
+++ b/d2/arch/win32/crashdump.c
@@ -1,0 +1,33 @@
+// Contains handlers for automatically generating crash dumps on Windows.
+
+#include <windows.h>
+#include <DbgHelp.h>
+#include "dxxerror.h"
+
+void win32_create_dump(EXCEPTION_POINTERS* exceptionPointers)
+{
+	// Append the current date and time to the dump file name.
+	char dumpFileName[MAX_PATH];
+	SYSTEMTIME stLocalTime;
+	GetLocalTime(&stLocalTime);
+	wsprintf(dumpFileName, "d2x-redux_%04d%02d%02d_%02d%02d%02d.dmp",
+			 stLocalTime.wYear, stLocalTime.wMonth, stLocalTime.wDay,
+			 stLocalTime.wHour, stLocalTime.wMinute, stLocalTime.wSecond);
+
+	HANDLE hDumpFile = CreateFile(dumpFileName, GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
+	if (hDumpFile != INVALID_HANDLE_VALUE) {
+		MINIDUMP_EXCEPTION_INFORMATION exceptionInfo;
+		exceptionInfo.ThreadId = GetCurrentThreadId();
+		exceptionInfo.ExceptionPointers = exceptionPointers;
+		exceptionInfo.ClientPointers = FALSE;
+
+		MiniDumpWriteDump(GetCurrentProcess(), GetCurrentProcessId(), hDumpFile, MiniDumpNormal, &exceptionInfo, NULL, NULL);
+		CloseHandle(hDumpFile);
+	}
+}
+
+LONG WINAPI win32_exception_handler(EXCEPTION_POINTERS* exceptionPointers)
+{
+	win32_create_dump(exceptionPointers);
+	return EXCEPTION_CONTINUE_SEARCH;
+}

--- a/d2/main/CMakeLists.txt
+++ b/d2/main/CMakeLists.txt
@@ -101,7 +101,7 @@ if(UDP)
 endif()
 
 if(WIN32)
-    target_link_libraries(d2x-redux PUBLIC glu32 winmm ws2_32)
+    target_link_libraries(d2x-redux PUBLIC glu32 winmm ws2_32 dbghelp)
     target_link_libraries(d2x-redux PRIVATE arch_win32)
     target_sources(d2x-redux PRIVATE
         ${CMAKE_SOURCE_DIR}/arch/win32/d2x-rebirth.ico

--- a/d2/main/inferno.c
+++ b/d2/main/inferno.c
@@ -289,6 +289,25 @@ int standard_handler(d_event *event)
 	return 0;
 }
 
+// Use SEH for catching exceptions on Windows, this is needed because of the SDL parachute
+// But only on MSVC/64-bit clang (SEH is broken on 32-bit clang https://github.com/llvm/llvm-project/issues/25753)
+#if defined(WIN32) && (!defined(__clang__) || !defined(__i386__))
+int inner_main(int argc, char *argv[]);
+LONG WINAPI win32_exception_handler(EXCEPTION_POINTERS* exceptionPointers);
+
+int main(int argc, char *argv[])
+{
+	__try {
+		return inner_main(argc, argv);
+	} __except (win32_exception_handler(GetExceptionInformation())) {
+		return 1;
+	}
+}
+
+#undef main
+#define main inner_main
+#endif
+
 jmp_buf LeaveEvents;
 #define PROGNAME argv[0]
 


### PR DESCRIPTION
It is necessary to use SEH since SDL also catches exceptions (to restore the video mode on exit).

Also create pdb files when using clang on Windows and use clang in github Windows workflows.

crashdump.c is from PR #120 by SiriusTR.