### PR TITLE
Increment D2 protocol version for 1.2

### DIFF
--- a/d2/main/multi.h
+++ b/d2/main/multi.h
@@ -60,7 +60,7 @@ extern int multi_protocol; // set and determinate used protocol
 #define MULTI_PROTO_UDP 1 // UDP protocol
 
 // What version of the multiplayer protocol is this? Increment each time something drastic changes in Multiplayer without the version number changes. Can be reset to 0 each time the version of the game changes
-#define MULTI_PROTO_VERSION 30005 // Redux 1.1
+#define MULTI_PROTO_VERSION 30006 // Redux 1.2
 
 // PROTOCOL VARIABLES AND DEFINES - END
 


### PR DESCRIPTION
The weapon rebalance toggle (#182) changes the netgame protocol for D2, so we'll need to change the protocol version number.
I'm just doing this for D2 for now since protocol changes for D1 haven't yet hit. (I expect they will soon though, since I'm testing a respawn algorithm option that will affect both games.)