### PR TITLE
Add "Get Latest" menu option when version mismatched, that will open dxx-redux home page.

### DIFF
--- a/d1/main/net_udp.c
+++ b/d1/main/net_udp.c
@@ -1070,7 +1070,14 @@ int net_udp_game_connect(direct_join *dj)
 	
 	if (Netgame.protocol.udp.valid == -1)
 	{
-		nm_messagebox(TXT_ERROR,1,TXT_OK,"Version mismatch! Cannot join Game.\nHost game version: %i.%i.%i\nHost game protocol: %i\nYour game version: %s\nYour game protocol: %i",Netgame.protocol.udp.program_iver[0],Netgame.protocol.udp.program_iver[1],Netgame.protocol.udp.program_iver[2],Netgame.protocol.udp.program_iver[3],VERSION, MULTI_PROTO_VERSION);
+		if (nm_messagebox(TXT_ERROR,2,TXT_OK,"Get Latest","Version mismatch! Cannot join Game.\nHost game version: %i.%i.%i\nHost game protocol: %i\nYour game version: %s\nYour game protocol: %i",Netgame.protocol.udp.program_iver[0],Netgame.protocol.udp.program_iver[1],Netgame.protocol.udp.program_iver[2],Netgame.protocol.udp.program_iver[3],VERSION, MULTI_PROTO_VERSION) == 1)
+#ifdef _WIN32
+			system("start https://www.dxx-redux.com");
+#elif defined(__APPLE__)
+			system("open https://www.dxx-redux.com");
+#else
+			system("xdg-open https://www.dxx-redux.com");
+#endif
 		dj->connecting = 0;
 		return 0;
 	}

--- a/d2/main/net_udp.c
+++ b/d2/main/net_udp.c
@@ -1061,7 +1061,14 @@ int net_udp_game_connect(direct_join *dj)
 	
 	if (Netgame.protocol.udp.valid == -1)
 	{
-		nm_messagebox(TXT_ERROR,1,TXT_OK,"Version mismatch! Cannot join Game.\nHost game version: %i.%i.%i\nHost game protocol: %i\nYour game version: %s\nYour game protocol: %i",Netgame.protocol.udp.program_iver[0],Netgame.protocol.udp.program_iver[1],Netgame.protocol.udp.program_iver[2],Netgame.protocol.udp.program_iver[3],VERSION, MULTI_PROTO_VERSION);
+		if (nm_messagebox(TXT_ERROR,2,TXT_OK,"Get Latest","Version mismatch! Cannot join Game.\nHost game version: %i.%i.%i\nHost game protocol: %i\nYour game version: %s\nYour game protocol: %i",Netgame.protocol.udp.program_iver[0],Netgame.protocol.udp.program_iver[1],Netgame.protocol.udp.program_iver[2],Netgame.protocol.udp.program_iver[3],VERSION, MULTI_PROTO_VERSION) == 1)
+#ifdef _WIN32
+			system("start https://www.dxx-redux.com");
+#elif defined(__APPLE__)
+			system("open https://www.dxx-redux.com");
+#else
+			system("xdg-open https://www.dxx-redux.com");
+#endif
 		dj->connecting = 0;
 		return 0;
 	}


### PR DESCRIPTION
This basically serves to direct a player to the main dxx-redux website when a version mismatch is detected when attempting to join a MP match. Arguably useful for many situations, In my head this is most useful for returning players, or for people who have borrowed other users directories to be able to "catch-up" so to speak.