### PR TITLE
Send more info to tracker(s) about game events.

### DIFF
--- a/d1/main/fireball.c
+++ b/d1/main/fireball.c
@@ -194,6 +194,12 @@ object *object_create_explosion_sub(object *objp, short segnum, vms_vector * pos
 										con_printf(CON_NORMAL, "You took %.1f damage from %s's %s blast, shields now %.1f\n", f2fl(damage), killer_name, weapon_name, f2fl(Players[Player_num].shields - damage));
 										
 										multi_send_damage(damage, obj0p->shields, killer->type, killer->id, DAMAGE_BLAST, objp);
+										
+										// Record explosion kill (missile, smart, mega, etc.)
+										if (obj0p->shields - damage < 0 && objp != NULL && objp->type == OBJ_WEAPON)
+										{
+											multi_record_killer_weapon(obj0p->id, 0, objp->id);  // 0 = weapon kill
+										}
 									} else if ((obj0p->id == Player_num) && (! Player_is_dead)) {
 										con_printf(CON_NORMAL, "You took %.1f damage from a %s blast, shields now %.1f\n",
 											f2fl(damage),
@@ -201,6 +207,15 @@ object *object_create_explosion_sub(object *objp, short segnum, vms_vector * pos
 											f2fl(Players[Player_num].shields - damage));
 
 										multi_send_damage(damage, obj0p->shields, obj_type, 0, DAMAGE_BLAST, objp);
+										
+										// Record explosion kill from environment/other sources
+										if (obj0p->shields - damage < 0)
+										{
+											if (objp != NULL && objp->type == OBJ_WEAPON)
+												multi_record_killer_weapon(obj0p->id, 0, objp->id);  // Weapon explosion
+											else
+												multi_record_killer_weapon(obj0p->id, 3, obj_type);  // 3 = environment
+										}
 									}
 
 									// Explosions CAN be friendly fire.

--- a/d1/main/multi.c
+++ b/d1/main/multi.c
@@ -1333,6 +1333,14 @@ void multi_compute_kill(int killer, int killed)
 
 	multi_sort_kill_list();
 	multi_show_player_list();
+	
+	// Send gamelog kill event to all players for synchronization
+	if (Game_mode & GM_NETWORK)
+	{
+		// TODO: Extract actual weapon type and ID from killer object
+		// For now, pass 0 as placeholders
+		net_udp_send_gamelog_kill(killer_pnum, killed_pnum, 0, 0);
+	}
 }
 
 void multi_do_protocol_frame(int force, int listen)
@@ -3466,6 +3474,13 @@ multi_send_message(void)
 		strncpy((char*)multibuf+loc, Network_message, MAX_MESSAGE_LEN); loc += MAX_MESSAGE_LEN;
 		multibuf[loc-1] = '\0';
 		multi_send_data(multibuf, loc, 0);
+		
+		// Send gamelog chat event to all players for synchronization
+		if (Game_mode & GM_NETWORK)
+		{
+			net_udp_send_gamelog_chat(Player_num, Network_message);
+		}
+		
 		Network_message_reciever = -1;
 	}
 }

--- a/d1/main/multi.c
+++ b/d1/main/multi.c
@@ -28,6 +28,10 @@ COPYRIGHT 1993-1998 PARALLAX SOFTWARE CORPORATION.  ALL RIGHTS RESERVED.
 #include "fuelcen.h"
 #include "scores.h"
 #include "gauges.h"
+
+// Track the weapon that caused each player's death for accurate gamelog reporting
+static int player_killer_weapon_type[MAX_PLAYERS];
+static int player_killer_weapon_id[MAX_PLAYERS];
 #include "collide.h"
 #include "dxxerror.h"
 #include "fireball.h"
@@ -153,6 +157,16 @@ const char GMNamesShrt[MULTI_GAME_TYPE_COUNT][8]={
 	"UNKNOWN",
 	"BOUNTY"
 };
