### PR TITLE
Add data segments to Windows crash dumps

### DIFF
--- a/d1/arch/win32/crashdump.c
+++ b/d1/arch/win32/crashdump.c
@@ -21,7 +21,7 @@ void win32_create_dump(EXCEPTION_POINTERS* exceptionPointers)
 		exceptionInfo.ExceptionPointers = exceptionPointers;
 		exceptionInfo.ClientPointers = FALSE;
 
-		MiniDumpWriteDump(GetCurrentProcess(), GetCurrentProcessId(), hDumpFile, MiniDumpNormal, &exceptionInfo, NULL, NULL);
+		MiniDumpWriteDump(GetCurrentProcess(), GetCurrentProcessId(), hDumpFile, MiniDumpWithDataSegs, &exceptionInfo, NULL, NULL);
 		CloseHandle(hDumpFile);
 	}
 }

--- a/d2/arch/win32/crashdump.c
+++ b/d2/arch/win32/crashdump.c
@@ -21,7 +21,7 @@ void win32_create_dump(EXCEPTION_POINTERS* exceptionPointers)
 		exceptionInfo.ExceptionPointers = exceptionPointers;
 		exceptionInfo.ClientPointers = FALSE;
 
-		MiniDumpWriteDump(GetCurrentProcess(), GetCurrentProcessId(), hDumpFile, MiniDumpNormal, &exceptionInfo, NULL, NULL);
+		MiniDumpWriteDump(GetCurrentProcess(), GetCurrentProcessId(), hDumpFile, MiniDumpWithDataSegs, &exceptionInfo, NULL, NULL);
 		CloseHandle(hDumpFile);
 	}
 }


### PR DESCRIPTION
Increases dump size from 64kb to 22mb but it's quite useful.