### PR TITLE
Add Classic No Ammo Autoselect option

### DIFF
--- a/d1/main/menu.c
+++ b/d1/main/menu.c
@@ -2012,7 +2012,7 @@ struct misc_menu_data {
 
 void do_misc_menu()
 {
-	newmenu_item m[35];
+	newmenu_item m[36];
 	int i = 0;
 	struct misc_menu_data misc_menu_data;
 
@@ -2063,65 +2063,66 @@ void do_misc_menu()
 		ADD_CHECK(19, "No Weapon Autoselect when firing",PlayerCfg.NoFireAutoselect);		
 		ADD_CHECK(20, "Autoselect after firing",PlayerCfg.SelectAfterFire);
 		ADD_CHECK(21, "Only Cycle Autoselect Weapons",PlayerCfg.CycleAutoselectOnly);		
-		ADD_CHECK(22, "Ammo Warnings",PlayerCfg.VulcanAmmoWarnings);
-		ADD_CHECK(23, "Shield Warnings",PlayerCfg.ShieldWarnings);
-		ADD_CHECK(24, "No Player Chat Sound",PlayerCfg.NoChatSound);
-
-		m[25].type = NM_TYPE_TEXT;
-		m[25].text = "";
+		ADD_CHECK(22, "Classic No Ammo Autoselect",PlayerCfg.ClassicAutoselectWeapon);
+		ADD_CHECK(23, "Ammo Warnings",PlayerCfg.VulcanAmmoWarnings);
+		ADD_CHECK(24, "Shield Warnings",PlayerCfg.ShieldWarnings);
+		ADD_CHECK(25, "No Player Chat Sound",PlayerCfg.NoChatSound);
 
 		m[26].type = NM_TYPE_TEXT;
-		m[26].text = "My Ship Colors:";
+		m[26].text = "";
+
+		m[27].type = NM_TYPE_TEXT;
+		m[27].text = "My Ship Colors:";
 
 		print_ship_color(misc_menu_data.preferred_color, SDL_arraysize(misc_menu_data.preferred_color),
 			PlayerCfg.ShipColor);
-		m[27].type = NM_TYPE_SLIDER;
-		m[27].value = PlayerCfg.ShipColor;
-		m[27].text = misc_menu_data.preferred_color;
-		m[27].min_value = 0;
-		m[27].max_value = 8;
-
-		print_missile_color(misc_menu_data.missile_color, SDL_arraysize(misc_menu_data.missile_color),
-			PlayerCfg.MissileColor);
 		m[28].type = NM_TYPE_SLIDER;
-		m[28].value = PlayerCfg.MissileColor;
-		m[28].text = misc_menu_data.missile_color;
+		m[28].value = PlayerCfg.ShipColor;
+		m[28].text = misc_menu_data.preferred_color;
 		m[28].min_value = 0;
 		m[28].max_value = 8;
 
-		ADD_CHECK(29, "Show Custom Ship Colors", PlayerCfg.ShowCustomColors);
+		print_missile_color(misc_menu_data.missile_color, SDL_arraysize(misc_menu_data.missile_color),
+			PlayerCfg.MissileColor);
+		m[29].type = NM_TYPE_SLIDER;
+		m[29].value = PlayerCfg.MissileColor;
+		m[29].text = misc_menu_data.missile_color;
+		m[29].min_value = 0;
+		m[29].max_value = 8;
 
-		m[30].type = NM_TYPE_TEXT;
-		m[30].text = "";
+		ADD_CHECK(30, "Show Custom Ship Colors", PlayerCfg.ShowCustomColors);
 
 		m[31].type = NM_TYPE_TEXT;
-		m[31].text = "Team Colors:";
+		m[31].text = "";
+
+		m[32].type = NM_TYPE_TEXT;
+		m[32].text = "Team Colors:";
 
 		print_my_team_color(misc_menu_data.my_team_color, SDL_arraysize(misc_menu_data.my_team_color),
 			PlayerCfg.MyTeamColor);
-		m[32].type = NM_TYPE_SLIDER;
-		m[32].value = PlayerCfg.MyTeamColor;
-		m[32].text = misc_menu_data.my_team_color;
-		m[32].min_value = 0;
-		m[32].max_value = 8;
-
-		print_other_team_color(misc_menu_data.other_team_color, SDL_arraysize(misc_menu_data.other_team_color),
-			PlayerCfg.OtherTeamColor);
 		m[33].type = NM_TYPE_SLIDER;
-		m[33].value = PlayerCfg.OtherTeamColor;
-		m[33].text = misc_menu_data.other_team_color;
+		m[33].value = PlayerCfg.MyTeamColor;
+		m[33].text = misc_menu_data.my_team_color;
 		m[33].min_value = 0;
 		m[33].max_value = 8;
 
+		print_other_team_color(misc_menu_data.other_team_color, SDL_arraysize(misc_menu_data.other_team_color),
+			PlayerCfg.OtherTeamColor);
+		m[34].type = NM_TYPE_SLIDER;
+		m[34].value = PlayerCfg.OtherTeamColor;
+		m[34].text = misc_menu_data.other_team_color;
+		m[34].min_value = 0;
+		m[34].max_value = 8;
+
 		if (PlayerCfg.MyTeamColor == 8 && PlayerCfg.OtherTeamColor == 8) {
 			// If we're not setting explicit team colors, we don't override what the game host picked
-			m[34].type = NM_TYPE_TEXT;
-			m[34].text = "Ignore Per-Game Team Colors (N/A)";
+			m[35].type = NM_TYPE_TEXT;
+			m[35].text = "Ignore Per-Game Team Colors (N/A)";
 		} else {
-			m[34].type = NM_TYPE_CHECK;
-			m[34].text = "Ignore Per-Game Team Colors";
+			m[35].type = NM_TYPE_CHECK;
+			m[35].text = "Ignore Per-Game Team Colors";
 		}
-		m[34].value = PlayerCfg.PreferMyTeamColors;
+		m[35].value = PlayerCfg.PreferMyTeamColors;
 
 		i = newmenu_do1(NULL, "Misc Options", SDL_arraysize(m), m, menu_misc_options_handler, &misc_menu_data, i);
 
@@ -2146,11 +2147,12 @@ void do_misc_menu()
 		PlayerCfg.NoFireAutoselect		= m[19].value;
 		PlayerCfg.SelectAfterFire		= m[20].value;  if(PlayerCfg.SelectAfterFire) { PlayerCfg.NoFireAutoselect = 1; }
 		PlayerCfg.CycleAutoselectOnly		= m[21].value;
-		PlayerCfg.VulcanAmmoWarnings = m[22].value; 
-		PlayerCfg.ShieldWarnings = m[23].value; 
-		PlayerCfg.NoChatSound = m[24].value;
-		PlayerCfg.ShowCustomColors = m[29].value;
-		PlayerCfg.PreferMyTeamColors = (PlayerCfg.MyTeamColor == 8 && PlayerCfg.OtherTeamColor == 8) ? 0 : m[34].value;
+		PlayerCfg.ClassicAutoselectWeapon = m[22].value;
+		PlayerCfg.VulcanAmmoWarnings = m[23].value;
+		PlayerCfg.ShieldWarnings = m[24].value;
+		PlayerCfg.NoChatSound = m[25].value;
+		PlayerCfg.ShowCustomColors = m[30].value;
+		PlayerCfg.PreferMyTeamColors = (PlayerCfg.MyTeamColor == 8 && PlayerCfg.OtherTeamColor == 8) ? 0 : m[35].value;
 
 	} while( i>-1 );
 
@@ -2169,30 +2171,30 @@ int menu_misc_options_handler(newmenu* menu, d_event* event, void* userdata)
 	struct misc_menu_data* menu_data = (struct misc_menu_data*)userdata;
 	
 	if (event->type == EVENT_NEWMENU_CHANGED) {
-		if (citem == 27) {
-			PlayerCfg.ShipColor = menus[27].value;
+		if (citem == 28) {
+			PlayerCfg.ShipColor = menus[citem].value;
 			print_ship_color(menu_data->preferred_color, SDL_arraysize(menu_data->preferred_color),
 				PlayerCfg.ShipColor);
-		} else if (citem == 28) {
-			PlayerCfg.MissileColor = menus[28].value;
+		} else if (citem == 29) {
+			PlayerCfg.MissileColor = menus[citem].value;
 			print_missile_color(menu_data->missile_color, SDL_arraysize(menu_data->missile_color),
 				PlayerCfg.MissileColor);
-		} else if (citem == 32) {
-			PlayerCfg.MyTeamColor = menus[32].value;
+		} else if (citem == 33) {
+			PlayerCfg.MyTeamColor = menus[citem].value;
 			print_my_team_color(menu_data->my_team_color, SDL_arraysize(menu_data->my_team_color),
 				PlayerCfg.MyTeamColor);
-		} else if (citem == 33) {
-			PlayerCfg.OtherTeamColor = menus[33].value;
+		} else if (citem == 34) {
+			PlayerCfg.OtherTeamColor = menus[citem].value;
 			print_other_team_color(menu_data->other_team_color, SDL_arraysize(menu_data->other_team_color),
 				PlayerCfg.OtherTeamColor);
 		}
 
 		if (PlayerCfg.MyTeamColor == 8 && PlayerCfg.OtherTeamColor == 8) {
-			menus[34].type = NM_TYPE_TEXT;
-			menus[34].text = "Ignore Per-Game Team Colors (N/A)";
+			menus[35].type = NM_TYPE_TEXT;
+			menus[35].text = "Ignore Per-Game Team Colors (N/A)";
 		} else {
-			menus[34].type = NM_TYPE_CHECK;
-			menus[34].text = "Ignore Per-Game Team Colors";
+			menus[35].type = NM_TYPE_CHECK;
+			menus[35].text = "Ignore Per-Game Team Colors";
 		}
 	}
 

--- a/d1/main/playsave.c
+++ b/d1/main/playsave.c
@@ -146,6 +146,7 @@ int new_player_config()
 		PlayerCfg.ObsShowBombTimes[obs_mode] = 0;
 	}
 	PlayerCfg.NoChatSound = 0;
+	PlayerCfg.ClassicAutoselectWeapon = 0;
 
 	// Default taunt macros
 	#ifdef NETWORK
@@ -465,6 +466,8 @@ int read_player_d1x(char *filename)
 				}
 				if(!strcmp(word,"NOCHATSOUND"))
 					PlayerCfg.NoChatSound = atoi(line);
