### PR TITLE
Force C standard version in CMakeLists

### DIFF
--- a/d1/CMakeLists.txt
+++ b/d1/CMakeLists.txt
@@ -4,6 +4,9 @@
 cmake_minimum_required (VERSION 3.21)
 project(d1x-redux VERSION 1.1)
 
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_C_STANDARD_REQUIRED TRUE)
+
 option(OPENGL "Build with OpenGL support [default: ON]" ON)
 option(SDLMIXER "Build with SDL_Mixer support for sound and music (includes external music support) [default: ON]" ON)
 option(ASM "Build with ASSEMBLER code (only with OpenGL OFF, requires NASM and x86) [default: OFF]" OFF)

--- a/d2/CMakeLists.txt
+++ b/d2/CMakeLists.txt
@@ -8,6 +8,9 @@ project(
     LANGUAGES C CXX
     )
 
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_C_STANDARD_REQUIRED TRUE)
+
 option(OPENGL "Build with OpenGL support [default: ON]" ON)
 option(SDLMIXER "Build with SDL_Mixer support for sound and music (includes external music support) [default: ON]" ON)
 option(ASM "Build with ASSEMBLER code (only with OpenGL OFF, requires NASM and x86) [default: OFF]" OFF)


### PR DESCRIPTION
This fixes compilation with GCC 15 (released in Fedora42), that defaults to C23. C23 defines 'bool', which pstypes.h also tries to define (unsuccessfully so).

I assumed C99, let me know if it should be something else.