### PR TITLE
Fix reactor gunpoint calculation

### DIFF
--- a/d1/main/state.c
+++ b/d1/main/state.c
@@ -366,8 +366,10 @@ void state_object_rw_to_object(object_rw *obj_rw, object *obj)
 			// gun points of reactor now part of the object but of course not saved in object_rw and overwritten due to reset_objects(). Let's just recompute them.
 			int i = 0;
 			reactor *reactor = get_reactor_definition(obj->id);
-			for (i=0; i<reactor->n_guns; i++)
-				calc_controlcen_gun_point(reactor, obj, i);
+			if (obj->type == OBJ_CNTRLCEN) {
+				for (i=0; i<reactor->n_guns; i++)
+					calc_controlcen_gun_point(reactor, obj, i);
+			}
 			break;
 		}
 	}

--- a/d2/main/state.c
+++ b/d2/main/state.c
@@ -396,8 +396,10 @@ void state_object_rw_to_object(object_rw *obj_rw, object *obj)
 			// gun points of reactor now part of the object but of course not saved in object_rw and overwritten due to reset_objects(). Let's just recompute them.
 			int i = 0;
 			reactor *reactor = get_reactor_definition(obj->id);
-			for (i=0; i<reactor->n_guns; i++)
-				calc_controlcen_gun_point(reactor, obj, i);
+			if (obj->type == OBJ_CNTRLCEN) {
+			  for (i=0; i<reactor->n_guns; i++)
+				  calc_controlcen_gun_point(reactor, obj, i);
+			}
 			break;
 		}
 	}

--- a/d2/main/state.c
+++ b/d2/main/state.c
@@ -397,8 +397,8 @@ void state_object_rw_to_object(object_rw *obj_rw, object *obj)
 			int i = 0;
 			reactor *reactor = get_reactor_definition(obj->id);
 			if (obj->type == OBJ_CNTRLCEN) {
-			  for (i=0; i<reactor->n_guns; i++)
-				  calc_controlcen_gun_point(reactor, obj, i);
+				for (i=0; i<reactor->n_guns; i++)
+					calc_controlcen_gun_point(reactor, obj, i);
 			}
 			break;
 		}


### PR DESCRIPTION
* Game crashes when loading a save game where no recator is in due to a boss. 