+				if(!strcmp(word,"CLASSICAUTOSELECTWEAPON"))
+					PlayerCfg.ClassicAutoselectWeapon = atoi(line);
 
 				// Observer settings - migrate from old version
 				// If migrating from an older version, set all observer modes to the same value
@@ -916,6 +919,7 @@ int write_player_d1x(char *filename)
 		//PHYSFSX_printf(fout,"quietplasma=%i\n",PlayerCfg.QuietPlasma);	
 		PHYSFSX_printf(fout,"maxfps=%i\n",PlayerCfg.maxFps);	
 		PHYSFSX_printf(fout,"nochatsound=%i\n",PlayerCfg.NoChatSound);
+		PHYSFSX_printf(fout,"classicautoselectweapon=%i\n",PlayerCfg.ClassicAutoselectWeapon);
 		PHYSFSX_printf(fout,"[end]\n");
 		PHYSFSX_printf(fout, "[observer]\n");
 		PHYSFSX_printf(fout, "obssharesettings=%i\n", PlayerCfg.ObsShareSettings);

--- a/d1/main/playsave.h
+++ b/d1/main/playsave.h
@@ -132,6 +132,7 @@ typedef struct player_config
 	ubyte ObsPlayerChat[NUM_OBS_MODES];
 	ubyte ObsShowBombTimes[NUM_OBS_MODES];
 	ubyte NoChatSound;
