### PR TITLE
Try to fix font related crash in show_HUD_names

### DIFF
--- a/d1/main/gauges.c
+++ b/d1/main/gauges.c
@@ -3909,6 +3909,8 @@ void show_HUD_names()
 
 	int my_pnum = get_pnum_for_hud();
 
+	gr_set_curfont(GAME_FONT);
+
 	if(Netgame.BlackAndWhitePyros)
 		selected_player_rgb = player_rgb_alt;
 	else

--- a/d2/main/gauges.c
+++ b/d2/main/gauges.c
@@ -4234,6 +4234,8 @@ void show_HUD_names()
 
 	int my_pnum = get_pnum_for_hud();
 
+	gr_set_curfont(GAME_FONT);
+
 	if(Netgame.BlackAndWhitePyros)
 		selected_player_rgb = player_rgb_alt;
 	else


### PR DESCRIPTION
From the crash dump it looked like it still used a freed font. Maybe because the font was reloaded after a graphics/resolution change.