### PR TITLE
Fix observer mode weapon summary mispaint under limited observer info

### DIFF
--- a/d1/main/gauges.c
+++ b/d1/main/gauges.c
@@ -3204,6 +3204,8 @@ void observer_maybe_show_kill_graph() {
 		char reason[20];
 		char damage_info_text[40];
 
+		gr_set_curfont(GAME_FONT);
+
 		if (drawn_players <= 2) {
 			// Show top 3 damage done sources per pilot.
 			y -= (LINE_SPACING * 5);

--- a/d2/main/gauges.c
+++ b/d2/main/gauges.c
@@ -3526,6 +3526,8 @@ void observer_maybe_show_kill_graph() {
 		char reason[20];
 		char damage_info_text[40];
 
+		gr_set_curfont(GAME_FONT);
+
 		if (drawn_players <= 2) {
 			// Show top 3 damage done sources per pilot.
 			y -= (LINE_SPACING * 5);


### PR DESCRIPTION
In a recent edition of the Observatory, we had a player who had limited observer info turned on, which caused the damage/weapon summary display to render with the incorrect (huge) font. Apparently it didn't anticipate the font needing to be changed at this point. This change switches to GAME_FONT before drawing the report just to be sure.