+
+// Record the weapon that killed a player (called from collision detection)
+void multi_record_killer_weapon(int player_num, int weapon_type, int weapon_id)
+{
+	if (player_num >= 0 && player_num < MAX_PLAYERS)
+	{
+		player_killer_weapon_type[player_num] = weapon_type;
+		player_killer_weapon_id[player_num] = weapon_id;
+	}
+}
 
 int Current_obs_player = OBSERVER_PLAYER_ID; // Current player being observed. Defaults to the observer player ID.
 bool Obs_at_distance = 0; // True if you're viewing the player from a cube back.
@@ -1337,9 +1351,15 @@ void multi_compute_kill(int killer, int killed)
 	// Send gamelog kill event to all players for synchronization
 	if (Game_mode & GM_NETWORK)
 	{
-		// TODO: Extract actual weapon type and ID from killer object
-		// For now, pass 0 as placeholders
-		net_udp_send_gamelog_kill(killer_pnum, killed_pnum, 0, 0);
+		// Use the tracked weapon info set at the point of impact
+		int weapon_type = player_killer_weapon_type[killed_pnum];
+		int weapon_id = player_killer_weapon_id[killed_pnum];
+		
+		// Clear the tracking after use
+		player_killer_weapon_type[killed_pnum] = 3;  // Default to environment
+		player_killer_weapon_id[killed_pnum] = 0;
+		
+		net_udp_send_gamelog_kill(killer_pnum, killed_pnum, weapon_type, weapon_id);
 	}
 }
 
@@ -1957,21 +1977,6 @@ void multi_send_message_end()
 	Network_message_reciever = 100;
 	HUD_init_message(HM_MULTI, "%s '%s'", TXT_SENDING, Network_message);
 	multi_send_message();
-	
-	// Relay chat to tracker for logging
-	if (Game_mode & GM_NETWORK)
-	{
-		switch (multi_protocol)
-		{
-#ifdef USE_UDP
-			case MULTI_PROTO_UDP:
-				net_udp_send_gamelog_chat(Player_num, Network_message);
-				break;
-#endif
-			default:
-				break;
-		}
-	}
 	
 	multi_message_feedback();
 	game_flush_inputs();

--- a/d1/main/multi.c
+++ b/d1/main/multi.c
@@ -1957,6 +1957,22 @@ void multi_send_message_end()
 	Network_message_reciever = 100;
 	HUD_init_message(HM_MULTI, "%s '%s'", TXT_SENDING, Network_message);
 	multi_send_message();
+	
+	// Relay chat to tracker for logging
+	if (Game_mode & GM_NETWORK)
+	{
+		switch (multi_protocol)
+		{
+#ifdef USE_UDP
+			case MULTI_PROTO_UDP:
+				net_udp_send_gamelog_chat(Player_num, Network_message);
+				break;
+#endif
+			default:
+				break;
+		}
+	}
+	
 	multi_message_feedback();
 	game_flush_inputs();
 }

--- a/d1/main/multi.h
+++ b/d1/main/multi.h
@@ -250,6 +250,7 @@ void multi_send_play_sound(int sound_num, fix volume);
 void multi_send_audio_taunt(int taunt_num);
 void multi_send_score(void);
 void multi_send_trigger(int trigger);
+void multi_record_killer_weapon(int player_num, int weapon_type, int weapon_id);
 void multi_send_hostage_door_status(int wallnum);
 void multi_send_damage(fix damage, fix shields, ubyte killer_type, ubyte killer_id, ubyte damage_type, object* source);
 void multi_do_damage( const ubyte *buf );

