### PR TITLE
Save symbols from Windows builds

### DIFF
--- a/.github/workflows/package-msvc.yml
+++ b/.github/workflows/package-msvc.yml
@@ -53,8 +53,22 @@ jobs:
     - name: Build D2
       run: cmake --build buildd2
 
-    - name: Upload artifact
+    - name: List generated PDB files
+      shell: pwsh
+      run: Get-ChildItem -Path buildd1,buildd2 -Recurse -Filter *.pdb | ForEach-Object { $_.FullName }
+
+    - name: Upload binary artifact
       uses: actions/upload-artifact@v4
       with:
-        name: msvc-${{ matrix.arch }}
+        name: msvc-${{ matrix.arch }}-${{ github.sha }}
         path: 'buildd?/main/*.*'
+
+    - name: Upload symbol artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: msvc-symbols-${{ matrix.arch }}-${{ github.sha }}
+        path: |
+          buildd1/**/*.pdb
+          buildd2/**/*.pdb
+        if-no-files-found: error
+        retention-days: 180

--- a/.github/workflows/package-msvc.yml
+++ b/.github/workflows/package-msvc.yml
@@ -71,4 +71,4 @@ jobs:
           buildd1/**/*.pdb
           buildd2/**/*.pdb
         if-no-files-found: error
-        retention-days: 180
+        retention-days: 90

--- a/.github/workflows/package-windows.yml
+++ b/.github/workflows/package-windows.yml
@@ -55,6 +55,9 @@ jobs:
       - name: Build D2
         run: cmake --build buildd2
 
+      - name: List generated PDB files
+        run: find buildd1 buildd2 -type f -name '*.pdb'
+
       - name: Package
         run: ./contrib/packaging/windows/build_package.sh
 
@@ -63,3 +66,13 @@ jobs:
         with:
           name: windows
           path: '*.zip'
+
+      - name: Upload symbol artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-symbols-msys-clang-${{ github.sha }}
+          path: |
+            buildd1/**/*.pdb
+            buildd2/**/*.pdb
+          if-no-files-found: error
+          retention-days: 180

--- a/.github/workflows/package-windows.yml
+++ b/.github/workflows/package-windows.yml
@@ -75,4 +75,4 @@ jobs:
             buildd1/**/*.pdb
             buildd2/**/*.pdb
           if-no-files-found: error
-          retention-days: 180
+          retention-days: 90


### PR DESCRIPTION
When debugging a recent crash from Redux 1.1 I was unable to track down symbols and found out we haven't been saving them. This PR preserves PDBs from workflow-initiated builds in a separate .zip. It currently only has this for Windows builds - I might be able to figure something out for Mac/Linux if we need it but am less sure what to look for there.