### PR TITLE
Add rebalanced D2 weapons as separate multiplayer option

### DIFF
--- a/d2/main/collide.c
+++ b/d2/main/collide.c
@@ -2312,9 +2312,12 @@ void collide_player_and_weapon( object * playerobj, object * weapon, vms_vector 
 		return;
 	}
 
-	if (weapon->id == OMEGA_ID)
+	if (weapon->id == OMEGA_ID) {
 		if (!ok_to_do_omega_damage(weapon)) // see comment in laser.c
 			return;
+		if ((Game_mode & GM_MULTI) && Netgame.RebalancedWeapons)
+			damage *= get_rebalance_omega_damage_scale(weapon);
+		}
 
 	//	Don't collide own smart mines unless direct hit.
 	if (weapon->id == SUPERPROX_ID)

--- a/d2/main/collide.c
+++ b/d2/main/collide.c
@@ -2316,7 +2316,7 @@ void collide_player_and_weapon( object * playerobj, object * weapon, vms_vector 
 		if (!ok_to_do_omega_damage(weapon)) // see comment in laser.c
 			return;
 		if ((Game_mode & GM_MULTI) && Netgame.RebalancedWeapons)
-			damage *= get_rebalance_omega_damage_scale(weapon);
+			damage *= get_rebalanced_omega_damage_scale(weapon);
 		}
 
 	//	Don't collide own smart mines unless direct hit.

--- a/d2/main/laser.c
+++ b/d2/main/laser.c
@@ -347,6 +347,29 @@ int ok_to_do_omega_damage(object *weapon)
 	return 1;
 }
 