--- a/d1/main/net_udp.c
+++ b/d1/main/net_udp.c
@@ -7708,6 +7708,14 @@ void net_udp_send_gamelog_kill(int killer_id, int killed_id, int weapon_type, in
 	buf[len] = (ubyte)weapon_type; len++;
 	buf[len] = (ubyte)weapon_id; len++;
 	
+	// Send to tracker
+#ifdef USE_TRACKER
+	if (GameArg.MplTrackerAddr && GameArg.MplTrackerAddr[0])
+	{
+		dxx_sendto(UDP_Socket[2], buf, len, 0, (struct sockaddr *)&TrackerSocket, sizeof(TrackerSocket));
+	}
+#endif
+	
 	// Send to all players
 	for (int i = 1; i < N_players; i++)
 	{
@@ -7746,6 +7754,14 @@ void net_udp_send_gamelog_chat(int player_id, const char *message)
 	memcpy(&buf[len], message, msg_len);
 	len += msg_len;
 	buf[len] = '\0'; len++;
+	
+	// Send to tracker
+#ifdef USE_TRACKER
+	if (GameArg.MplTrackerAddr && GameArg.MplTrackerAddr[0])
+	{
+		dxx_sendto(UDP_Socket[2], buf, len, 0, (struct sockaddr *)&TrackerSocket, sizeof(TrackerSocket));
+	}
+#endif
 	
 	// Send to all players
 	for (int i = 1; i < N_players; i++)

--- a/d1/main/net_udp.c
+++ b/d1/main/net_udp.c
@@ -146,7 +146,11 @@ void resetProxy(int pnum);
 void update_address_for_player(int pnum, struct _sockaddr new_addr); 
 void net_udp_send_p2p_reattempt_direct (int to_player, int connect_to_player);
 void net_udp_process_p2p_reattempt_direct (ubyte *data, struct _sockaddr sender_addr, int data_len);
-void drop_rx_packet(ubyte  *data, char* reason); 
+void drop_rx_packet(ubyte  *data, char* reason);
+void net_udp_send_gamelog_kill(int killer_id, int killed_id, int weapon_type, int weapon_id);
+void net_udp_send_gamelog_chat(int player_id, const char *message);
+void net_udp_process_gamelog_kill(ubyte *data, int data_len);
+void net_udp_process_gamelog_chat(ubyte *data, int data_len); 
 
 void forward_to_observers(ubyte *data, int data_len, int needack);
 void check_observers(fix64 now);
@@ -3553,7 +3557,15 @@ void net_udp_process_packet(ubyte *data, struct _sockaddr sender_addr, int lengt
 
 		case UPID_REATTEMPT_DIRECT:
 			net_udp_process_p2p_reattempt_direct( data, sender_addr, length);
-			break; 
+			break;
+
+		case UPID_GAMELOG_KILL:
+			net_udp_process_gamelog_kill(data, length);
+			break;
+
+		case UPID_GAMELOG_CHAT:
+			net_udp_process_gamelog_chat(data, length);
+			break;
 
 		default:
 			con_printf(CON_DEBUG, "unknown packet type received - type %i\n", data[0]);
@@ -7675,6 +7687,135 @@ void net_udp_process_obs_quit(ubyte *data, int data_len, struct _sockaddr sender
 	memset(&Netgame.observers[obsnum], 0, sizeof(netplayer_info));
 	Netgame.numobservers--;
 	multi_send_obs_update(1, 0);
+}
+
+// Send kill event to all players for gamelog synchronization
+void net_udp_send_gamelog_kill(int killer_id, int killed_id, int weapon_type, int weapon_id)
+{
+	if (!multi_i_am_master())
+		return;
+	
+	ubyte buf[UPID_GAMELOG_KILL_SIZE];
+	int len = 0;
+	
+	buf[len] = UPID_GAMELOG_KILL; len++;
+	
+	// Send timestamp as fix64 (8 bytes)
+	memcpy(buf + len, &GameTime64, sizeof(fix64)); len += sizeof(fix64);
+	
+	buf[len] = (ubyte)killer_id; len++;
+	buf[len] = (ubyte)killed_id; len++;
+	buf[len] = (ubyte)weapon_type; len++;
+	buf[len] = (ubyte)weapon_id; len++;
+	
+	// Send to all players
+	for (int i = 1; i < N_players; i++)
+	{
+		if (Players[i].connected == CONNECT_PLAYING)
+			dxx_sendto(UDP_Socket[0], buf, len, 0, (struct sockaddr *)&Netgame.players[i].protocol.udp.addr, sizeof(struct _sockaddr));
+	}
+	
+	// Also forward to observers
+	for (int i = 0; i < Netgame.max_numobservers; i++)
+	{
+		if (Netgame.observers[i].connected)
+			dxx_sendto(UDP_Socket[0], buf, len, 0, (struct sockaddr *)&Netgame.observers[i].protocol.udp.addr, sizeof(struct _sockaddr));
+	}
+}
+
+// Send chat message to all players for gamelog synchronization
+void net_udp_send_gamelog_chat(int player_id, const char *message)
+{
+	if (!multi_i_am_master())
+		return;
+	
+	ubyte buf[128];
+	int len = 0;
+	
+	buf[len] = UPID_GAMELOG_CHAT; len++;
+	
+	// Send timestamp as fix64 (8 bytes)
+	memcpy(buf + len, &GameTime64, sizeof(fix64)); len += sizeof(fix64);
+	
+	buf[len] = (ubyte)player_id; len++;
+	
+	// Copy message
+	int msg_len = strlen(message);
+	if (msg_len > MAX_MESSAGE_LEN - 1)
+		msg_len = MAX_MESSAGE_LEN - 1;
+	memcpy(&buf[len], message, msg_len);
+	len += msg_len;
+	buf[len] = '\0'; len++;
+	
+	// Send to all players
+	for (int i = 1; i < N_players; i++)
+	{
+		if (Players[i].connected == CONNECT_PLAYING)
+			dxx_sendto(UDP_Socket[0], buf, len, 0, (struct sockaddr *)&Netgame.players[i].protocol.udp.addr, sizeof(struct _sockaddr));
+	}
+	
+	// Also forward to observers
+	for (int i = 0; i < Netgame.max_numobservers; i++)
+	{
+		if (Netgame.observers[i].connected)
+			dxx_sendto(UDP_Socket[0], buf, len, 0, (struct sockaddr *)&Netgame.observers[i].protocol.udp.addr, sizeof(struct _sockaddr));
+	}
+}
+
+// Process received kill event
+void net_udp_process_gamelog_kill(ubyte *data, int data_len)
+{
+	int len = 1; // Skip packet type
+	fix64 timestamp;
+	int killer_id, killed_id, weapon_type, weapon_id;
+	
+	if (data_len < UPID_GAMELOG_KILL_SIZE)
+		return;
+	
+	// Read timestamp
+	memcpy(&timestamp, data + len, sizeof(fix64)); len += sizeof(fix64);
+	
+	killer_id = data[len]; len++;
+	killed_id = data[len]; len++;
+	weapon_type = data[len]; len++;
+	weapon_id = data[len]; len++;
+	
+	// Log to game log if available
+	// This is processed by clients to keep their gamelogs synchronized
+	// The actual logging is handled by the existing gamelog system
+	
+	con_printf(CON_DEBUG, "Gamelog: Player %d killed Player %d with weapon %d (type %d) at time %d\n", 
+			   killer_id, killed_id, weapon_id, weapon_type, (int)timestamp);
+}
+
+// Process received chat message
+void net_udp_process_gamelog_chat(ubyte *data, int data_len)
+{
+	int len = 1; // Skip packet type
+	fix64 timestamp;
+	int player_id;
+	char message[MAX_MESSAGE_LEN];
+	
+	if (data_len < 10) // Minimum size check
+		return;
+	
+	// Read timestamp
+	memcpy(&timestamp, data + len, sizeof(fix64)); len += sizeof(fix64);
+	
+	player_id = data[len]; len++;
+	
+	// Copy message
+	int remaining = data_len - len;
+	if (remaining > MAX_MESSAGE_LEN - 1)
+		remaining = MAX_MESSAGE_LEN - 1;
+	memcpy(message, &data[len], remaining);
+	message[remaining] = '\0';
+	
+	// Log to game log if available
+	// This is processed by clients to keep their gamelogs synchronized
+	
+	con_printf(CON_DEBUG, "Gamelog: Player %d sent message at time %d: %s\n", 
+			   player_id, (int)timestamp, message);
 }
 
 #endif

--- a/d1/main/net_udp.h
+++ b/d1/main/net_udp.h
@@ -93,6 +93,9 @@ void net_udp_send_obs_quit();
 #define UPID_OBSDATA 29
 #define UPID_OBSQUIT 30
 #define UPID_OBSQUIT_SIZE (1 + 4 + 4)
+#define UPID_GAMELOG_KILL 31
+#define UPID_GAMELOG_KILL_SIZE (1 + 8 + 1 + 1 + 1 + 1)
+#define UPID_GAMELOG_CHAT 32
 
 // Structure keeping lite game infos (for netlist, etc.)
 typedef struct UDP_netgame_info_lite

--- a/d1/main/net_udp.h
+++ b/d1/main/net_udp.h
@@ -24,6 +24,8 @@ int net_udp_level_sync();
 void net_udp_send_mdata_direct(ubyte *data, int data_len, int pnum, int priority);
 void net_udp_send_netgame_update();
 void net_udp_send_obs_quit();
+void net_udp_send_gamelog_kill(int killer_id, int killed_id, int weapon_type, int weapon_id);
+void net_udp_send_gamelog_chat(int player_id, const char *message);
 
 // Some defines
 #ifdef IPv6

--- a/d2/main/fireball.c
+++ b/d2/main/fireball.c
@@ -277,6 +277,12 @@ object *object_create_explosion_sub(object *objp, short segnum, vms_vector * pos
 										con_printf(CON_NORMAL, "You took %.1f damage from %s's %s blast, shields now %.1f\n", f2fl(damage), killer_name, weapon_name, f2fl(Players[Player_num].shields - damage));
 
 										multi_send_damage(damage, obj0p->shields, killer->type, killer->id, DAMAGE_BLAST, objp);
+										
+										// Record explosion kill (missile, smart, mega, etc.)
+										if (obj0p->shields - damage < 0 && objp != NULL && objp->type == OBJ_WEAPON)
+										{
+											multi_record_killer_weapon(obj0p->id, 0, objp->id);  // 0 = weapon kill
+										}
 									} else if ((obj0p->id == Player_num) && (! Player_is_dead)) {
 										con_printf(CON_NORMAL, "You took %.1f damage from a %s blast, shields now %.1f\n",
 											f2fl(damage),
@@ -284,6 +290,15 @@ object *object_create_explosion_sub(object *objp, short segnum, vms_vector * pos
 											f2fl(Players[Player_num].shields - damage));
 
 										multi_send_damage(damage, obj0p->shields, obj_type, 0, DAMAGE_BLAST, objp);
+										
+										// Record explosion kill from environment/other sources
+										if (obj0p->shields - damage < 0)
+										{
+											if (objp != NULL && objp->type == OBJ_WEAPON)
+												multi_record_killer_weapon(obj0p->id, 0, objp->id);  // Weapon explosion
+											else
+												multi_record_killer_weapon(obj0p->id, 3, obj_type);  // 3 = environment
+										}
 									}
 
 									// Explosions CAN be friendly fire.

--- a/d2/main/multi.h
+++ b/d2/main/multi.h
@@ -288,6 +288,7 @@ void multi_send_play_sound(int sound_num, fix volume);
 void multi_send_audio_taunt(int taunt_num);
 void multi_send_score(void);
 void multi_send_trigger(int trigger);
+void multi_record_killer_weapon(int player_num, int weapon_type, int weapon_id);
 void multi_send_hostage_door_status(int wallnum);
 void multi_send_drop_weapon (int objnum,int seed);
 void multi_send_drop_marker (int player,vms_vector position,char messagenum,char text[]);

--- a/d2/main/net_udp.c
+++ b/d2/main/net_udp.c
@@ -151,6 +151,10 @@ void add_message_to_obs_buffer(ubyte *data, int data_len, int needack);
 void check_obs_buffer(fix64 now);
 void forward_to_observers_nodelay(ubyte *data, int data_len, int needack);
 void net_udp_process_obs_quit(ubyte *data, int data_len, struct _sockaddr sender_addr);
+void net_udp_send_gamelog_kill(int killer_id, int killed_id, int weapon_type, int weapon_id);
+void net_udp_send_gamelog_chat(int player_id, const char *message);
+void net_udp_process_gamelog_kill(ubyte *data, int data_len);
+void net_udp_process_gamelog_chat(ubyte *data, int data_len);
 
 void net_udp_reset_connection_statuses(); 
 
@@ -3605,6 +3609,14 @@ void net_udp_process_packet(ubyte *data, struct _sockaddr sender_addr, int lengt
 		case UPID_REATTEMPT_DIRECT:
 			net_udp_process_p2p_reattempt_direct( data, sender_addr, length);
 			break; 
+
+		case UPID_GAMELOG_KILL:
+			net_udp_process_gamelog_kill(data, length);
+			break;
+
+		case UPID_GAMELOG_CHAT:
+			net_udp_process_gamelog_chat(data, length);
+			break;
 
 		default:
 			con_printf(CON_DEBUG, "unknown packet type received - type %i\n", data[0]);
@@ -7846,4 +7858,148 @@ void net_udp_process_obs_quit(ubyte *data, int data_len, struct _sockaddr sender
 	memset(&Netgame.observers[obsnum], 0, sizeof(netplayer_info));
 	Netgame.numobservers--;
 	multi_send_obs_update(1, 0);
+}
+// Send kill event to all players for gamelog synchronization
+void net_udp_send_gamelog_kill(int killer_id, int killed_id, int weapon_type, int weapon_id)
+{
+	if (!multi_i_am_master())
+		return;
+	
+	ubyte buf[UPID_GAMELOG_KILL_SIZE];
+	int len = 0;
+	
+	buf[len] = UPID_GAMELOG_KILL; len++;
+	
+	// Send timestamp as fix64 (8 bytes)
+	memcpy(buf + len, &GameTime64, sizeof(fix64)); len += sizeof(fix64);
+	
+	buf[len] = (ubyte)killer_id; len++;
+	buf[len] = (ubyte)killed_id; len++;
+	buf[len] = (ubyte)weapon_type; len++;
+	buf[len] = (ubyte)weapon_id; len++;
+	
+	// Send to tracker
+#ifdef USE_TRACKER
+	if (GameArg.MplTrackerAddr && GameArg.MplTrackerAddr[0])
+	{
+		dxx_sendto(UDP_Socket[2], buf, len, 0, (struct sockaddr *)&TrackerSocket, sizeof(TrackerSocket));
+	}
+#endif
+	
+	// Send to all players
+	for (int i = 1; i < N_players; i++)
+	{
+		if (Players[i].connected == CONNECT_PLAYING)
+			dxx_sendto(UDP_Socket[0], buf, len, 0, (struct sockaddr *)&Netgame.players[i].protocol.udp.addr, sizeof(struct _sockaddr));
+	}
+	
+	// Also forward to observers
+	for (int i = 0; i < Netgame.max_numobservers; i++)
+	{
+		if (Netgame.observers[i].connected)
+			dxx_sendto(UDP_Socket[0], buf, len, 0, (struct sockaddr *)&Netgame.observers[i].protocol.udp.addr, sizeof(struct _sockaddr));
+	}
+}
+
+// Send chat message to all players for gamelog synchronization
+void net_udp_send_gamelog_chat(int player_id, const char *message)
+{
+	if (!multi_i_am_master())
+		return;
+	
+	ubyte buf[128];
+	int len = 0;
+	
+	buf[len] = UPID_GAMELOG_CHAT; len++;
+	
+	// Send timestamp as fix64 (8 bytes)
+	memcpy(buf + len, &GameTime64, sizeof(fix64)); len += sizeof(fix64);
+	
+	buf[len] = (ubyte)player_id; len++;
+	
+	// Copy message
+	int msg_len = strlen(message);
+	if (msg_len > MAX_MESSAGE_LEN - 1)
+		msg_len = MAX_MESSAGE_LEN - 1;
+	memcpy(&buf[len], message, msg_len);
+	len += msg_len;
+	buf[len] = '\0'; len++;
+	
+	// Send to tracker
+#ifdef USE_TRACKER
+	if (GameArg.MplTrackerAddr && GameArg.MplTrackerAddr[0])
+	{
+		dxx_sendto(UDP_Socket[2], buf, len, 0, (struct sockaddr *)&TrackerSocket, sizeof(TrackerSocket));
+	}
+#endif
+	
+	// Send to all players
+	for (int i = 1; i < N_players; i++)
+	{
+		if (Players[i].connected == CONNECT_PLAYING)
+			dxx_sendto(UDP_Socket[0], buf, len, 0, (struct sockaddr *)&Netgame.players[i].protocol.udp.addr, sizeof(struct _sockaddr));
+	}
+	
+	// Also forward to observers
+	for (int i = 0; i < Netgame.max_numobservers; i++)
+	{
+		if (Netgame.observers[i].connected)
+			dxx_sendto(UDP_Socket[0], buf, len, 0, (struct sockaddr *)&Netgame.observers[i].protocol.udp.addr, sizeof(struct _sockaddr));
+	}
+}
+
+// Process received kill event
+void net_udp_process_gamelog_kill(ubyte *data, int data_len)
+{
+	int len = 1; // Skip packet type
+	fix64 timestamp;
+	int killer_id, killed_id, weapon_type, weapon_id;
+	
+	if (data_len < UPID_GAMELOG_KILL_SIZE)
+		return;
+	
+	// Read timestamp
+	memcpy(&timestamp, data + len, sizeof(fix64)); len += sizeof(fix64);
+	
+	killer_id = data[len]; len++;
+	killed_id = data[len]; len++;
+	weapon_type = data[len]; len++;
+	weapon_id = data[len]; len++;
+	
+	// Log to game log if available
+	// This is processed by clients to keep their gamelogs synchronized
+	// The actual logging is handled by the existing gamelog system
+	
+	con_printf(CON_DEBUG, "Gamelog: Player %d killed Player %d with weapon %d (type %d) at time %d\n", 
+			   killer_id, killed_id, weapon_id, weapon_type, (int)timestamp);
+}
+
+// Process received chat message
+void net_udp_process_gamelog_chat(ubyte *data, int data_len)
+{
+	int len = 1; // Skip packet type
+	fix64 timestamp;
+	int player_id;
+	char message[MAX_MESSAGE_LEN];
+	
+	if (data_len < 10) // Minimum size check
+		return;
+	
+	// Read timestamp
+	memcpy(&timestamp, data + len, sizeof(fix64)); len += sizeof(fix64);
+	
+	player_id = data[len]; len++;
+	
+	// Copy message
+	int remaining = data_len - len;
+	if (remaining > MAX_MESSAGE_LEN - 1)
+		remaining = MAX_MESSAGE_LEN - 1;
+	memcpy(message, &data[len], remaining);
+	message[remaining] = '\0';
+	
+	// Log to game log if available
+	// This is processed by clients to keep their gamelogs synchronized
+	
+	con_printf(CON_DEBUG, "Gamelog: Player %d sent message at time %d: %s\n", 
+			   player_id, (int)timestamp, message);
 }

--- a/d2/main/net_udp.h
+++ b/d2/main/net_udp.h
@@ -24,6 +24,8 @@ int net_udp_level_sync();
 void net_udp_send_mdata_direct(ubyte *data, int data_len, int pnum, int priority);
 void net_udp_send_netgame_update();
 void net_udp_send_obs_quit();
+void net_udp_send_gamelog_kill(int killer_id, int killed_id, int weapon_type, int weapon_id);
+void net_udp_send_gamelog_chat(int player_id, const char *message);
 
 // Some defines
 #ifdef IPv6
@@ -93,6 +95,9 @@ void net_udp_send_obs_quit();
 #define UPID_OBSDATA 29
 #define UPID_OBSQUIT 30
 #define UPID_OBSQUIT_SIZE (1 + 4 + 4)
+#define UPID_GAMELOG_KILL 31
+#define UPID_GAMELOG_KILL_SIZE (1 + 8 + 1 + 1 + 1 + 1)
+#define UPID_GAMELOG_CHAT 32
 
 // Structure keeping lite game infos (for netlist, etc.)
 typedef struct UDP_netgame_info_lite


### PR DESCRIPTION
These changes add packets sent for 

- Chat Logs
- Kill events + Timestamps
- Death Event categorization (Weapon, Robot, Environment)
- Cause of death from ID (laser LV, mega, smart blob, lava, etc...)

in my SNG fork, this method works, and is relayed to www.dxxtracker.com -> [game example](https://dxxtracker.com/game.html?id=game-02-13-2026-03-04-37-code-audacity)