### PR TITLE
Hide shield bar for first person observed player

### DIFF
--- a/d1/main/gauges.c
+++ b/d1/main/gauges.c
@@ -3992,7 +3992,8 @@ void show_HUD_names()
 						y1 = f2i(y-dy)+FSPACY(1);
 						gr_string (x1, y1, s);
 					}
-					if (is_observer() && PlayerCfg.ObsShowShieldBar[get_observer_game_mode()]) {
+					if (is_observer() && PlayerCfg.ObsShowShieldBar[get_observer_game_mode()] &&
+						(!is_observing_player() || Obs_at_distance || Current_obs_player != pnum)) {
 #ifdef OGL
 						glLineWidth(1);
 #endif

--- a/d2/main/gauges.c
+++ b/d2/main/gauges.c
@@ -4317,7 +4317,8 @@ void show_HUD_names()
 						y1 = f2i(y-dy)+FSPACY(1);
 						gr_string (x1, y1, s);
 					}
-					if (is_observer() && PlayerCfg.ObsShowShieldBar[get_observer_game_mode()]) {
+					if (is_observer() && PlayerCfg.ObsShowShieldBar[get_observer_game_mode()] &&
+						(!is_observing_player() || Obs_at_distance || Current_obs_player != pnum)) {
 #ifdef OGL
 						glLineWidth(1);
 #endif


### PR DESCRIPTION
Shield bar could briefly appear over cockpit when player and viewer position were slightly different.