### PR TITLE
Update default .ini files to show new default tracker URL

### DIFF
--- a/d1/d1x-default.ini
+++ b/d1/d1x-default.ini
@@ -40,7 +40,7 @@
 ;-udp_hostaddr <s>             Use IP address/Hostname <s> for manual game joining (default: localhost)
 ;-udp_hostport <n>             Use UDP port <n> for manual game joining (default: 42424)
 ;-udp_myport <n>               Set my own UDP port to <n> (default: 42424)
-;-tracker_hostaddr <n>         Address of Tracker server to register/query games to/from (default: dxxtracker.reenigne.net)
+;-tracker_hostaddr <n>         Address of Tracker server to register/query games to/from (default: retro-tracker.game-server.cc)
 ;-tracker_hostport <n>         Port of Tracker server to register/query games to/from (default: 42420)
 ;-netlog                       Write network traffic log (netlog.txt)
 

--- a/d2/d2x-default.ini
+++ b/d2/d2x-default.ini
@@ -43,7 +43,7 @@
 ;-udp_hostaddr <s>             Use IP address/Hostname <s> for manual game joining (default: localhost)
 ;-udp_hostport <n>             Use UDP port <n> for manual game joining (default: 42424)
 ;-udp_myport <n>               Set my own UDP port to <n> (default: 42424)
-;-tracker_hostaddr <n>         Address of Tracker server to register/query games to/from (default: dxxtracker.reenigne.net)
+;-tracker_hostaddr <n>         Address of Tracker server to register/query games to/from (default: retro-tracker.game-server.cc)
 ;-tracker_hostport <n>         Port of Tracker server to register/query games to/from (default: 42420)
 ;-netlog                       Write network traffic log (netlog.txt)
 


### PR DESCRIPTION
They were still stuck on dxxtracker.reenigne.net which has been down for a while. I updated them to state the default is retro-tracker.game-server.cc