### PR TITLE
Fix obs cockpit partially changed

### DIFF
--- a/d1/main/game.c
+++ b/d1/main/game.c
@@ -187,49 +187,48 @@ void init_cockpit()
 	}
 #endif
 
+	if (is_observer() && !can_draw_observer_cockpit())
+		PlayerCfg.CurrentCockpitMode = CM_FULL_SCREEN;
+
 	gr_set_current_canvas(NULL);
 
-	if (is_observer() && !can_draw_observer_cockpit()) {
-		game_init_render_sub_buffers(0, 0, SWIDTH, SHEIGHT);
-	} else {
-		switch( PlayerCfg.CurrentCockpitMode ) {
-			case CM_FULL_COCKPIT:
-				game_init_render_sub_buffers(0, 0, SWIDTH, (SHEIGHT*2)/3);
-				break;
+	switch( PlayerCfg.CurrentCockpitMode ) {
+		case CM_FULL_COCKPIT:
+			game_init_render_sub_buffers(0, 0, SWIDTH, (SHEIGHT*2)/3);
+			break;
 
-			case CM_REAR_VIEW:
-			{
-				int x1 = 0, y1 = 0, x2 = SWIDTH, y2 = (SHEIGHT*2)/3;
-				grs_bitmap *bm;
+		case CM_REAR_VIEW:
+		{
+			int x1 = 0, y1 = 0, x2 = SWIDTH, y2 = (SHEIGHT*2)/3;
+			grs_bitmap *bm;
 
-				PIGGY_PAGE_IN(cockpit_bitmap[PlayerCfg.CurrentCockpitMode]);
-				bm = &GameBitmaps[cockpit_bitmap[PlayerCfg.CurrentCockpitMode].index];
-				gr_bitblt_find_transparent_area(bm, &x1, &y1, &x2, &y2);
-				game_init_render_sub_buffers(x1*((float)SWIDTH/bm->bm_w), y1*((float)SHEIGHT/bm->bm_h), (x2-x1+1)*((float)SWIDTH/bm->bm_w), (y2-y1+2)*((float)SHEIGHT/bm->bm_h));
-				break;
-			}
-			case CM_FULL_SCREEN:
-				game_init_render_sub_buffers(0, 0, SWIDTH, SHEIGHT);
-				break;
+			PIGGY_PAGE_IN(cockpit_bitmap[PlayerCfg.CurrentCockpitMode]);
+			bm = &GameBitmaps[cockpit_bitmap[PlayerCfg.CurrentCockpitMode].index];
+			gr_bitblt_find_transparent_area(bm, &x1, &y1, &x2, &y2);
+			game_init_render_sub_buffers(x1*((float)SWIDTH/bm->bm_w), y1*((float)SHEIGHT/bm->bm_h), (x2-x1+1)*((float)SWIDTH/bm->bm_w), (y2-y1+2)*((float)SHEIGHT/bm->bm_h));
+			break;
+		}
+		case CM_FULL_SCREEN:
+			game_init_render_sub_buffers(0, 0, SWIDTH, SHEIGHT);
+			break;
 
-			case CM_STATUS_BAR:
-				game_init_render_sub_buffers( 0, 0, SWIDTH, (HIRESMODE?(SHEIGHT*2)/2.6:(SHEIGHT*2)/2.72) );
-				break;
+		case CM_STATUS_BAR:
+			game_init_render_sub_buffers( 0, 0, SWIDTH, (HIRESMODE?(SHEIGHT*2)/2.6:(SHEIGHT*2)/2.72) );
+			break;
 
-			case CM_LETTERBOX:
-			{
-				int x,y,w,h;
+		case CM_LETTERBOX:
+		{
+			int x,y,w,h;
 
-				x = 0; w = SM_W(Game_screen_mode);
-				h = (SM_H(Game_screen_mode) * 3) / 4; // true letterbox size (16:9)
-				y = (SM_H(Game_screen_mode)-h)/2;
+			x = 0; w = SM_W(Game_screen_mode);
+			h = (SM_H(Game_screen_mode) * 3) / 4; // true letterbox size (16:9)
+			y = (SM_H(Game_screen_mode)-h)/2;
 
-				gr_rect(x,0,w,SM_H(Game_screen_mode)-h);
-				gr_rect(x,SM_H(Game_screen_mode)-h,w,SM_H(Game_screen_mode));
+			gr_rect(x,0,w,SM_H(Game_screen_mode)-h);
+			gr_rect(x,SM_H(Game_screen_mode)-h,w,SM_H(Game_screen_mode));
 
-				game_init_render_sub_buffers( x, y, w, h );
-				break;
-			}
+			game_init_render_sub_buffers( x, y, w, h );
+			break;
 		}
 	}
 

--- a/d2/main/game.c
+++ b/d2/main/game.c
@@ -198,50 +198,48 @@ void init_cockpit()
 	}
 #endif
 
+	if (is_observer() && !can_draw_observer_cockpit())
+		PlayerCfg.CurrentCockpitMode = CM_FULL_SCREEN;
+
 	gr_set_current_canvas(NULL);
 
-	if (is_observer() && !can_draw_observer_cockpit()) {
-		game_init_render_sub_buffers(0, 0, SWIDTH, SHEIGHT);
-	}
-	else {
-		switch (PlayerCfg.CurrentCockpitMode) {
-			case CM_FULL_COCKPIT:
-				game_init_render_sub_buffers(0, 0, SWIDTH, (SHEIGHT * 2) / 3);
-				break;
+	switch (PlayerCfg.CurrentCockpitMode) {
+		case CM_FULL_COCKPIT:
+			game_init_render_sub_buffers(0, 0, SWIDTH, (SHEIGHT * 2) / 3);
+			break;
 
-			case CM_REAR_VIEW:
-			{
-				int x1 = 0, y1 = 0, x2 = SWIDTH, y2 = (SHEIGHT * 2) / 3;
-				grs_bitmap* bm;
+		case CM_REAR_VIEW:
+		{
+			int x1 = 0, y1 = 0, x2 = SWIDTH, y2 = (SHEIGHT * 2) / 3;
+			grs_bitmap* bm;
 
-				PIGGY_PAGE_IN(cockpit_bitmap[PlayerCfg.CurrentCockpitMode]);
-				bm = &GameBitmaps[cockpit_bitmap[PlayerCfg.CurrentCockpitMode].index];
-				gr_bitblt_find_transparent_area(bm, &x1, &y1, &x2, &y2);
-				game_init_render_sub_buffers(x1 * ((float)SWIDTH / bm->bm_w), y1 * ((float)SHEIGHT / bm->bm_h), (x2 - x1 + 1) * ((float)SWIDTH / bm->bm_w), (y2 - y1 + 2) * ((float)SHEIGHT / bm->bm_h));
-				break;
-			}
-			case CM_FULL_SCREEN:
-				game_init_render_sub_buffers(0, 0, SWIDTH, SHEIGHT);
-				break;
+			PIGGY_PAGE_IN(cockpit_bitmap[PlayerCfg.CurrentCockpitMode]);
+			bm = &GameBitmaps[cockpit_bitmap[PlayerCfg.CurrentCockpitMode].index];
+			gr_bitblt_find_transparent_area(bm, &x1, &y1, &x2, &y2);
+			game_init_render_sub_buffers(x1 * ((float)SWIDTH / bm->bm_w), y1 * ((float)SHEIGHT / bm->bm_h), (x2 - x1 + 1) * ((float)SWIDTH / bm->bm_w), (y2 - y1 + 2) * ((float)SHEIGHT / bm->bm_h));
+			break;
+		}
+		case CM_FULL_SCREEN:
+			game_init_render_sub_buffers(0, 0, SWIDTH, SHEIGHT);
+			break;
 
-			case CM_STATUS_BAR:
-				game_init_render_sub_buffers(0, 0, SWIDTH, (HIRESMODE ? (SHEIGHT * 2) / 2.6 : (SHEIGHT * 2) / 2.72));
-				break;
+		case CM_STATUS_BAR:
+			game_init_render_sub_buffers(0, 0, SWIDTH, (HIRESMODE ? (SHEIGHT * 2) / 2.6 : (SHEIGHT * 2) / 2.72));
+			break;
 
-			case CM_LETTERBOX:
-			{
-				int x, y, w, h;
+		case CM_LETTERBOX:
+		{
+			int x, y, w, h;
 
-				x = 0; w = SM_W(Game_screen_mode);
-				h = (SM_H(Game_screen_mode) * 3) / 4; // true letterbox size (16:9)
-				y = (SM_H(Game_screen_mode) - h) / 2;
+			x = 0; w = SM_W(Game_screen_mode);
+			h = (SM_H(Game_screen_mode) * 3) / 4; // true letterbox size (16:9)
+			y = (SM_H(Game_screen_mode) - h) / 2;
 
-				gr_rect(x, 0, w, SM_H(Game_screen_mode) - h);
-				gr_rect(x, SM_H(Game_screen_mode) - h, w, SM_H(Game_screen_mode));
+			gr_rect(x, 0, w, SM_H(Game_screen_mode) - h);
+			gr_rect(x, SM_H(Game_screen_mode) - h, w, SM_H(Game_screen_mode));
 
-				game_init_render_sub_buffers(x, y, w, h);
-				break;
-			}
+			game_init_render_sub_buffers(x, y, w, h);
+			break;
 		}
 	}
 


### PR DESCRIPTION
The function init_cockpit could suppress the cockpit without changing the cockpit mode, which would later prevent a correct cockpit switch when the cockpit could be shown. This was visible as an incorrect aspect ratio.

(changes from the switch line onwards are just indent changes)