+	ubyte ClassicAutoselectWeapon;
 } __pack__ player_config;
 
 extern struct player_config PlayerCfg;

--- a/d1/main/weapon.c
+++ b/d1/main/weapon.c
@@ -368,11 +368,115 @@ void do_weapon_select(int weapon_num, int secondary_flag)
 	select_weapon(weapon_num, secondary_flag, 1, 1);
 }
 
+void classic_auto_select_weapon(int weapon_type)
+{
+	int	r;
+	int cutpoint;
+	int looped=0;
+
+	if (weapon_type==0) {
+		r = player_has_weapon(Player_num, Players[Player_num].primary_weapon, 0);
+		if (r != HAS_ALL) {
+			int	cur_weapon;
+			int	try_again = 1;
+
+			if(Players[Player_num].primary_weapon == LASER_INDEX && Players[Player_num].flags & PLAYER_FLAGS_QUAD_LASERS) {
+				cur_weapon = POrderList(16);
+			} else {
+				cur_weapon = POrderList(Players[Player_num].primary_weapon);
+			}
+
+			cutpoint = POrderList (255);
+
+			while (try_again) {
+				cur_weapon++;
+
+				if (cur_weapon>=cutpoint)
+				{
+					if (looped)
+					{
+						HUD_init_message_literal(HM_DEFAULT, TXT_NO_PRIMARY);
+						select_weapon(0, 0, 0, 1);
+						try_again = 0;
+						continue;
+					}
+					cur_weapon=0;
+					looped=1;
+				}
+
+
+				if (cur_weapon==MAX_PRIMARY_WEAPONS)
+					cur_weapon = 0;
+
+				//	Hack alert!  Because the fusion uses 0 energy at the end (it's got the weird chargeup)
+				//	it looks like it takes 0 to fire, but it doesn't, so never auto-select.
+				// if (PlayerCfg.PrimaryOrder[cur_weapon] == FUSION_INDEX)
+				//	continue;
+
+				if (PlayerCfg.PrimaryOrder[cur_weapon] == Players[Player_num].primary_weapon) {
+					HUD_init_message_literal(HM_DEFAULT, TXT_NO_PRIMARY);
+					select_weapon(0, 0, 0, 1);
+					try_again = 0;			// Tried all weapons!
+
+				} else if (PlayerCfg.PrimaryOrder[cur_weapon]!=255 && player_has_weapon_lasers_not_quads(PlayerCfg.PrimaryOrder[cur_weapon], 0) == HAS_ALL) {
+					select_weapon(PlayerCfg.PrimaryOrder[cur_weapon], 0, 1, 1 );
+					try_again = 0;
+				}
+			}
+		}
+
+	} else {
+
+		Assert(weapon_type==1);
+		r = player_has_weapon(Player_num, Players[Player_num].secondary_weapon, 1);
+		if (r != HAS_ALL) {
+			int	cur_weapon;
+			int	try_again = 1;
+
+			cur_weapon = SOrderList(Players[Player_num].secondary_weapon);
+			cutpoint = SOrderList (255);
+
+
+			while (try_again) {
+				cur_weapon++;
+
+				if (cur_weapon>=cutpoint)
+				{
+					if (looped)
+					{
+						HUD_init_message_literal(HM_DEFAULT, "No secondary weapons selected!");
+						try_again = 0;
+						continue;
+					}
+					cur_weapon=0;
+					looped=1;
+				}
+
+				if (cur_weapon==MAX_SECONDARY_WEAPONS)
+					cur_weapon = 0;
+
+				if (PlayerCfg.SecondaryOrder[cur_weapon] == Players[Player_num].secondary_weapon) {
+					HUD_init_message_literal(HM_DEFAULT, "No secondary weapons available!");
+					try_again = 0;				// Tried all weapons!
+				} else if (player_has_weapon(Player_num, PlayerCfg.SecondaryOrder[cur_weapon], 1) == HAS_ALL) {
+					select_weapon(PlayerCfg.SecondaryOrder[cur_weapon], 1, 1, 1 );
+					try_again = 0;
+				}
+			}
+		}
+	}
+}
+
 //	----------------------------------------------------------------------------------------
 //	Automatically select best available weapon if unable to fire current weapon.
 // Weapon type: 0==primary, 1==secondary
 void auto_select_weapon(int weapon_type)
 {
+	if (PlayerCfg.ClassicAutoselectWeapon) {
+		classic_auto_select_weapon(weapon_type);
+		return;
+	}
+
 	// Can you fire your current weapon? 
 	if(weapon_type == 0 && player_has_weapon(Player_num, Players[Player_num].primary_weapon, 0) == HAS_ALL) { return; }
 	if(weapon_type == 1 && player_has_weapon(Player_num, Players[Player_num].secondary_weapon, 1) == HAS_ALL) { return; }

--- a/d2/main/menu.c
+++ b/d2/main/menu.c
@@ -2039,7 +2039,7 @@ struct misc_menu_data {
 
 void do_misc_menu()
 {
-	newmenu_item m[39];
+	newmenu_item m[40];
 	int i = 0;
 	struct misc_menu_data misc_menu_data;
 
@@ -2094,65 +2094,66 @@ void do_misc_menu()
 		ADD_CHECK(23, "No Weapon Autoselect when firing",PlayerCfg.NoFireAutoselect);
 		ADD_CHECK(24, "Autoselect after firing",PlayerCfg.SelectAfterFire);
 		ADD_CHECK(25, "Only Cycle Autoselect Weapons",PlayerCfg.CycleAutoselectOnly);
-		ADD_CHECK(26, "Ammo Warnings",PlayerCfg.VulcanAmmoWarnings);
-		ADD_CHECK(27, "Shield Warnings",PlayerCfg.ShieldWarnings);
-		ADD_CHECK(28, "No Player Chat Sound",PlayerCfg.NoChatSound);
-
-		m[29].type = NM_TYPE_TEXT;
-		m[29].text = "";
+		ADD_CHECK(26, "Classic No Ammo Autoselect",PlayerCfg.ClassicAutoselectWeapon);
+		ADD_CHECK(27, "Ammo Warnings",PlayerCfg.VulcanAmmoWarnings);
+		ADD_CHECK(28, "Shield Warnings",PlayerCfg.ShieldWarnings);
+		ADD_CHECK(29, "No Player Chat Sound",PlayerCfg.NoChatSound);
 
 		m[30].type = NM_TYPE_TEXT;
-		m[30].text = "My Ship Colors:";
+		m[30].text = "";
+
+		m[31].type = NM_TYPE_TEXT;
+		m[31].text = "My Ship Colors:";
 
 		print_ship_color(misc_menu_data.preferred_color, SDL_arraysize(misc_menu_data.preferred_color),
 			PlayerCfg.ShipColor);
-		m[31].type = NM_TYPE_SLIDER;
-		m[31].value = PlayerCfg.ShipColor;
-		m[31].text = misc_menu_data.preferred_color;
-		m[31].min_value = 0;
-		m[31].max_value = 8;
-
-		print_missile_color(misc_menu_data.missile_color, SDL_arraysize(misc_menu_data.missile_color),
-			PlayerCfg.MissileColor);
 		m[32].type = NM_TYPE_SLIDER;
-		m[32].value = PlayerCfg.MissileColor;
-		m[32].text = misc_menu_data.missile_color;
+		m[32].value = PlayerCfg.ShipColor;
+		m[32].text = misc_menu_data.preferred_color;
 		m[32].min_value = 0;
 		m[32].max_value = 8;
 
-		ADD_CHECK(33, "Show Custom Ship Colors", PlayerCfg.ShowCustomColors);
+		print_missile_color(misc_menu_data.missile_color, SDL_arraysize(misc_menu_data.missile_color),
+			PlayerCfg.MissileColor);
+		m[33].type = NM_TYPE_SLIDER;
+		m[33].value = PlayerCfg.MissileColor;
+		m[33].text = misc_menu_data.missile_color;
+		m[33].min_value = 0;
+		m[33].max_value = 8;
 
-		m[34].type = NM_TYPE_TEXT;
-		m[34].text = "";
+		ADD_CHECK(34, "Show Custom Ship Colors", PlayerCfg.ShowCustomColors);
 
 		m[35].type = NM_TYPE_TEXT;
-		m[35].text = "Team Colors:";
+		m[35].text = "";
+
+		m[36].type = NM_TYPE_TEXT;
+		m[36].text = "Team Colors:";
 
 		print_my_team_color(misc_menu_data.my_team_color, SDL_arraysize(misc_menu_data.my_team_color),
 			PlayerCfg.MyTeamColor);
-		m[36].type = NM_TYPE_SLIDER;
-		m[36].value = PlayerCfg.MyTeamColor;
-		m[36].text = misc_menu_data.my_team_color;
-		m[36].min_value = 0;
-		m[36].max_value = 8;
-
-		print_other_team_color(misc_menu_data.other_team_color, SDL_arraysize(misc_menu_data.other_team_color),
-			PlayerCfg.OtherTeamColor);
 		m[37].type = NM_TYPE_SLIDER;
-		m[37].value = PlayerCfg.OtherTeamColor;
-		m[37].text = misc_menu_data.other_team_color;
+		m[37].value = PlayerCfg.MyTeamColor;
+		m[37].text = misc_menu_data.my_team_color;
 		m[37].min_value = 0;
 		m[37].max_value = 8;
 
+		print_other_team_color(misc_menu_data.other_team_color, SDL_arraysize(misc_menu_data.other_team_color),
+			PlayerCfg.OtherTeamColor);
+		m[38].type = NM_TYPE_SLIDER;
+		m[38].value = PlayerCfg.OtherTeamColor;
+		m[38].text = misc_menu_data.other_team_color;
+		m[38].min_value = 0;
+		m[38].max_value = 8;
+
 		if (PlayerCfg.MyTeamColor == 8 && PlayerCfg.OtherTeamColor == 8) {
 			// If we're not setting explicit team colors, we don't override what the game host picked
-			m[38].type = NM_TYPE_TEXT;
-			m[38].text = "Ignore Per-Game Team Colors (N/A)";
+			m[39].type = NM_TYPE_TEXT;
+			m[39].text = "Ignore Per-Game Team Colors (N/A)";
 		} else {
-			m[38].type = NM_TYPE_CHECK;
-			m[38].text = "Ignore Per-Game Team Colors";
+			m[39].type = NM_TYPE_CHECK;
+			m[39].text = "Ignore Per-Game Team Colors";
 		}
-		m[38].value = PlayerCfg.PreferMyTeamColors;
+		m[39].value = PlayerCfg.PreferMyTeamColors;
 
 		i = newmenu_do1(NULL, "Misc Options", SDL_arraysize(m), m, menu_misc_options_handler, &misc_menu_data, i);
 
@@ -2183,11 +2184,12 @@ void do_misc_menu()
 		PlayerCfg.NoFireAutoselect		= m[23].value;
 		PlayerCfg.SelectAfterFire		= m[24].value; if(PlayerCfg.SelectAfterFire) { PlayerCfg.NoFireAutoselect = 1; }
 		PlayerCfg.CycleAutoselectOnly		= m[25].value;
-		PlayerCfg.VulcanAmmoWarnings = m[26].value; 
-		PlayerCfg.ShieldWarnings = m[27].value;
-		PlayerCfg.NoChatSound = m[28].value;
-		PlayerCfg.ShowCustomColors = m[33].value;
-		PlayerCfg.PreferMyTeamColors = (PlayerCfg.MyTeamColor == 8 && PlayerCfg.OtherTeamColor == 8) ? 0 : m[38].value;
+		PlayerCfg.ClassicAutoselectWeapon = m[26].value;
+		PlayerCfg.VulcanAmmoWarnings = m[27].value;
+		PlayerCfg.ShieldWarnings = m[28].value;
+		PlayerCfg.NoChatSound = m[29].value;
+		PlayerCfg.ShowCustomColors = m[34].value;
+		PlayerCfg.PreferMyTeamColors = (PlayerCfg.MyTeamColor == 8 && PlayerCfg.OtherTeamColor == 8) ? 0 : m[39].value;
 
 	} while( i>-1 );
 
@@ -2206,30 +2208,30 @@ int menu_misc_options_handler(newmenu* menu, d_event* event, void* userdata)
 	struct misc_menu_data* menu_data = (struct misc_menu_data*)userdata;
 	
 	if (event->type == EVENT_NEWMENU_CHANGED) {
-		if (citem == 31) {
-			PlayerCfg.ShipColor = menus[31].value;
+		if (citem == 32) {
+			PlayerCfg.ShipColor = menus[citem].value;
 			print_ship_color(menu_data->preferred_color, SDL_arraysize(menu_data->preferred_color),
 				PlayerCfg.ShipColor);
-		} else if (citem == 32) {
-			PlayerCfg.MissileColor = menus[32].value;
+		} else if (citem == 33) {
+			PlayerCfg.MissileColor = menus[citem].value;
 			print_missile_color(menu_data->missile_color, SDL_arraysize(menu_data->missile_color),
 				PlayerCfg.MissileColor);
-		} else if (citem == 36) {
-			PlayerCfg.MyTeamColor = menus[36].value;
+		} else if (citem == 37) {
+			PlayerCfg.MyTeamColor = menus[citem].value;
 			print_my_team_color(menu_data->my_team_color, SDL_arraysize(menu_data->my_team_color),
 				PlayerCfg.MyTeamColor);
-		} else if (citem == 37) {
-			PlayerCfg.OtherTeamColor = menus[37].value;
+		} else if (citem == 38) {
+			PlayerCfg.OtherTeamColor = menus[citem].value;
 			print_other_team_color(menu_data->other_team_color, SDL_arraysize(menu_data->other_team_color),
 				PlayerCfg.OtherTeamColor);
 		}
 
 		if (PlayerCfg.MyTeamColor == 8 && PlayerCfg.OtherTeamColor == 8) {
-			menus[38].type = NM_TYPE_TEXT;
-			menus[38].text = "Ignore Per-Game Team Colors (N/A)";
+			menus[39].type = NM_TYPE_TEXT;
+			menus[39].text = "Ignore Per-Game Team Colors (N/A)";
 		} else {
-			menus[38].type = NM_TYPE_CHECK;
-			menus[38].text = "Ignore Per-Game Team Colors";
+			menus[39].type = NM_TYPE_CHECK;
+			menus[39].text = "Ignore Per-Game Team Colors";
 		}
 	}
 

--- a/d2/main/playsave.c
+++ b/d2/main/playsave.c
@@ -168,6 +168,7 @@ int new_player_config()
 		PlayerCfg.ObsShowBombTimes[obs_mode] = 0;
 	}
 	PlayerCfg.NoChatSound = 0;
+	PlayerCfg.ClassicAutoselectWeapon = 0;
 
 	// Default taunt macros
 	#ifdef NETWORK
@@ -436,6 +437,8 @@ int read_player_d2x(char *filename)
 				}
 				if(!strcmp(word,"NOCHATSOUND"))
 					PlayerCfg.NoChatSound = atoi(line);
+				if(!strcmp(word,"CLASSICAUTOSELECTWEAPON"))
+					PlayerCfg.ClassicAutoselectWeapon = atoi(line);
 
 				// Observer settings - migrate from old version
 				// If migrating from an older version, set all observer modes to the same value
@@ -702,6 +705,7 @@ int write_player_d2x(char *filename)
 		//PHYSFSX_printf(fout,"quietplasma=%i\n",PlayerCfg.QuietPlasma);	
 		PHYSFSX_printf(fout,"maxfps=%i\n",PlayerCfg.maxFps);	
 		PHYSFSX_printf(fout,"nochatsound=%i\n",PlayerCfg.NoChatSound);
+		PHYSFSX_printf(fout,"classicautoselectweapon=%i\n",PlayerCfg.ClassicAutoselectWeapon);
 		PHYSFSX_printf(fout,"[end]\n");
 		PHYSFSX_printf(fout, "[observer]\n");
 		PHYSFSX_printf(fout, "obssharesettings=%i\n", PlayerCfg.ObsShareSettings);

--- a/d2/main/playsave.h
+++ b/d2/main/playsave.h
@@ -125,6 +125,7 @@ typedef struct player_config
 	ubyte ObsPlayerChat[NUM_OBS_MODES];
 	ubyte ObsShowBombTimes[NUM_OBS_MODES];
 	ubyte NoChatSound;
+	ubyte ClassicAutoselectWeapon;
 } __pack__ player_config;
 
 extern struct player_config PlayerCfg;


### PR DESCRIPTION
Function classic_auto_select_weapon comes from commit 1d694d1.

With the classic autoselect, the next lower weapon with ammo is chosen when running out of ammo, with the default autoselect the highest weapon with ammo is chosen.

Closes #99