### PR TITLE
Fix V-HAM with exit sequences part 2

### DIFF
--- a/d2/main/bm.c
+++ b/d2/main/bm.c
@@ -588,6 +588,8 @@ int load_exit_models()
 		return 0;
 	}
 
+	Robot_replacements_loaded = 1; // indicate extra robots need to be reloaded
+
 	return 1;
 }
 


### PR DESCRIPTION
Set Robot_replacements_loaded when loading exit models to make sure V-HAM is reloaded for next level.