+// For rebalanced weapons - Omega cannon damage falls off with distance to the target
+fix get_rebalance_omega_damage_scale(object* weapon)
+{
+	int parent_sig = weapon->ctype.laser_info.parent_signature;
+	int parent_num = weapon->ctype.laser_info.parent_num;
+
+	if (weapon->type != OBJ_WEAPON || weapon->id != OMEGA_ID)
+		return F1_0;
+	if (!(Game_mode & GM_MULTI) || !Netgame.RebalancedWeapons)
+		return F1_0;
+
+	if (Objects[parent_num].signature == parent_sig) {
+		fix max_dist_fraction = fixdiv(vm_vec_dist(&Objects[parent_num].pos, &weapon->pos), MAX_OMEGA_DIST);
+		if (max_dist_fraction > F1_0)
+		{
+			return 0;
+		}
+		return F1_0 - max_dist_fraction;
+	}
+
+	return F1_0;
+}
+
 // ---------------------------------------------------------------------------------
 void create_omega_blobs(int firing_segnum, vms_vector *firing_pos, vms_vector *goal_pos, object *parent_objp)
 {
@@ -679,19 +702,23 @@ int Laser_create_new( vms_vector * direction, vms_vector * position, int segnum,
 		obj->mtype.phys_info.flags |= PF_STICK;		//this obj sticks to walls
 
 	obj->shields = Weapon_info[obj->id].strength[Difficulty_level];
-	if( (Game_mode & GM_MULTI) && Netgame.OriginalD1Weapons) {
-		if(obj->id == 0) {        // Laser 1
-			obj->shields = 10 * F1_0; 
-		} else if(obj->id == 1) { // Laser 2
-			obj->shields = 11 * F1_0; 
-		} else if(obj->id == 2) { // Laser 3
-			obj->shields = 12 * F1_0; 
-		} else if(obj->id == 3 || obj->id == 30 || obj->id == 31) { // Laser 4
-			obj->shields = 13 * F1_0; 
-		} else if(obj->id == 12) { // Spread
-			obj->shields = 10 * F1_0; 
-		} else if(obj->id == 14) { // Fusion
-			obj->shields = 60 * F1_0; 
+	if ((Game_mode & GM_MULTI) && Netgame.RebalancedWeapons) {
+		if (obj->id == LASER_ID_L1) {
+			obj->shields = 10 * F1_0;
+		} else if (obj->id == LASER_ID_L2) {
+			obj->shields = 11 * F1_0;
+		} else if (obj->id == LASER_ID_L3) {
+			obj->shields = 12 * F1_0;
+		} else if (obj->id == LASER_ID_L4) {
+			obj->shields = 13 * F1_0;
+		} else if (obj->id == LASER_ID_L5) {
+			obj->shields = 13.25 * F1_0;
+		} else if (obj->id == LASER_ID_L6) {
+			obj->shields = 13.5 * F1_0;
+		} else if (obj->id == SPREADFIRE_ID) {
+			obj->shields = 10 * F1_0;
+		} else if (obj->id == FUSION_ID) {
+			obj->shields = 60 * F1_0;
 		}
 	}
 
@@ -810,10 +837,10 @@ int Laser_create_new( vms_vector * direction, vms_vector * position, int segnum,
 	if (Weapon_info[obj->id].thrust != 0)
 		weapon_speed /= 2;
 
-	if( (Game_mode & GM_MULTI) && Netgame.OriginalD1Weapons) {
-		if(obj->id == 12) { // Spread
-			weapon_speed = 200 * F1_0; 
-		} 
+	if ((Game_mode & GM_MULTI) && Netgame.RebalancedWeapons) {
+		if (obj->id == SPREADFIRE_ID) {
+			weapon_speed = 200 * F1_0;
+		}
 	}
 
 	vm_vec_copy_scale( &obj->mtype.phys_info.velocity, direction, weapon_speed + parent_speed );
@@ -1266,10 +1293,10 @@ void Laser_player_fire_spread_delay(object *obj, int laser_type, int gun_num, fi
 	vm_vec_add(&LaserPos,&obj->pos,&gun_point);
 
 	fix weapon_speed = Weapon_info[laser_type].speed[Difficulty_level];
-	if( (Game_mode & GM_MULTI) && Netgame.OriginalD1Weapons) {
-		if(laser_type == 12) { // Spread
-			weapon_speed = 200 * F1_0; 
-		} 
+	if ((Game_mode & GM_MULTI) && Netgame.RebalancedWeapons) {
+		if (laser_type == SPREADFIRE_ID) {
+			weapon_speed = 200 * F1_0;
+		}
 	}
 
 	//	If supposed to fire at a delayed time (delay_time), then move this point backwards.
@@ -1533,10 +1560,10 @@ void Laser_do_weapon_sequence(object *obj, int doHomerFrame, fix idealHomerFrame
 				temp_vec = obj->mtype.phys_info.velocity;
 				speed = vm_vec_normalize_quick(&temp_vec);
 				max_speed = Weapon_info[obj->id].speed[Difficulty_level];
-				if( (Game_mode & GM_MULTI) && Netgame.OriginalD1Weapons) {
-					if(obj->id == 12) { // Spread
-						max_speed = 200 * F1_0; 
-					} 
+				if ((Game_mode & GM_MULTI) && Netgame.RebalancedWeapons) {
+					if (obj->id == SPREADFIRE_ID) {
+						max_speed = 200 * F1_0;
+					}
 				}
 				if (speed+F1_0 < max_speed) {
 					speed += fixmul(max_speed, idealHomerFrameTime/2);
@@ -1616,10 +1643,10 @@ void Laser_do_weapon_sequence(object *obj, int doHomerFrame, fix idealHomerFrame
 		fix	weapon_speed;
 
 		fix max_weapon_speed = Weapon_info[obj->id].speed[Difficulty_level];
-		if( (Game_mode & GM_MULTI) && Netgame.OriginalD1Weapons) {
-			if(obj->id == 12) { // Spread
-				max_weapon_speed = 200 * F1_0; 
-			} 
+		if ((Game_mode & GM_MULTI) && Netgame.RebalancedWeapons) {
+			if (obj->id == SPREADFIRE_ID) {
+				max_weapon_speed = 200 * F1_0;
+			}
 		}
 
 		weapon_speed = vm_vec_mag_quick(&obj->mtype.phys_info.velocity);
@@ -1647,7 +1674,7 @@ void do_laser_firing_player(void)
 	player	*plp = &Players[Player_num];
 	fix		energy_used;
 	int		ammo_used,primary_ammo;
-	int		weapon_index;
+	int		weapon_id;
 	int		rval = 0;
 	int 		nfires = 1;
 	static int Spreadfire_toggle=0;
@@ -1656,8 +1683,8 @@ void do_laser_firing_player(void)
 	if (Player_is_dead)
 		return;
 
-	weapon_index = Primary_weapon_to_weapon_info[Players[Player_num].primary_weapon];
-	energy_used = Weapon_info[weapon_index].energy_usage;
+	weapon_id = Primary_weapon_to_weapon_info[Players[Player_num].primary_weapon];
+	energy_used = Weapon_info[weapon_id].energy_usage;
 	if (Players[Player_num].primary_weapon == OMEGA_INDEX)
 		energy_used = 0;	//	Omega consumes energy when recharging, not when firing.
 
@@ -1665,11 +1692,19 @@ void do_laser_firing_player(void)
 		energy_used = fixmul(energy_used, i2f(Difficulty_level+2)/4);
 
 	//	MK, 01/26/96, Helix use 2x energy in multiplayer.  bitmaps.tbl parm should have been reduced for single player.
-	if (weapon_index == HELIX_INDEX)
-		if (Game_mode & GM_MULTI)
+	// Note: This didn't work in vanilla because the ID check was written incorrectly;
+	// fixing specifically for rebalanced weapons.
+	if ((Game_mode & GM_MULTI) && Netgame.RebalancedWeapons) {
+		if (weapon_id == HELIX_ID)
 			energy_used *= 2;
+	}
 
-	ammo_used = Weapon_info[weapon_index].ammo_usage;
+	ammo_used = Weapon_info[weapon_id].ammo_usage;
+
+	if ((Game_mode & GM_MULTI) && Netgame.RebalancedWeapons) {
+		if (weapon_id == GAUSS_ID)
+			ammo_used *= 10; // 2 -> 20
+	}
 
 	primary_ammo = (Players[Player_num].primary_weapon == GAUSS_INDEX)?(plp->primary_ammo[VULCAN_INDEX]):(plp->primary_ammo[Players[Player_num].primary_weapon]);
 
@@ -1679,14 +1714,20 @@ void do_laser_firing_player(void)
 	while (Next_laser_fire_time <= GameTime64) {
 		if	((plp->energy >= energy_used) && (primary_ammo >= ammo_used)) {
 			int	laser_level, flags, fire_frame_overhead = 0;
+			fix fire_wait = Weapon_info[weapon_id].fire_wait;
+
+			if ((Game_mode & GM_MULTI) && Netgame.RebalancedWeapons) {
+				if (Players[Player_num].primary_weapon == HELIX_INDEX)
+					fire_wait = 0.2 * F1_0; // default is 0.15
+			}
 
 			if (GameTime64 - Next_laser_fire_time <= FrameTime) // if firing is prolonged by FrameTime overhead, let's try to fix that.
 				fire_frame_overhead = GameTime64 - Next_laser_fire_time;
 
-                        Last_laser_fired_time = GameTime64;
+			Last_laser_fired_time = GameTime64;
 
 			if (!cheats.rapidfire)
-				Next_laser_fire_time = GameTime64 + Weapon_info[weapon_index].fire_wait - fire_frame_overhead;
+				Next_laser_fire_time = GameTime64 + fire_wait - fire_frame_overhead;
 			else
 				Next_laser_fire_time = GameTime64 + (F1_0/25) - fire_frame_overhead;
 
@@ -1732,7 +1773,7 @@ void do_laser_firing_player(void)
 			}
 
 			pre_ammo = (Players[Player_num].energy)/F1_0; 
-			post_ammo = (Players[Player_num].energy - (energy_used * rval) / Weapon_info[weapon_index].fire_count)/F1_0; 
+			post_ammo = (Players[Player_num].energy - (energy_used * rval) / Weapon_info[weapon_id].fire_count)/F1_0; 
 			warning_increment = 5; 
 			if(Players[Player_num].primary_weapon != VULCAN_INDEX && Players[Player_num].primary_weapon != GAUSS_INDEX && PlayerCfg.VulcanAmmoWarnings) {
 			
@@ -1754,7 +1795,7 @@ void do_laser_firing_player(void)
 				}					
 			}
 
-			plp->energy -= (energy_used * rval) / Weapon_info[weapon_index].fire_count;
+			plp->energy -= (energy_used * rval) / Weapon_info[weapon_id].fire_count;
 			if (plp->energy < 0)
 				plp->energy = 0;
 

--- a/d2/main/laser.c
+++ b/d2/main/laser.c
@@ -716,15 +716,22 @@ int Laser_create_new( vms_vector * direction, vms_vector * position, int segnum,
 		} else if (obj->id == LASER_ID_L4) {
 			obj->shields = 13 * F1_0;
 		} else if (obj->id == LASER_ID_L5) {
-			obj->shields = 13.25 * F1_0;
+			obj->shields = 13 * F1_0;
 		} else if (obj->id == LASER_ID_L6) {
-			obj->shields = 13.5 * F1_0;
+			obj->shields = 13 * F1_0;
 		} else if (obj->id == SPREADFIRE_ID) {
 			obj->shields = 10 * F1_0;
 		} else if (obj->id == FUSION_ID) {
 			// Note: This actually just cancels out the multi_damage_scale applied to fusion,
 			// but it works, so no real reason to change it right now.
 			obj->shields = 60 * F1_0;
+		}
+	}
+	if ((Game_mode & GM_MULTI) && Netgame.RebalancedWeapons) {
+		if (obj->id == LASER_ID_L5) {
+			obj->shields = 13.25 * F1_0;
+		} else if (obj->id == LASER_ID_L6) {
+			obj->shields = 13.5 * F1_0;
 		} else if (obj->id == SUPERPROX_ID) {
 			// Smart mine; down from 30
 			obj->shields = 10 * F1_0;

--- a/d2/main/laser.c
+++ b/d2/main/laser.c
@@ -718,6 +718,8 @@ int Laser_create_new( vms_vector * direction, vms_vector * position, int segnum,
 		} else if (obj->id == SPREADFIRE_ID) {
 			obj->shields = 10 * F1_0;
 		} else if (obj->id == FUSION_ID) {
+			// Note: This actually just cancels out the multi_damage_scale applied to fusion,
+			// but it works, so no real reason to change it right now.
 			obj->shields = 60 * F1_0;
 		}
 	}

--- a/d2/main/laser.c
+++ b/d2/main/laser.c
@@ -721,6 +721,12 @@ int Laser_create_new( vms_vector * direction, vms_vector * position, int segnum,
 			// Note: This actually just cancels out the multi_damage_scale applied to fusion,
 			// but it works, so no real reason to change it right now.
 			obj->shields = 60 * F1_0;
+		} else if (obj->id == SUPERPROX_ID) {
+			// Smart mine; down from 30
+			obj->shields = 10 * F1_0;
+		} else if (obj->id == SMART_MINE_HOMING_ID) {
+			// Smart mine blob; down from 25
+			obj->shields = 3 * F1_0;
 		}
 	}
 

--- a/d2/main/laser.c
+++ b/d2/main/laser.c
@@ -352,7 +352,7 @@ int ok_to_do_omega_damage(object *weapon)
 }
 
 // For rebalanced weapons - Omega cannon damage falls off with distance to the target
-fix get_rebalance_omega_damage_scale(object* weapon)
+fix get_rebalanced_omega_damage_scale(object* weapon)
 {
 	int parent_sig = weapon->ctype.laser_info.parent_signature;
 	int parent_num = weapon->ctype.laser_info.parent_num;
@@ -706,7 +706,7 @@ int Laser_create_new( vms_vector * direction, vms_vector * position, int segnum,
 		obj->mtype.phys_info.flags |= PF_STICK;		//this obj sticks to walls
 
 	obj->shields = Weapon_info[obj->id].strength[Difficulty_level];
-	if ((Game_mode & GM_MULTI) && Netgame.RebalancedWeapons) {
+	if ((Game_mode & GM_MULTI) && Netgame.OriginalD1Weapons) {
 		if (obj->id == LASER_ID_L1) {
 			obj->shields = 10 * F1_0;
 		} else if (obj->id == LASER_ID_L2) {
@@ -849,7 +849,7 @@ int Laser_create_new( vms_vector * direction, vms_vector * position, int segnum,
 	if (Weapon_info[obj->id].thrust != 0)
 		weapon_speed /= 2;
 
-	if ((Game_mode & GM_MULTI) && Netgame.RebalancedWeapons) {
+	if ((Game_mode & GM_MULTI) && Netgame.OriginalD1Weapons) {
 		if (obj->id == SPREADFIRE_ID) {
 			weapon_speed = 200 * F1_0;
 		}
@@ -1305,7 +1305,7 @@ void Laser_player_fire_spread_delay(object *obj, int laser_type, int gun_num, fi
 	vm_vec_add(&LaserPos,&obj->pos,&gun_point);
 
 	fix weapon_speed = Weapon_info[laser_type].speed[Difficulty_level];
-	if ((Game_mode & GM_MULTI) && Netgame.RebalancedWeapons) {
+	if ((Game_mode & GM_MULTI) && Netgame.OriginalD1Weapons) {
 		if (laser_type == SPREADFIRE_ID) {
 			weapon_speed = 200 * F1_0;
 		}
@@ -1572,7 +1572,7 @@ void Laser_do_weapon_sequence(object *obj, int doHomerFrame, fix idealHomerFrame
 				temp_vec = obj->mtype.phys_info.velocity;
 				speed = vm_vec_normalize_quick(&temp_vec);
 				max_speed = Weapon_info[obj->id].speed[Difficulty_level];
-				if ((Game_mode & GM_MULTI) && Netgame.RebalancedWeapons) {
+				if ((Game_mode & GM_MULTI) && Netgame.OriginalD1Weapons) {
 					if (obj->id == SPREADFIRE_ID) {
 						max_speed = 200 * F1_0;
 					}
@@ -1655,7 +1655,7 @@ void Laser_do_weapon_sequence(object *obj, int doHomerFrame, fix idealHomerFrame
 		fix	weapon_speed;
 
 		fix max_weapon_speed = Weapon_info[obj->id].speed[Difficulty_level];
-		if ((Game_mode & GM_MULTI) && Netgame.RebalancedWeapons) {
+		if ((Game_mode & GM_MULTI) && Netgame.OriginalD1Weapons) {
 			if (obj->id == SPREADFIRE_ID) {
 				max_weapon_speed = 200 * F1_0;
 			}

--- a/d2/main/laser.c
+++ b/d2/main/laser.c
@@ -161,6 +161,10 @@ int laser_are_related( int o1, int o2 )
 			if ((Objects[o1].id == PHOENIX_ID && (GameTime64 > Objects[o1].ctype.laser_info.creation_time + F1_0/4)) ||
 			   (Objects[o1].id == GUIDEDMISS_ID && (GameTime64 > Objects[o1].ctype.laser_info.creation_time + F1_0*2)) ||
 				(((Objects[o1].id == PROXIMITY_ID) || (Objects[o1].id == SUPERPROX_ID)) && (GameTime64 > Objects[o1].ctype.laser_info.creation_time + F1_0*4))) {
+				// Rebalanced Phoenix: It won't hit you until it's bounced at least once
+				if (Objects[o1].id == PHOENIX_ID && (Game_mode & GM_MULTI) && Netgame.RebalancedWeapons &&
+					(Objects[o1].mtype.phys_info.flags & PF_BOUNCES_TWICE) && !(Objects[o1].mtype.phys_info.flags & PF_BOUNCED_ONCE))
+					return 1;
 				return 0;
 			} else
 				return 1;

--- a/d2/main/laser.c
+++ b/d2/main/laser.c
@@ -1715,7 +1715,7 @@ void do_laser_firing_player(void)
 
 	if ((Game_mode & GM_MULTI) && Netgame.RebalancedWeapons) {
 		if (weapon_id == GAUSS_ID)
-			ammo_used *= 10; // 2 -> 20
+			ammo_used *= 3; // 2 -> 6
 	}
 
 	primary_ammo = (Players[Player_num].primary_weapon == GAUSS_INDEX)?(plp->primary_ammo[VULCAN_INDEX]):(plp->primary_ammo[Players[Player_num].primary_weapon]);

--- a/d2/main/laser.h
+++ b/d2/main/laser.h
@@ -156,6 +156,7 @@ extern muzzle_info Muzzle_data[MUZZLE_QUEUE_MAX];
 extern fix Omega_charge;
 // NOTE: OMEGA_CHARGE_SCALE moved to laser.c to avoid long rebuilds if changed
 extern int ok_to_do_omega_damage(struct object *weapon);
+fix get_rebalance_omega_damage_scale(struct object* weapon);
 
 static inline int is_proximity_bomb_or_smart_mine(enum weapon_type_t id)
 {

--- a/d2/main/laser.h
+++ b/d2/main/laser.h
@@ -156,7 +156,7 @@ extern muzzle_info Muzzle_data[MUZZLE_QUEUE_MAX];
 extern fix Omega_charge;
 // NOTE: OMEGA_CHARGE_SCALE moved to laser.c to avoid long rebuilds if changed
 extern int ok_to_do_omega_damage(struct object *weapon);
-fix get_rebalance_omega_damage_scale(struct object* weapon);
+fix get_rebalanced_omega_damage_scale(struct object* weapon);
 
 static inline int is_proximity_bomb_or_smart_mine(enum weapon_type_t id)
 {

--- a/d2/main/multi.h
+++ b/d2/main/multi.h
@@ -570,7 +570,7 @@ typedef struct netgame_info
 	ubyte						DarkSmartBlobs;
 	ubyte						LowVulcan;
 	ubyte						AllowPreferredColors;
-	ubyte						RebalancedWeapons;
+	ubyte						OriginalD1Weapons;
 #ifdef USE_TRACKER
 	ubyte						Tracker;
 #endif
@@ -580,6 +580,7 @@ typedef struct netgame_info
 	ubyte						ReducedFlash;
 	ubyte						DisableGaussSplash;
 	ubyte						team_color[2];
+	ubyte						RebalancedWeapons;
 } __pack__ netgame_info;
 
 extern int Host_is_obs; // Reminder for host only that they are an observer.  Do not set for other players or observers.

--- a/d2/main/multi.h
+++ b/d2/main/multi.h
@@ -570,7 +570,7 @@ typedef struct netgame_info
 	ubyte						DarkSmartBlobs;
 	ubyte						LowVulcan;
 	ubyte						AllowPreferredColors;
-	ubyte						OriginalD1Weapons;
+	ubyte						RebalancedWeapons;
 #ifdef USE_TRACKER
 	ubyte						Tracker;
 #endif

--- a/d2/main/net_udp.c
+++ b/d2/main/net_udp.c
@@ -3065,7 +3065,7 @@ void net_udp_send_game_info(struct _sockaddr sender_addr, ubyte info_upid, ubyte
 		buf[len] = Netgame.AllowPreferredColors;                len++;
 		buf[len] = Netgame.BornWithBurner;						len++; 
 		buf[len] = Netgame.GaussAmmoStyle;						len++; 
-		buf[len] = Netgame.RebalancedWeapons;                   len++;
+		buf[len] = Netgame.OriginalD1Weapons;                   len++;
 		buf[len] = Netgame.obs_min; len++;
 		buf[len] = Netgame.host_is_obs; len++;
 		buf[len] = Netgame.HomingUpdateRate; len++;
@@ -3075,6 +3075,7 @@ void net_udp_send_game_info(struct _sockaddr sender_addr, ubyte info_upid, ubyte
 		buf[len] = Netgame.DisableGaussSplash; len++;
 		buf[len] = Netgame.team_color[0];						len++;
 		buf[len] = Netgame.team_color[1];						len++;
+		buf[len] = Netgame.RebalancedWeapons; len++;
 
 		if(info_upid == UPID_SYNC) {
 			PUT_INTEL_INT(buf + len, player_tokens[to_player]); len += 4; 
@@ -3316,7 +3317,7 @@ int net_udp_process_game_info(ubyte *data, int data_len, struct _sockaddr game_a
 		Netgame.AllowPreferredColors = data[len];                len++; 
 		Netgame.BornWithBurner = data[len];                len++; 		
 		Netgame.GaussAmmoStyle = data[len];                len++;
-		Netgame.RebalancedWeapons = data[len];             len++;
+		Netgame.OriginalD1Weapons = data[len];             len++;
 		Netgame.obs_min = data[len]; len++;
 		Netgame.host_is_obs = data[len]; len++;
 		Netgame.HomingUpdateRate = data[len]; len++;
@@ -3326,6 +3327,7 @@ int net_udp_process_game_info(ubyte *data, int data_len, struct _sockaddr game_a
 		Netgame.DisableGaussSplash = data[len]; len++;
 		Netgame.team_color[0] = data[len];						len++;
 		Netgame.team_color[1] = data[len];						len++;
+		Netgame.RebalancedWeapons = data[len]; len++;
 
 		if (Netgame.host_is_obs) {
 			multi_make_player_ghost(0);
@@ -3827,7 +3829,7 @@ static int opt_difficulty,opt_packets,opt_shortpack,opt_bright, opt_show_names, 
 static int opt_primary_dup, opt_secondary_dup, opt_secondary_cap; 
 static int opt_spawn_no_invul, opt_spawn_short_invul, opt_spawn_long_invul, opt_spawn_preview; 
 static int opt_burner_spawn; 
-static int opt_allowprefcolor, opt_ow;
+static int opt_allowprefcolor, opt_ow, opt_rw;
 //static int opt_dark_smarts;
 static int opt_low_vulcan;
 static int opt_gauss_duplicating, opt_gauss_depleting, opt_gauss_steady_recharge, opt_gauss_steady_respawn; 
@@ -3869,9 +3871,9 @@ void net_udp_more_game_options ()
 	char HomingUpdateRateText[80];
 	
 #ifdef USE_TRACKER
-	newmenu_item m[49];
+	newmenu_item m[50];
 #else
-	newmenu_item m[48];
+	newmenu_item m[49];
 #endif
 
 	snprintf(packstring,sizeof(char)*4,"%d",Netgame.PacketsPerSec);
@@ -3940,7 +3942,10 @@ void net_udp_more_game_options ()
 	m[opt].type = NM_TYPE_CHECK; m[opt].text = "Low Vulcan Ammo"; m[opt].value = Netgame.LowVulcan; opt++;	
 
 	opt_ow = opt;
-	m[opt].type = NM_TYPE_CHECK; m[opt].text = "Rebalanced Weapons"; m[opt].value = Netgame.RebalancedWeapons; opt++;
+	m[opt].type = NM_TYPE_CHECK; m[opt].text = "Original D1 Weapons"; m[opt].value = Netgame.OriginalD1Weapons; opt++;
+
+	opt_rw = opt;
+	m[opt].type = NM_TYPE_CHECK; m[opt].text = "Rebalanced Weapons (beta)"; m[opt].value = Netgame.RebalancedWeapons; opt++;
 
 
 	m[opt].type = NM_TYPE_TEXT; m[opt].text = ""; opt++;
@@ -4087,12 +4092,13 @@ menu:
 	//Netgame.DarkSmartBlobs = m[opt_dark_smarts].value;
 	Netgame.LowVulcan = m[opt_low_vulcan].value;
 	Netgame.AllowPreferredColors = m[opt_allowprefcolor].value;
-	Netgame.RebalancedWeapons = m[opt_ow].value;
+	Netgame.OriginalD1Weapons = m[opt_ow].value;
 	Netgame.HomingUpdateRate = m[opt_homing_update_rate].value + 20;
 	Netgame.RemoteHitSpark = m[opt_remote_hit_spark].value;
 	Netgame.AllowCustomModelsTextures = m[opt_allow_custom_models_textures].value;
 	Netgame.ReducedFlash = m[opt_reduced_flash].value;
 	Netgame.DisableGaussSplash = m[opt_disable_gauss_splash].value;
+	Netgame.RebalancedWeapons = m[opt_rw].value;
 }
 
 int net_udp_more_options_handler( newmenu *menu, d_event *event, void *userdata )
@@ -4402,12 +4408,13 @@ void netgame_set_defaults()
 	Netgame.GaussAmmoStyle = GAUSS_STYLE_STEADY_RECHARGING;
 	Netgame.LowVulcan = 0; 
 	Netgame.AllowPreferredColors = 0;
-	Netgame.RebalancedWeapons = 0;
+	Netgame.OriginalD1Weapons = 0;
 	Netgame.HomingUpdateRate = 25;
 	Netgame.RemoteHitSpark = 0;
 	Netgame.AllowCustomModelsTextures = 0;
 	Netgame.ReducedFlash = 0;
 	Netgame.DisableGaussSplash = 0;
+	Netgame.RebalancedWeapons = 0;
 
 #ifdef USE_TRACKER
 	Netgame.Tracker = 1;

--- a/d2/main/net_udp.c
+++ b/d2/main/net_udp.c
@@ -3065,7 +3065,7 @@ void net_udp_send_game_info(struct _sockaddr sender_addr, ubyte info_upid, ubyte
 		buf[len] = Netgame.AllowPreferredColors;                len++;
 		buf[len] = Netgame.BornWithBurner;						len++; 
 		buf[len] = Netgame.GaussAmmoStyle;						len++; 
-		buf[len] = Netgame.OriginalD1Weapons;                   len++;
+		buf[len] = Netgame.RebalancedWeapons;                   len++;
 		buf[len] = Netgame.obs_min; len++;
 		buf[len] = Netgame.host_is_obs; len++;
 		buf[len] = Netgame.HomingUpdateRate; len++;
@@ -3316,7 +3316,7 @@ int net_udp_process_game_info(ubyte *data, int data_len, struct _sockaddr game_a
 		Netgame.AllowPreferredColors = data[len];                len++; 
 		Netgame.BornWithBurner = data[len];                len++; 		
 		Netgame.GaussAmmoStyle = data[len];                len++;
-		Netgame.OriginalD1Weapons = data[len];             len++; 
+		Netgame.RebalancedWeapons = data[len];             len++;
 		Netgame.obs_min = data[len]; len++;
 		Netgame.host_is_obs = data[len]; len++;
 		Netgame.HomingUpdateRate = data[len]; len++;
@@ -3940,7 +3940,7 @@ void net_udp_more_game_options ()
 	m[opt].type = NM_TYPE_CHECK; m[opt].text = "Low Vulcan Ammo"; m[opt].value = Netgame.LowVulcan; opt++;	
 
 	opt_ow = opt;
-	m[opt].type = NM_TYPE_CHECK; m[opt].text = "Original D1 Weapons"; m[opt].value = Netgame.OriginalD1Weapons; opt++;	
+	m[opt].type = NM_TYPE_CHECK; m[opt].text = "Rebalanced Weapons"; m[opt].value = Netgame.RebalancedWeapons; opt++;
 
 
 	m[opt].type = NM_TYPE_TEXT; m[opt].text = ""; opt++;
@@ -4087,7 +4087,7 @@ menu:
 	//Netgame.DarkSmartBlobs = m[opt_dark_smarts].value;
 	Netgame.LowVulcan = m[opt_low_vulcan].value;
 	Netgame.AllowPreferredColors = m[opt_allowprefcolor].value;
-	Netgame.OriginalD1Weapons = m[opt_ow].value;
+	Netgame.RebalancedWeapons = m[opt_ow].value;
 	Netgame.HomingUpdateRate = m[opt_homing_update_rate].value + 20;
 	Netgame.RemoteHitSpark = m[opt_remote_hit_spark].value;
 	Netgame.AllowCustomModelsTextures = m[opt_allow_custom_models_textures].value;
@@ -4402,7 +4402,7 @@ void netgame_set_defaults()
 	Netgame.GaussAmmoStyle = GAUSS_STYLE_STEADY_RECHARGING;
 	Netgame.LowVulcan = 0; 
 	Netgame.AllowPreferredColors = 0;
-	Netgame.OriginalD1Weapons = 0;
+	Netgame.RebalancedWeapons = 0;
 	Netgame.HomingUpdateRate = 25;
 	Netgame.RemoteHitSpark = 0;
 	Netgame.AllowCustomModelsTextures = 0;

--- a/d2/main/net_udp.h
+++ b/d2/main/net_udp.h
@@ -50,7 +50,7 @@ void net_udp_send_obs_quit();
 #define UPID_GAME_INFO_REQ_SIZE			 13
 #define UPID_GAME_INFO_LITE_REQ_SIZE		 11
 #define UPID_GAME_INFO				  3 // Packet containing all info about a netgame.
-#define UPID_GAME_INFO_SIZE			(6 + 4*2 + 367 + (NETGAME_NAME_LEN+1) + (MISSION_NAME_LEN+1) + ((MAX_PLAYERS+4)*(CALLSIGN_LEN+1)) + 20*12)
+#define UPID_GAME_INFO_SIZE			(6 + 4*2 + 368 + (NETGAME_NAME_LEN+1) + (MISSION_NAME_LEN+1) + ((MAX_PLAYERS+4)*(CALLSIGN_LEN+1)) + 20*12)
 #define UPID_GAME_INFO_LITE_REQ			  4 // Requesting lite info about a netgame. Used for discovering games.
 #define UPID_GAME_INFO_LITE			  5 // Packet containing lite netgame info.
 #define UPID_GAME_INFO_LITE_SIZE		 (31 + (NETGAME_NAME_LEN+1) + (MISSION_NAME_LEN+1))

--- a/d2/main/physics.c
+++ b/d2/main/physics.c
@@ -662,9 +662,9 @@ void do_physics_sim(object *obj)
 
 						if (bounced && (Game_mode & GM_MULTI) && Netgame.RebalancedWeapons) {
 							if (obj->type == OBJ_WEAPON && obj->id == PHOENIX_ID) {
-								// Halve power and reduce speed by 10%
+								// Halve power and reduce speed by 20%
 								obj->shields /= 2;
-								vm_vec_scale2(&obj->mtype.phys_info.velocity, 9, 10);
+								vm_vec_scale2(&obj->mtype.phys_info.velocity, 8, 10);
 							}
 						}
 

--- a/d2/main/physics.c
+++ b/d2/main/physics.c
@@ -660,6 +660,14 @@ void do_physics_sim(object *obj)
 
 						vm_vec_scale_add2(&obj->mtype.phys_info.velocity,&hit_info.hit_wallnorm,-wall_part);
 
+						if (bounced && (Game_mode & GM_MULTI) && Netgame.RebalancedWeapons) {
+							if (obj->type == OBJ_WEAPON && obj->id == PHOENIX_ID) {
+								// Halve power and reduce speed by 10%
+								obj->shields /= 2;
+								vm_vec_scale2(&obj->mtype.phys_info.velocity, 9, 10);
+							}
+						}
+
 						if (check_vel) {
 							fix vel = vm_vec_mag_quick(&obj->mtype.phys_info.velocity);
 

--- a/d2/main/playsave.c
+++ b/d2/main/playsave.c
@@ -1300,7 +1300,7 @@ int read_netgame_settings_file(const char *filename, netgame_info *ng, int no_na
 			else if (!strcmp(token, "BornWithBurner"))
 				ng->BornWithBurner = strtol(value, NULL, 10);	
 			else if (!strcmp(token, "OriginalD1Weapons"))
-				ng->OriginalD1Weapons = strtol(value, NULL, 10);
+				ng->RebalancedWeapons = strtol(value, NULL, 10);
 			else if (!strcmp(token, "PrimaryDupFactor"))
 				ng->PrimaryDupFactor = strtol(value, NULL, 10);
 			else if (!strcmp(token, "SecondaryDupFactor"))
@@ -1384,7 +1384,7 @@ int write_netgame_settings_file(const char *filename, netgame_info *ng, int no_n
 	PHYSFSX_printf(file, "FairColors=%i\n", ng->FairColors);
 	PHYSFSX_printf(file, "BlackAndWhitePyros=%i\n", ng->BlackAndWhitePyros);
 	PHYSFSX_printf(file, "BornWithBurner=%i\n", ng->BornWithBurner);
-	PHYSFSX_printf(file, "OriginalD1Weapons=%i\n", ng->OriginalD1Weapons);
+	PHYSFSX_printf(file, "OriginalD1Weapons=%i\n", ng->RebalancedWeapons);
 	PHYSFSX_printf(file, "PrimaryDupFactor=%i\n", ng->PrimaryDupFactor);
 	PHYSFSX_printf(file, "SecondaryDupFactor=%i\n", ng->SecondaryDupFactor);
 	PHYSFSX_printf(file, "SecondaryCapFactor=%i\n", ng->SecondaryCapFactor);

--- a/d2/main/playsave.c
+++ b/d2/main/playsave.c
@@ -1300,6 +1300,8 @@ int read_netgame_settings_file(const char *filename, netgame_info *ng, int no_na
 			else if (!strcmp(token, "BornWithBurner"))
 				ng->BornWithBurner = strtol(value, NULL, 10);	
 			else if (!strcmp(token, "OriginalD1Weapons"))
+				ng->OriginalD1Weapons = strtol(value, NULL, 10);
+			else if (!strcmp(token, "RebalancedWeapons"))
 				ng->RebalancedWeapons = strtol(value, NULL, 10);
 			else if (!strcmp(token, "PrimaryDupFactor"))
 				ng->PrimaryDupFactor = strtol(value, NULL, 10);
@@ -1384,7 +1386,8 @@ int write_netgame_settings_file(const char *filename, netgame_info *ng, int no_n
 	PHYSFSX_printf(file, "FairColors=%i\n", ng->FairColors);
 	PHYSFSX_printf(file, "BlackAndWhitePyros=%i\n", ng->BlackAndWhitePyros);
 	PHYSFSX_printf(file, "BornWithBurner=%i\n", ng->BornWithBurner);
-	PHYSFSX_printf(file, "OriginalD1Weapons=%i\n", ng->RebalancedWeapons);
+	PHYSFSX_printf(file, "OriginalD1Weapons=%i\n", ng->OriginalD1Weapons);
+	PHYSFSX_printf(file, "RebalancedWeapons=%i\n", ng->RebalancedWeapons);
 	PHYSFSX_printf(file, "PrimaryDupFactor=%i\n", ng->PrimaryDupFactor);
 	PHYSFSX_printf(file, "SecondaryDupFactor=%i\n", ng->SecondaryDupFactor);
 	PHYSFSX_printf(file, "SecondaryCapFactor=%i\n", ng->SecondaryCapFactor);

--- a/d2/main/weapon.c
+++ b/d2/main/weapon.c
@@ -177,7 +177,10 @@ int player_has_weapon(ubyte pnum, int weapon_num, int secondary_flag)
 
 		// Special case: Gauss cannon uses vulcan ammo.
 		if (weapon_num == GAUSS_INDEX) {
-			if (Weapon_info[weapon_index].ammo_usage <= Players[pnum].primary_ammo[VULCAN_INDEX])
+			int ammo_usage = Weapon_info[weapon_index].ammo_usage;
+			if ((Game_mode & GM_MULTI) && Netgame.RebalancedWeapons)
+				ammo_usage *= 3; // 2 -> 6
+			if (ammo_usage <= Players[pnum].primary_ammo[VULCAN_INDEX])
 				return_value |= HAS_AMMO_FLAG;
 		} else
 			if (Weapon_info[weapon_index].ammo_usage <= Players[pnum].primary_ammo[weapon_num])


### PR DESCRIPTION
I was working on replacing the "Original D1 Weapons" option in D2 multiplayer games with one that also tweaks D2 weapons to mitigate some of the balancing problems with them. However, exactly what these changes should be is difficult for the community to agree on without playing with them, and it's proven to be difficult to do that with unofficial builds.

I figured a solution might be to just add it as a _separate_ option (not replacing Original D1 Weapons) but in the main Redux release so that it's easier for players to test it. I denoted it as "beta" because I believe the alterations are likely to change in future depending on feedback.

Naturally these changes are D2 only.