### PR TITLE
Load ogl textures earlier

### DIFF
--- a/d1/main/gameseq.c
+++ b/d1/main/gameseq.c
@@ -677,8 +677,12 @@ void LoadLevel(int level_num,int page_in_textures)
 
 	gr_palette_load(gr_palette);		//actually load the palette
 
-	if ( page_in_textures )
+	if ( page_in_textures ) {
 		piggy_load_level_data();
+#ifdef OGL
+		ogl_cache_level_textures();
+#endif
+	}
 }
 
 //sets up Player_num & ConsoleObject
@@ -1224,10 +1228,6 @@ void StartNewLevelSub(int level_num, int page_in_textures, int secret_flag)
 
 	reset_special_effects();
 	init_exploding_walls();
-
-#ifdef OGL
-	ogl_cache_level_textures();
-#endif
 
 #ifdef NETWORK
 	if (Network_rejoined == 1)

--- a/d2/main/gameseq.c
+++ b/d2/main/gameseq.c
@@ -771,8 +771,12 @@ void LoadLevel(int level_num,int page_in_textures)
 
 	load_level_robots(level_num);
 
-	if ( page_in_textures )
+	if ( page_in_textures ) {
 		piggy_load_level_data();
+#ifdef OGL
+		ogl_cache_level_textures();
+#endif
+	}
 
 #ifdef NETWORK
 	my_segments_checksum = netmisc_calc_checksum();
@@ -1630,7 +1634,6 @@ void StartNewLevelSub(int level_num, int page_in_textures, int secret_flag)
 
 #ifdef OGL
 	gr_remap_mono_fonts();
-	ogl_cache_level_textures();
 #endif
 
 

--- a/d2/main/kmatrix.c
+++ b/d2/main/kmatrix.c
@@ -49,6 +49,7 @@ COPYRIGHT 1993-1999 PARALLAX SOFTWARE CORPORATION.  ALL RIGHTS RESERVED.
 #include "gauges.h"
 #include "pcx.h"
 #include "args.h"
+#include "gamepal.h"
 
 #ifdef OGL
 #include "ogl_init.h"
@@ -411,6 +412,7 @@ void kmatrix_view(int network)
 		return;
 	}
 	gr_palette_load(gr_palette);
+	strcpy(last_palette_loaded,"");		//force palette load next time
 	
 	km->network = network;
 	km->end_time = -1;


### PR DESCRIPTION
Prevents multi game starting before textures are loaded. Needs last_palette_loaded reset in kmatrix to make sure correct palette is loaded while loading the textures after a level change in MP.